### PR TITLE
 [SPR-28] feat: swagger 설정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/climeet/climeet_backend/global/config/SwaggerConfig.java
@@ -2,23 +2,47 @@ package com.climeet.climeet_backend.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+    // TODO: 2024/01/02 JWT 토큰 발급 과정 구체화 -> hash
+    String jwtSchemeName = "JWT TOKEN";
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo());
+                .addServersItem(new Server().url("/"))
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement())
+                .components(components());
     }
 
     private Info apiInfo() {
         return new Info()
                 .title("Climeet Springdoc 테스트")
                 .description("Springdoc을 사용한 Climeet Swagger UI 테스트")
-                .version("1.0.0");
+                .version("1.0.0")
+                .contact(new Contact().name("gmail").url("https://www.google.com/intl/ko/gmail/about/"))
+                .description("잘못된 부분이나 오류 발생 시 해당 메일로 문의해주세요.\n\"x-aaaalvgcy2mugvl3nbio4uiweq@w1702553627-cxp994679.slack.com\"");
+        // TODO: 2024/01/02  슬랙 웹훅 url로 변경 예정
+    }
+
+    private Components components(){
+        return new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+    }
+
+    private SecurityRequirement securityRequirement(){
+        return new SecurityRequirement().addList(jwtSchemeName);
     }
 }


### PR DESCRIPTION
## 요약
swagger 헤더 설정

## 상세 내용
<img width="1437" alt="스크린샷 2024-01-02 오후 4 41 46" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/4f9014f0-811b-4b5e-81b2-5de1b6d08a4e">

- 기존 swagger 고정 헤더에서 두 가지를 추가하였습니다.

1. 문의 메일 링크 -> [ 웹훅 - slack ] "swagger문의 채널 "
2. Bearer JWT를 이용한 api 인증

## 테스트 확인 내용
- 메일 전송
<img width="1306" alt="스크린샷 2024-01-02 오후 4 47 16" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/787f53ac-3735-4024-a9e7-f5a1a6d52cc4">
- slack swagger문의 채널 확인
<img width="1399" alt="스크린샷 2024-01-02 오후 4 48 05" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/e5ebea3b-979d-461d-a475-c00fd2d82df9">


## 질문 및 이외 사항
- [todo] jwt 생성로직 구체화

## ETC
closed #5 