### PR TITLE
[SPR-41] feat: 숏츠 업로드 

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
@@ -13,10 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -37,6 +39,10 @@ public class Shorts extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
+
+    private String videoUrl;
+
+    private String thumbnailImageUrl;
 
     private int likeCount = 0;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -1,10 +1,24 @@
 package com.climeet.climeet_backend.domain.shorts;
 
+import com.climeet.climeet_backend.domain.shorts.dto.ShortsRequestDto.PostShortsReq;
+import com.climeet.climeet_backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @RestController
 public class ShortsController {
 
+    private final ShortsService shortsService;
+
+    @PostMapping("/shorts")
+    public ApiResponse<String> uploadShorts(@RequestPart(value = "video") MultipartFile video,
+        @RequestPart MultipartFile thumbnailImage,
+        @RequestPart PostShortsReq postShortsReq) {
+        shortsService.uploadShorts(video, thumbnailImage, postShortsReq);
+        return ApiResponse.onSuccess("업로드 성공");
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -2,12 +2,15 @@ package com.climeet.climeet_backend.domain.shorts;
 
 import com.climeet.climeet_backend.domain.shorts.dto.ShortsRequestDto.PostShortsReq;
 import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "shorts", description = "숏츠 API")
 @RequiredArgsConstructor
 @RestController
 public class ShortsController {
@@ -15,6 +18,7 @@ public class ShortsController {
     private final ShortsService shortsService;
 
     @PostMapping("/shorts")
+    @Operation(summary = "숏츠 업로드")
     public ApiResponse<String> uploadShorts(@RequestPart(value = "video") MultipartFile video,
         @RequestPart MultipartFile thumbnailImage,
         @RequestPart PostShortsReq postShortsReq) {

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -19,8 +19,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class ShortsService {
 
     private final ShortsRepository shortsRepository;
-    private final ClimbingGymRepository climbingGymRepository;
-    private final SectorRepository sectorRepository;
     private final RouteRepository routeRepository;
     private final S3Service s3Service;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -1,10 +1,51 @@
 package com.climeet.climeet_backend.domain.shorts;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.route.RouteRepository;
+import com.climeet.climeet_backend.domain.sector.Sector;
+import com.climeet.climeet_backend.domain.sector.SectorRepository;
+import com.climeet.climeet_backend.domain.shorts.dto.ShortsRequestDto.PostShortsReq;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import com.climeet.climeet_backend.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class ShortsService {
 
+    private final ShortsRepository shortsRepository;
+    private final ClimbingGymRepository climbingGymRepository;
+    private final SectorRepository sectorRepository;
+    private final RouteRepository routeRepository;
+    private final S3Service s3Service;
+
+    public void uploadShorts(MultipartFile video, MultipartFile thumbnailImage,
+        PostShortsReq postShortsReq) {
+
+        Route route = routeRepository.findById(postShortsReq.getRouteId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE));
+        Sector sector = route.getSector();
+        ClimbingGym climbingGym= sector.getClimbingGym();
+
+        String videoUrl = s3Service.uploadFile(video).getImgUrl();
+        String thumbnailImageUrl = s3Service.uploadFile(thumbnailImage).getImgUrl();
+
+        Shorts shorts = Shorts.builder()
+            .climbingGym(climbingGym)
+            .route(route)
+            .sector(sector)
+            .videoUrl(videoUrl)
+            .thumbnailImageUrl(thumbnailImageUrl)
+            .description(postShortsReq.getDescription())
+            .isPublic(postShortsReq.isPublic())
+            .isSoundEnabled(postShortsReq.isSoundEnabled())
+            .build();
+
+        shortsRepository.save(shorts);
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -19,16 +19,20 @@ import org.springframework.web.multipart.MultipartFile;
 public class ShortsService {
 
     private final ShortsRepository shortsRepository;
+    private final ClimbingGymRepository climbingGymRepository;
+    private final SectorRepository sectorRepository;
     private final RouteRepository routeRepository;
     private final S3Service s3Service;
 
     public void uploadShorts(MultipartFile video, MultipartFile thumbnailImage,
         PostShortsReq postShortsReq) {
 
+        ClimbingGym climbingGym = climbingGymRepository.findById(postShortsReq.getClimbingGymId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+        Sector sector = sectorRepository.findById(postShortsReq.getSectorId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SECTOR));
         Route route = routeRepository.findById(postShortsReq.getRouteId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE));
-        Sector sector = route.getSector();
-        ClimbingGym climbingGym= sector.getClimbingGym();
 
         String videoUrl = s3Service.uploadFile(video).getImgUrl();
         String thumbnailImageUrl = s3Service.uploadFile(thumbnailImage).getImgUrl();

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
@@ -1,0 +1,19 @@
+package com.climeet.climeet_backend.domain.shorts.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShortsRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class PostShortsReq {
+
+        private Long climbingGymId;
+        private Long routeId;
+        private Long sectorId;
+        private String description;
+        boolean isSoundEnabled;
+        boolean isPublic;
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -30,7 +30,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),
-    _INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다.")
+    _INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다."),
+
+    //파일 업로드 관련
+    _FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -19,6 +19,15 @@ public enum ErrorStatus implements BaseErrorCode {
     //멤버 관련
     _EMPTY_MEMBER(HttpStatus.CONFLICT, "MEMBER_001", "존재하지 않는 사용자입니다."),
 
+    //암장 관련
+    _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),
+
+    //벽면 관련
+    _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),
+
+    //루트 관련
+    _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),
+
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),
     _INVALID_JWT(HttpStatus.UNAUTHORIZED, "AUTH_002", "유효하지 않은 JWT입니다.")

--- a/src/main/java/com/climeet/climeet_backend/global/s3/S3Controller.java
+++ b/src/main/java/com/climeet/climeet_backend/global/s3/S3Controller.java
@@ -1,0 +1,29 @@
+package com.climeet.climeet_backend.global.s3;
+
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import com.climeet.climeet_backend.global.s3.dto.S3Result;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/file")
+    public ApiResponse<S3Result> uploadFile(@RequestPart(value = "file") MultipartFile file) {
+        try {
+            S3Result result = s3Service.uploadFile(file);
+            return ApiResponse.onSuccess(result);
+        }
+        catch (Exception e) {
+            throw new GeneralException(ErrorStatus._FILE_UPLOAD_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/global/s3/S3Service.java
+++ b/src/main/java/com/climeet/climeet_backend/global/s3/S3Service.java
@@ -44,7 +44,22 @@ public class S3Service {
         return UUID.randomUUID().toString().concat(getFileExtension(fileName));
     }
 
-    public List<S3Result> uploadFile(List<MultipartFile> multipartFiles) {
+    public S3Result uploadFile(MultipartFile multipartFile) {
+        String fileName = createFileName(multipartFile.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+        }
+        return new S3Result(amazonS3Client.getUrl(bucket, fileName).toString());
+    }
+
+    public List<S3Result> uploadFiles(List<MultipartFile> multipartFiles) {
         List<S3Result> fileList = new ArrayList<>();
 
         // forEach 구문을 통해 multipartFile로 넘어온 파일들 하나씩 fileList에 추가

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+  servlet:
+    multipart:
+      max-request-size: 200MB
+      max-file-size : 200MB
 springdoc:
   swagger-ui:
     path: /


### PR DESCRIPTION
## 요약

- 숏츠 업로드 api 구현
- application.yml에서 multipart 크기 제한
- errorstatus 추가
- S3Service 수정

## 상세 내용

- 업로드 api 흐름
```java

Route route = routeRepository.findById(postShortsReq.getRouteId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE));
Sector sector = route.getSector();
ClimbingGym climbingGym= sector.getClimbingGym();

String videoUrl = s3Service.uploadFile(video).getImgUrl();
String thumbnailImageUrl = s3Service.uploadFile(thumbnailImage).getImgUrl();
```

- 쇼츠에 필요한 정보인 `루트`는 레포지토리를 방문해 가져옵니다. 이후 객체 그래프탐색을 통해 sector와 gym을 순차적으로 가져옵니다.
- 영상과 썸네일 파일은 S3Service의 uploadFile을 이용해 imgUrl을 반환받습니다.

---
- application.yml

```
  servlet:
    multipart:
      max-request-size: 200MB
      max-file-size : 200MB
```
스프링에서 multipart 파일의 크기 제한을 기본 1MB로 잡기 때문에 일단 임의로 200으로 늘렸습니다!
- max-request-size : 전송되는 개별 파일의 크기 제한
- max-file-size : 서버 측으로 전송된 요청 자체의 크기
- 파일외 descriptioin같은 내용도 있기에 통상 max-file-size가 더 커야하는게 맞습니다! 추후 영상의 크기가 어느 정도일지 나오면 파일 크기 제한 에외처리와 함께 수정하겠습니다!!

---
## 질문 및 이외 사항

- `루트`, `섹션`을 가져오는 두 가지 방법이 있습니다! 프론트에서 `routeId`와 `sectionId`, `climbingGymId`도 다 주기에 아래와 같이 리포지토리를 방문해 가져올 수 있습니다.
```java
ClimbingGym climbingGym = climbingGymRepository.findById(postShortsReq.getClimbingGymId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
Sector sector = sectorRepository.findById(postShortsReq.getSectorId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SECTOR));
Route route = routeRepository.findById(postShortsReq.getRouteId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE));
```
위처럼 각각 유효성 검증이 필요한 경우에는 일일히 조회를 해야하는데 쇼츠 업로드 로직에서 유효성 검증이 필요할까요..? 제가 놓친 부분이 혹시 있다면 알려주시면 감사하겠습니다~!
+ 만약 없다면 dto에서 routeId만 받는걸로 수정하겠습니다.
+ 객체 그래프 탐색을 하기 위해서는 route와 section, gym과 section의 로딩 전략을 즉시 로딩으로 수정해야합니다. 
-> 이 부분에서 쿼리횟수를 줄이기 위해 즉시 로딩을 쓰는 것보다 N+1문제를 막는것이 더 효율적일 것 같습니다 일단 다른 부분 확인해주시고 코멘트 남겨주세요! 일단 일일히 방문하는 것으로 수정후 다시 커밋올리겠습니다~~!