### PR TITLE
[SPR/31] feat: 캘린더 생성, 조회 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+/src/main/resources/application-local.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -1,8 +1,9 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> {
 
-    ClimbingGym findByName(String gymName);
+    Optional<ClimbingGym> findById(Long gymId);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -3,5 +3,6 @@ package com.climeet.climeet_backend.domain.climbinggym;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> {
+
     ClimbingGym findByName(String gymName);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -3,5 +3,5 @@ package com.climeet.climeet_backend.domain.climbinggym;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> {
-
+    ClimbingGym findByName(String gymName);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
@@ -2,8 +2,6 @@ package com.climeet.climeet_backend.domain.climbingrecord;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
-import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
-import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor
@@ -34,10 +33,33 @@ public class ClimbingRecord extends BaseTimeEntity {
 
     private LocalTime climbingTime;
 
+    //도전횟수
+    @ColumnDefault("0")
+    private Integer totalAttemptCount;
+
+    //완등횟수
+    @ColumnDefault("0")
+    private Integer totalCompletedCount;
+
+    //평균레벨
+    @ColumnDefault("0")
+    private Integer avgDifficulty;
+
     public static ClimbingRecord toEntity(ClimbingRecordRequestDto requestDto,
         ClimbingGym climbingGym) {
         return ClimbingRecord.builder()
+            .climbingDate(requestDto.getDate())
+            .climbingTime(requestDto.getTime())
             .gym(climbingGym)
             .build();
+    }
+
+
+    public void attemptCountUp(int count) {
+        this.totalAttemptCount += count;
+    }
+
+    public void totalCompletedCountUp() {
+        this.totalCompletedCount++;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
@@ -1,6 +1,9 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
+import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,15 +13,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class ClimbingRecord extends BaseTimeEntity {
 
     @Id
@@ -31,4 +33,11 @@ public class ClimbingRecord extends BaseTimeEntity {
     private LocalDate climbingDate;
 
     private LocalTime climbingTime;
+
+    public static ClimbingRecord toEntity(ClimbingRecordRequestDto requestDto,
+        ClimbingGym climbingGym) {
+        return ClimbingRecord.builder()
+            .gym(climbingGym)
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
@@ -34,15 +34,12 @@ public class ClimbingRecord extends BaseTimeEntity {
     private LocalTime climbingTime;
 
     //도전횟수
-    @ColumnDefault("0")
     private Integer totalAttemptCount;
 
     //완등횟수
-    @ColumnDefault("0")
     private Integer totalCompletedCount;
 
     //평균레벨
-    @ColumnDefault("0")
     private Integer avgDifficulty;
 
     public static ClimbingRecord toEntity(ClimbingRecordRequestDto requestDto,
@@ -51,11 +48,14 @@ public class ClimbingRecord extends BaseTimeEntity {
             .climbingDate(requestDto.getDate())
             .climbingTime(requestDto.getTime())
             .gym(climbingGym)
+            .totalAttemptCount(0)
+            .totalCompletedCount(0)
+            .avgDifficulty(0)
             .build();
     }
 
 
-    public void attemptCountUp(int count) {
+    public void attemptCountUp(Integer count) {
         this.totalAttemptCount += count;
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -1,13 +1,20 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.joda.time.DateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -22,10 +29,48 @@ public class ClimbingRecordController {
 
     private final ClimbingRecordService climbingRecordService;
 
-    @Operation(summary = "클라이밍기록생성", description = "클라이밍 기록 생성")
+    /**
+     * @param "ClimbingRecordRequestDto requestDto"
+     */
+    @Operation(summary = "클라이밍 기록 생성", description = "클라이밍 기록 생성")
     @PostMapping
     public ResponseEntity<?> addClimbingRecord(@RequestBody ClimbingRecordRequestDto requestDto) {
         climbingRecordService.createClimbingRecord(requestDto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
+
+    /**
+     * 간편기록 총 조회
+     *
+     * @param
+     * @return List<ClimbingRecordResponseDto>
+     */
+    @Operation(summary = "클라이밍 간편 기록 조회", description = "클라이밍 기록 생성")
+    @GetMapping
+    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordList() {
+        return new ResponseEntity<>(climbingRecordService.getClimbingRecordSimpleInfoList(),
+            HttpStatus.OK);
+    }
+
+    /**
+     * @param "date"
+     * @return ClimingRecordResponseDto
+     */
+    @Operation(summary = "클라이밍 기록 조회", description = "클라이밍 기록 생성")
+    @GetMapping("/{date}")
+    public ResponseEntity<List<ClimbingRecordSimpleInfo>> addClimbingRecord(
+        @PathVariable LocalDate date) {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    /**
+     * @param "id"
+     * @return ClimingRecordResponseDto
+     */
+    @Operation(summary = "클라이밍 기록 조회", description = "클라이밍 기록 생성")
+    @GetMapping("/{id}")
+    public ResponseEntity<ClimbingRecordSimpleInfo> addClimbingRecord(@PathVariable Long id) {
+        return new ResponseEntity<>(climbingRecordService.getClimbingRecord(id), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -1,30 +1,28 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
-import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
+
 
 import java.io.IOException;
 
 @RequiredArgsConstructor
-@RestController("/climbing-record")
+@RestController
+@RequestMapping("/climbing-record")
 public class ClimbingRecordController {
 
     private final ClimbingRecordService climbingRecordService;
@@ -43,34 +41,38 @@ public class ClimbingRecordController {
      * 간편기록 총 조회
      *
      * @param
-     * @return List<ClimbingRecordResponseDto>
+     * @return List<ClimbingRecordSimpleInfo>
      */
-    @Operation(summary = "클라이밍 간편 기록 조회", description = "클라이밍 기록 생성")
+    @Operation(summary = "클라이밍 간편 기록 전체 조회", description = "클라이밍 간편 기록 전체 조회")
     @GetMapping
-    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordList() {
-        return new ResponseEntity<>(climbingRecordService.getClimbingRecordSimpleInfoList(),
+    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecords() {
+        return new ResponseEntity<>(climbingRecordService.getClimbingRecords(),
             HttpStatus.OK);
     }
 
     /**
-     * @param "date"
-     * @return ClimingRecordResponseDto
+     * @param "starDate", "endDate"
+     * @return List<ClimbingRecordSimpleInfo>
      */
-    @Operation(summary = "클라이밍 기록 조회", description = "클라이밍 기록 생성")
-    @GetMapping("/{date}")
-    public ResponseEntity<List<ClimbingRecordSimpleInfo>> addClimbingRecord(
-        @PathVariable LocalDate date) {
-        return new ResponseEntity<>(HttpStatus.OK);
+    @Operation(summary = "클라이밍 기록 날짜 조회", description = "클라이밍 기록 날짜 조회")
+    @GetMapping("/between-dates")
+    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordsBetweenDates(
+        @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        List<ClimbingRecordSimpleInfo> climbingRecords = climbingRecordService.getClimbingRecordsBetweenLocalDates(
+            startDate, endDate);
+        return ResponseEntity.ok(climbingRecords);
     }
 
     /**
      * @param "id"
      * @return ClimingRecordResponseDto
      */
-    @Operation(summary = "클라이밍 기록 조회", description = "클라이밍 기록 생성")
+    @Operation(summary = "클라이밍 기록 id 조회", description = "클라이밍 기록 id 조회")
     @GetMapping("/{id}")
     public ResponseEntity<ClimbingRecordSimpleInfo> addClimbingRecord(@PathVariable Long id) {
         return new ResponseEntity<>(climbingRecordService.getClimbingRecord(id), HttpStatus.OK);
     }
+
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.climbingrecord;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 
+@Tag(name = "ClimbingRecords", description = "클라이밍 키록 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/climbing-record")
@@ -30,7 +32,7 @@ public class ClimbingRecordController {
     /**
      * @param "ClimbingRecordRequestDto requestDto"
      */
-    @Operation(summary = "클라이밍 기록 생성", description = "클라이밍 기록 생성")
+    @Operation(summary = "클라이밍 기록 생성")
     @PostMapping
     public ResponseEntity<?> addClimbingRecord(@RequestBody ClimbingRecordRequestDto requestDto) {
         climbingRecordService.createClimbingRecord(requestDto);
@@ -43,7 +45,7 @@ public class ClimbingRecordController {
      * @param
      * @return List<ClimbingRecordSimpleInfo>
      */
-    @Operation(summary = "클라이밍 간편 기록 전체 조회", description = "클라이밍 간편 기록 전체 조회")
+    @Operation(summary = "클라이밍 간편 기록 전체 조회")
     @GetMapping
     public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecords() {
         return new ResponseEntity<>(climbingRecordService.getClimbingRecords(),
@@ -54,7 +56,7 @@ public class ClimbingRecordController {
      * @param "starDate", "endDate"
      * @return List<ClimbingRecordSimpleInfo>
      */
-    @Operation(summary = "클라이밍 기록 날짜 조회", description = "클라이밍 기록 날짜 조회")
+    @Operation(summary = "클라이밍 기록 날짜 조회")
     @GetMapping("/between-dates")
     public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordsBetweenDates(
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -68,7 +70,7 @@ public class ClimbingRecordController {
      * @param "id"
      * @return ClimingRecordResponseDto
      */
-    @Operation(summary = "클라이밍 기록 id 조회", description = "클라이밍 기록 id 조회")
+    @Operation(summary = "클라이밍 기록 id 조회")
     @GetMapping("/{id}")
     public ResponseEntity<ClimbingRecordSimpleInfo> addClimbingRecord(@PathVariable Long id) {
         return new ResponseEntity<>(climbingRecordService.getClimbingRecord(id), HttpStatus.OK);

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -1,10 +1,31 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
-@RestController
+@RestController("/climbing-record")
 public class ClimbingRecordController {
 
+    private final ClimbingRecordService climbingRecordService;
+
+    @Operation(summary = "클라이밍기록생성", description = "클라이밍 기록 생성")
+    @PostMapping
+    public ResponseEntity<?> addClimbingRecord(@RequestBody ClimbingRecordRequestDto requestDto) {
+        climbingRecordService.createClimbingRecord(requestDto);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
@@ -1,7 +1,13 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, Long> {
 
+    List<ClimbingRecord> findByClimbingDateBetween(LocalDate startDate, LocalDate endDate);
+
+    Optional<ClimbingRecord> findById(Long id);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -4,12 +4,16 @@ import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
+import com.climeet.climeet_backend.domain.routerecord.RouteRecordRepository;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecordService;
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,14 +30,17 @@ public class ClimbingRecordService {
     @Transactional
     public ApiResponse<String> createClimbingRecord(ClimbingRecordRequestDto requestDto) {
         try {
-            ClimbingGym climbingGym = gymRepository.findByName(requestDto.getClimbingGymName());
+            ClimbingGym climbingGym = gymRepository.findById(requestDto.getGymId()).orElseThrow();
             //먼저 암장기록 저장
-            ClimbingRecord climbingRecord = climbingRecordRepository
+
+            ClimbingRecord savedClimbingRecord = climbingRecordRepository
                 .save(ClimbingRecord.toEntity(requestDto, climbingGym));
 
+            List<RouteRecordRequestDto> routeRecords = requestDto.getRouteRecordRequestDtoList();
             // 루트기록 리퀘스트 돌면서 루트 리퀘스트 저장
-            requestDto.getRouteRecordRequestDtoList().stream()
-                .map(dto -> routeRecordService.addRouteRecord(dto, climbingRecord));
+
+            routeRecords.forEach(
+                routeRecord -> routeRecordService.addRouteRecord(routeRecord, savedClimbingRecord));
 
             return ApiResponse.onSuccess("클라이밍 기록생성 성공");
         } catch (Exception e) {
@@ -41,7 +48,7 @@ public class ClimbingRecordService {
         }
     }
 
-    public List<ClimbingRecordSimpleInfo> getClimbingRecordSimpleInfoList() {
+    public List<ClimbingRecordSimpleInfo> getClimbingRecords() {
         try {
             List<ClimbingRecord> recordList = climbingRecordRepository.findAll();
             return recordList.stream()
@@ -52,8 +59,29 @@ public class ClimbingRecordService {
         }
     }
 
-    // TODO: 2024/01/04 운동기록 id로 조회(하나) & date로 찾기(여러 개)
+
     public ClimbingRecordSimpleInfo getClimbingRecord(Long id) {
-        return new ClimbingRecordSimpleInfo();
+        try {
+            return new ClimbingRecordSimpleInfo(climbingRecordRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST)));
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
     }
+
+    public List<ClimbingRecordSimpleInfo> getClimbingRecordsBetweenLocalDates(LocalDate startDate,
+        LocalDate endDate) {
+        try {
+            List<ClimbingRecord> climbingRecords = climbingRecordRepository.findByClimbingDateBetween(
+                startDate, endDate);
+            // Dto로 변환
+            return climbingRecords.stream()
+                .map(ClimbingRecordSimpleInfo::new)
+                .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+    }
+
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -1,10 +1,49 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto;
+import com.climeet.climeet_backend.domain.route.RouteRepository;
+import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
+import com.climeet.climeet_backend.domain.routerecord.RouteRecordRepository;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.climeet.climeet_backend.domain.routerecord.RouteRecord.toEntity;
 
 @RequiredArgsConstructor
 @Service
 public class ClimbingRecordService {
 
+    private final ClimbingRecordRepository climbingRecordRepository;
+    private final ClimbingGymRepository gymRepository;
+    private final RouteRecordRepository routeRecordRepository;
+    private final RouteRepository routeRepository;
+
+    public ApiResponse<String> createClimbingRecord(ClimbingRecordRequestDto requestDto) {
+        try {
+            ClimbingGym climbingGym = gymRepository.findByName(requestDto.getClimbingGymName());
+            //먼저 암장기록 저장
+            ClimbingRecord climbingRecord = climbingRecordRepository
+                .save(ClimbingRecord.toEntity(requestDto, climbingGym));
+
+            // 루트기록 리퀘스트 돌면서 루트 리퀘스트 저장
+            List<RouteRecord> routeRecords = requestDto.getRouteRecordRequestDtoList().stream()
+                .map(dto -> toEntity(dto, climbingRecord,
+                    routeRepository.findById(dto.getRouteId()).get()))
+                .collect(Collectors.toList());
+            routeRecordRepository.saveAll(routeRecords);
+            return ApiResponse.onSuccess("클라이밍 기록생성 성공");
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -3,20 +3,16 @@ package com.climeet.climeet_backend.domain.climbingrecord;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto;
-import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto;
-import com.climeet.climeet_backend.domain.route.RouteRepository;
-import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
-import com.climeet.climeet_backend.domain.routerecord.RouteRecordRepository;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
+import com.climeet.climeet_backend.domain.routerecord.RouteRecordService;
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static com.climeet.climeet_backend.domain.routerecord.RouteRecord.toEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
@@ -24,9 +20,10 @@ public class ClimbingRecordService {
 
     private final ClimbingRecordRepository climbingRecordRepository;
     private final ClimbingGymRepository gymRepository;
-    private final RouteRecordRepository routeRecordRepository;
-    private final RouteRepository routeRepository;
+    private final RouteRecordService routeRecordService;
 
+
+    @Transactional
     public ApiResponse<String> createClimbingRecord(ClimbingRecordRequestDto requestDto) {
         try {
             ClimbingGym climbingGym = gymRepository.findByName(requestDto.getClimbingGymName());
@@ -35,15 +32,28 @@ public class ClimbingRecordService {
                 .save(ClimbingRecord.toEntity(requestDto, climbingGym));
 
             // 루트기록 리퀘스트 돌면서 루트 리퀘스트 저장
-            List<RouteRecord> routeRecords = requestDto.getRouteRecordRequestDtoList().stream()
-                .map(dto -> toEntity(dto, climbingRecord,
-                    routeRepository.findById(dto.getRouteId()).get()))
-                .collect(Collectors.toList());
-            routeRecordRepository.saveAll(routeRecords);
+            requestDto.getRouteRecordRequestDtoList().stream()
+                .map(dto -> routeRecordService.addRouteRecord(dto, climbingRecord));
+
             return ApiResponse.onSuccess("클라이밍 기록생성 성공");
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
+    }
 
+    public List<ClimbingRecordSimpleInfo> getClimbingRecordSimpleInfoList() {
+        try {
+            List<ClimbingRecord> recordList = climbingRecordRepository.findAll();
+            return recordList.stream()
+                .map(ClimbingRecordSimpleInfo::new)
+                .toList();
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+    }
+
+    // TODO: 2024/01/04 운동기록 id로 조회(하나) & date로 찾기(여러 개)
+    public ClimbingRecordSimpleInfo getClimbingRecord(Long id) {
+        return new ClimbingRecordSimpleInfo();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -69,6 +69,7 @@ public class ClimbingRecordService {
         }
     }
 
+    // TODO: 2024/01/09 날짜로 조회할 때 시작날짜가 종료날짜보다 시점상 늦을 때 에러처리
     public List<ClimbingRecordSimpleInfo> getClimbingRecordsBetweenLocalDates(LocalDate startDate,
         LocalDate endDate) {
         try {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
@@ -17,14 +17,14 @@ import java.util.List;
 @Builder
 public class ClimbingRecordRequestDto {
 
-    @Schema(example = "2024-01-04", description = "날짜입력")
+    @Schema(example = "1", description = "짐 id")
+    private Long gymId;
+
+    @Schema(example = "LocalDate.of(2024, 1, 4)", description = "날짜입력")
     private LocalDate date;
 
-    @Schema(example = "1-0-0", description = "시간")
+    @Schema(example = "LocalTime.of(1, 30)", description = "시간")
     private LocalTime time;
-
-    @Schema(example = "더클라임 홍대점", description = "클라이밍 지점 이름")
-    private String climbingGymName;
 
     @Schema(description = "클라이밍 루트 목록")
     private List<RouteRecordRequestDto> routeRecordRequestDtoList;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
@@ -2,6 +2,8 @@ package com.climeet.climeet_backend.domain.climbingrecord.dto;
 
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,14 +18,15 @@ import java.util.List;
 public class ClimbingRecordRequestDto {
 
     @Schema(example = "2024-01-04", description = "날짜입력")
-    private String date;
+    private LocalDate date;
 
-    @Schema(example = "120", description = "분단위 시간")
-    private int time;
+    @Schema(example = "1-0-0", description = "시간")
+    private LocalTime time;
 
     @Schema(example = "더클라임 홍대점", description = "클라이밍 지점 이름")
     private String climbingGymName;
 
     @Schema(description = "클라이밍 루트 목록")
     private List<RouteRecordRequestDto> routeRecordRequestDtoList;
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
@@ -1,0 +1,29 @@
+package com.climeet.climeet_backend.domain.climbingrecord.dto;
+
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class ClimbingRecordRequestDto {
+
+    @Schema(example = "2024-01-04", description = "날짜입력")
+    private String date;
+
+    @Schema(example = "120", description = "분단위 시간")
+    private int time;
+
+    @Schema(example = "더클라임 홍대점", description = "클라이밍 지점 이름")
+    private String climbingGymName;
+
+    @Schema(description = "클라이밍 루트 목록")
+    private List<RouteRecordRequestDto> routeRecordRequestDtoList;
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -1,0 +1,4 @@
+package com.climeet.climeet_backend.domain.climbingrecord.dto;
+
+public class ClimbingRecordResponseDto {
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -1,5 +1,35 @@
 package com.climeet.climeet_backend.domain.climbingrecord.dto;
 
-public class ClimbingRecordResponseDto {
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbingrecord.ClimbingRecord;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+public class ClimbingRecordResponseDto {
+    @Getter
+    @NoArgsConstructor
+    public static class ClimbingRecordSimpleInfo{
+
+        private LocalDate date;
+        private String gymName;
+        private String gymProfileImg;
+        private LocalTime time;
+        private Integer totalCompletedCount;
+        private Integer totalAttemptCount;
+        private Integer avgDifficulty;
+
+        public ClimbingRecordSimpleInfo(ClimbingRecord climbingRecord) {
+            this.date = climbingRecord.getClimbingDate();
+            this.gymName = climbingRecord.getGym().getName();
+            this.avgDifficulty = climbingRecord.getAvgDifficulty();
+            this.time = climbingRecord.getClimbingTime();
+            this.gymProfileImg = climbingRecord.getGym().getProfileImageUrl();
+            this.totalAttemptCount = climbingRecord.getTotalAttemptCount();
+            this.totalCompletedCount = climbingRecord.getTotalCompletedCount();
+        }
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -10,9 +10,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class ClimbingRecordResponseDto {
+
     @Getter
     @NoArgsConstructor
-    public static class ClimbingRecordSimpleInfo{
+    public static class ClimbingRecordSimpleInfo {
 
         private LocalDate date;
         private String gymName;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -15,22 +15,22 @@ public class ClimbingRecordResponseDto {
     @NoArgsConstructor
     public static class ClimbingRecordSimpleInfo {
 
+        private Long ClimbingRecordId;
         private LocalDate date;
-        private String gymName;
-        private String gymProfileImg;
         private LocalTime time;
         private Integer totalCompletedCount;
         private Integer totalAttemptCount;
         private Integer avgDifficulty;
+        private Long gymId;
 
         public ClimbingRecordSimpleInfo(ClimbingRecord climbingRecord) {
+            this.ClimbingRecordId = climbingRecord.getId();
             this.date = climbingRecord.getClimbingDate();
-            this.gymName = climbingRecord.getGym().getName();
             this.avgDifficulty = climbingRecord.getAvgDifficulty();
             this.time = climbingRecord.getClimbingTime();
-            this.gymProfileImg = climbingRecord.getGym().getProfileImageUrl();
             this.totalAttemptCount = climbingRecord.getTotalAttemptCount();
             this.totalCompletedCount = climbingRecord.getTotalCompletedCount();
+            this.gymId = climbingRecord.getId();
         }
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -1,4 +1,5 @@
 package com.climeet.climeet_backend.domain.climbingrecord.dto;
 
 public class ClimbingRecordResponseDto {
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -1,7 +1,8 @@
 package com.climeet.climeet_backend.domain.route;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
-
+    Optional<Route> findById(Long id);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.routerecord;
 
 import com.climeet.climeet_backend.domain.climbingrecord.ClimbingRecord;
 import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,15 +11,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class RouteRecord extends BaseTimeEntity {
 
     @Id
@@ -34,4 +33,14 @@ public class RouteRecord extends BaseTimeEntity {
     private int attemptCount;
 
     private Boolean isCompleted = false;
+
+    public static RouteRecord toEntity(RouteRecordRequestDto requestDto,
+        ClimbingRecord climbingRecord, Route route) {
+        return RouteRecord.builder()
+            .climbingRecord(climbingRecord)
+            .route(route)
+            .attemptCount(requestDto.getAttemptCount())
+            .isCompleted(requestDto.getIsCompleted())
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
@@ -30,7 +30,7 @@ public class RouteRecord extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Route route;
 
-    private int attemptCount;
+    private Integer attemptCount;
 
     private Boolean isCompleted = false;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
@@ -1,13 +1,50 @@
 package com.climeet.climeet_backend.domain.routerecord;
 
 
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto.RouteRecordSimpleInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/route-record")
 public class RouteRecordController {
     private final RouteRecordService routeRecordService;
+
+    //생성로직은 ClimbingRecordService에서 구현
+
+    /**
+     * 간편기록 총 조회
+     * @param
+     * @return List<RouteRecordSimpleInfo>
+     */
+    @Operation(summary = "루트 기록 전체 조회", description = "루트 간편 기록 전체 조회")
+    @GetMapping
+    public ResponseEntity<List<RouteRecordSimpleInfo>> getRouteRecords() {
+        return new ResponseEntity<>(routeRecordService.getRouteRecords(),
+            HttpStatus.OK);
+    }
+
+    /**
+     * Id로 조회
+     * @param
+     * @return RouteRecordSimpleInfo
+     */
+    @Operation(summary = "루트 기록 Id 조회", description = "루트 간편 기록 id 조회")
+    @GetMapping("/{id}")
+        public ResponseEntity<RouteRecordSimpleInfo> getRouteRecord(@PathVariable Long id) {
+        return new ResponseEntity<>(routeRecordService.getRouteRecord(id),
+            HttpStatus.OK);
+    }
+
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
@@ -4,6 +4,7 @@ package com.climeet.climeet_backend.domain.routerecord;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto.RouteRecordSimpleInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
+@Tag(name = "RouteRecords", description = "루트 키록 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/route-record")
@@ -27,7 +29,7 @@ public class RouteRecordController {
      * @param
      * @return List<RouteRecordSimpleInfo>
      */
-    @Operation(summary = "루트 기록 전체 조회", description = "루트 간편 기록 전체 조회")
+    @Operation(summary = "루트 기록 전체 조회")
     @GetMapping
     public ResponseEntity<List<RouteRecordSimpleInfo>> getRouteRecords() {
         return new ResponseEntity<>(routeRecordService.getRouteRecords(),
@@ -39,7 +41,7 @@ public class RouteRecordController {
      * @param
      * @return RouteRecordSimpleInfo
      */
-    @Operation(summary = "루트 기록 Id 조회", description = "루트 간편 기록 id 조회")
+    @Operation(summary = "루트 기록 Id 조회")
     @GetMapping("/{id}")
         public ResponseEntity<RouteRecordSimpleInfo> getRouteRecord(@PathVariable Long id) {
         return new ResponseEntity<>(routeRecordService.getRouteRecord(id),

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
@@ -1,10 +1,15 @@
 package com.climeet.climeet_backend.domain.routerecord;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 
 @RequiredArgsConstructor
 @RestController
 public class RouteRecordController {
 
+    private final RouteRecordService routeRecordService;
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
@@ -1,15 +1,13 @@
 package com.climeet.climeet_backend.domain.routerecord;
 
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
 @RequiredArgsConstructor
 @RestController
 public class RouteRecordController {
-
     private final RouteRecordService routeRecordService;
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -1,10 +1,36 @@
 package com.climeet.climeet_backend.domain.routerecord;
 
+import com.climeet.climeet_backend.domain.climbingrecord.ClimbingRecord;
+import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.route.RouteRepository;
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto;
+import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class RouteRecordService {
 
+    private final RouteRecordRepository routeRecordRepository;
+    private final RouteRepository routeRepository;
+
+    @Transactional
+    public ApiResponse<String> addRouteRecord(RouteRecordRequestDto requestDto,
+        ClimbingRecord climbingRecord) {
+        try {
+            Route route = routeRepository.findById(requestDto.getRouteId()).get();
+            routeRecordRepository.save(RouteRecord.toEntity(requestDto, climbingRecord, route));
+            return ApiResponse.onSuccess("루트기록 성공");
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -27,7 +27,15 @@ public class RouteRecordService {
         ClimbingRecord climbingRecord) {
         try {
             Route route = routeRepository.findById(requestDto.getRouteId()).get();
+
             routeRecordRepository.save(RouteRecord.toEntity(requestDto, climbingRecord, route));
+
+            climbingRecord.attemptCountUp(requestDto.getAttemptCount());
+
+            if (requestDto.getIsCompleted()) {
+                climbingRecord.totalCompletedCountUp();
+            }
+
             return ApiResponse.onSuccess("루트기록 성공");
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
@@ -11,11 +11,12 @@ import lombok.NoArgsConstructor;
 public class RouteRecordRequestDto {
 
     // TODO: 2024/01/04 sectorName, difficulty로 루트 구분하는 상황 고려
+    // TODO: 2024/01/07 ClimbingRecord의 avgDifficulty 어떻게 구현 할 지 고민
 
     private Long routeId;
 
     //도전횟수
-    private int attemptCount;
+    private Integer attemptCount;
 
     //완등여부
     private Boolean isCompleted;

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
@@ -1,0 +1,22 @@
+package com.climeet.climeet_backend.domain.routerecord.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class RouteRecordRequestDto {
+
+    // TODO: 2024/01/04 sectorName, difficulty로 루트 구분하는 상황 고려
+
+    private Long routeId;
+
+    //도전횟수
+    private int attemptCount;
+
+    //완등여부
+    private Boolean isCompleted;
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordResponseDto.java
@@ -1,5 +1,27 @@
 package com.climeet.climeet_backend.domain.routerecord.dto;
 
-public class RouteRecordResponseDto {
+import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+public class RouteRecordResponseDto {
+    @Getter
+    @NoArgsConstructor
+    public static class RouteRecordSimpleInfo {
+
+        private Long routeRecordId;
+        private Long climbingRecordId;
+        private Long routeId;
+        private Integer attemptCount;
+        private Boolean isCompleted;
+
+        public RouteRecordSimpleInfo(RouteRecord routeRecord) {
+            this.routeRecordId = routeRecord.getId();
+            this.climbingRecordId = routeRecord.getClimbingRecord().getId();
+            this.routeId = routeRecord.getRoute().getId();
+            this.attemptCount = routeRecord.getAttemptCount();
+            this.isCompleted = routeRecord.getIsCompleted();
+
+        }
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordResponseDto.java
@@ -1,0 +1,5 @@
+package com.climeet.climeet_backend.domain.routerecord.dto;
+
+public class RouteRecordResponseDto {
+
+}


### PR DESCRIPTION
## 요약
- ClimbingRecord의 생성, 조회 로직 구현
- RouteRecord의 생성, 조회 로직 구현

## 상세 내용
요구사항에 맞춰 다음과 같이 생성 및 조회에 대한 API를 설계하였습니다.

### ClimbingRecord
```
   /**
     * @param "ClimbingRecordRequestDto requestDto"
     */
    @Operation(summary = "클라이밍 기록 생성", description = "클라이밍 기록 생성")
    @PostMapping
     public ResponseEntity<?> addClimbingRecord(@RequestBody ClimbingRecordRequestDto requestDto)
    
    /**
     * 간편기록 총 조회
     *
     * @param
     * @return List<ClimbingRecordSimpleInfo>
     */
    @Operation(summary = "클라이밍 간편 기록 전체 조회", description = "클라이밍 간편 기록 전체 조회")
    @GetMapping
    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecords() 

    /**
     * @param "starDate", "endDate"
     * @return List<ClimbingRecordSimpleInfo>
     */
    @Operation(summary = "클라이밍 기록 날짜 조회", description = "클라이밍 기록 날짜 조회")
    @GetMapping("/between-dates")
    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordsBetweenDates(
        @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
        @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate)
        
    /**
     * @param "id"
     * @return ClimingRecordResponseDto
     */
    @Operation(summary = "클라이밍 기록 id 조회", description = "클라이밍 기록 id 조회")
    @GetMapping("/{id}")
    public ResponseEntity<ClimbingRecordSimpleInfo> addClimbingRecord(@PathVariable Long id)
```
### RouteRecord
```
    /**
     * 간편기록 총 조회
     * @param
     * @return List<RouteRecordSimpleInfo>
     */
    @Operation(summary = "루트 기록 전체 조회", description = "루트 간편 기록 전체 조회")
    @GetMapping
    public ResponseEntity<List<RouteRecordSimpleInfo>> getRouteRecords() {
        return new ResponseEntity<>(routeRecordService.getRouteRecords(),
            HttpStatus.OK);
    }

    /**
     * Id로 조회
     * @param
     * @return RouteRecordSimpleInfo
     */
    @Operation(summary = "루트 기록 Id 조회", description = "루트 간편 기록 id 조회")
    @GetMapping("/{id}")
    public ResponseEntity<RouteRecordSimpleInfo> getRouteRecord(@PathVariable Long id)
    }
}
```

> 계층 간 RequestDto와 ResponseDto를 사용하였습니다.
이에 따라 추가해야 할 필드가 있어 보인다면 말씀 부탁드립니다. (이후 안드로이드 파트 인원들과 맞출 생각입니다.)
추가로 RouteRecord의 생성은 반드시 ClimbingRecord의 생성을 선행하기에 Controller 계층에서는 따로 구현하지 않았습니다.


## 테스트 확인 내용
- 로컬 데이터베이스에서 더미 값으로 구현한 생성, 조회 로직들이 동작하는 것을 확인하였습니다.
- 연관 관계로 인하여 사전에 생성되어 있어야 하는 Route, Climbing 의 경우 직접 쿼리문으로 생성하여 테스트 해보았고 ClimbingRecord, RouteRecord 의 각각의 Post, Get 요청들은 API 호출을 통하여 테스트해보았습니다.


## 질문 및 이외 사항
- 예외처리는 각각 맡은 객체들의 연관관계가 있는 만큼 불필요한 추가 작업 및 잦은 충돌이 있을 것으로 예상되어 따로 추가작성하지 않았습니다.
- 예외처리는 merge 후 팀원들의 예외처리 코드를 보고 부족한 부분을 하루 내지 이틀 안에 추가하겠습니다.