### PR TITLE
[SPR-40] feat: 루트 생성, 조회 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -11,10 +11,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -5,7 +5,6 @@ import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetRes
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -1,8 +1,11 @@
 package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateRequestDto;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,5 +29,11 @@ public class RouteController {
             routeCreateRequestDto.getDifficulty(),
             routeCreateRequestDto.getRouteImageUrl());
         return ApiResponse.onSuccess("새로운 Route를 추가했습니다.");
+    }
+
+    // 암장 루트 정보 조회
+    @GetMapping("/gym/route/{routeId}")
+    public ResponseEntity<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
+        return ResponseEntity.ok(routeService.getRoute(routeId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.route;
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateRequestDto;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.global.response.ApiResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,5 +36,11 @@ public class RouteController {
     @GetMapping("/gym/route/{routeId}")
     public ResponseEntity<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
         return ResponseEntity.ok(routeService.getRoute(routeId));
+    }
+
+    // 암장 루트 리스트 정보 조회
+    @GetMapping("/gym/{gymId}/routes")
+    public ResponseEntity<List<RouteGetResponseDto>> findAllRouteByGymId(@PathVariable Long gymId) {
+        return ResponseEntity.ok(routeService.getRouteList(gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -1,5 +1,30 @@
 package com.climeet.climeet_backend.domain.route;
 
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateRequestDto;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
 public class RouteController {
 
+    private final RouteService routeService;
+
+    // 암장 루트 추가
+    @PostMapping("/gym/{gymId}/route")
+    public ApiResponse<String> createRoute(@PathVariable Long gymId,
+        @RequestBody RouteCreateRequestDto routeCreateRequestDto) {
+        routeService.createRoute(
+            gymId,
+            routeCreateRequestDto.getSectorId(),
+            routeCreateRequestDto.getName(),
+            routeCreateRequestDto.getDifficulty(),
+            routeCreateRequestDto.getRouteImageUrl());
+        return ApiResponse.onSuccess("새로운 Route를 추가했습니다.");
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -34,13 +34,13 @@ public class RouteController {
 
     // 암장 루트 정보 조회
     @GetMapping("/gym/route/{routeId}")
-    public ResponseEntity<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
-        return ResponseEntity.ok(routeService.getRoute(routeId));
+    public ApiResponse<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
+        return ApiResponse.onSuccess(routeService.getRoute(routeId));
     }
 
     // 암장 루트 리스트 정보 조회
     @GetMapping("/gym/{gymId}/routes")
-    public ResponseEntity<List<RouteGetResponseDto>> findAllRouteByGymId(@PathVariable Long gymId) {
-        return ResponseEntity.ok(routeService.getRouteList(gymId));
+    public ApiResponse<List<RouteGetResponseDto>> findAllRouteByGymId(@PathVariable Long gymId) {
+        return ApiResponse.onSuccess(routeService.getRouteList(gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -1,7 +1,9 @@
 package com.climeet.climeet_backend.domain.route;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
 
+    List<Route> findBySectorClimbingGymId(Long gymId);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -1,10 +1,30 @@
 package com.climeet.climeet_backend.domain.route;
 
+import com.climeet.climeet_backend.domain.sector.Sector;
+import com.climeet.climeet_backend.domain.sector.SectorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class RouteService {
+
+    private final RouteRepository routeRepository;
+    private final SectorRepository sectorRepository;
+
+    @Transactional
+    public void createRoute(Long gymId, Long sectorId, String name, int difficulty,
+        String routeImageUrl) {
+        Sector sector = sectorRepository.findById(sectorId).orElseThrow();
+        Route route = Route.builder()
+            .sector(sector)
+            .name(name)
+            .difficulty(difficulty)
+            .routeImageUrl(routeImageUrl)
+            .build();
+
+        routeRepository.save(route);
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.route;
 
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,12 @@ public class RouteService {
             .build();
 
         routeRepository.save(route);
+    }
+
+    public RouteGetResponseDto getRoute(Long routeId) {
+        Route route = routeRepository.findById(routeId).orElseThrow();
+
+        return new RouteGetResponseDto(route);
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -3,6 +3,8 @@ package com.climeet.climeet_backend.domain.route;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,4 +36,11 @@ public class RouteService {
         return new RouteGetResponseDto(route);
     }
 
+    public List<RouteGetResponseDto> getRouteList(Long gymId) {
+        List<Route> routeList = routeRepository.findBySectorClimbingGymId(gymId);
+
+        return routeList.stream()
+            .map(RouteGetResponseDto::new)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -1,0 +1,17 @@
+package com.climeet.climeet_backend.domain.route.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RouteRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class RouteCreateRequestDto {
+
+        private Long sectorId;
+        private String name;
+        private int difficulty;
+        private String routeImageUrl;
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -1,0 +1,30 @@
+package com.climeet.climeet_backend.domain.route.dto;
+
+import com.climeet.climeet_backend.domain.route.Route;
+import lombok.*;
+
+public class RouteResponseDto {
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RouteGetResponseDto {
+
+        private Long sectorId;
+        private String sectorName;
+        private Long routeId;
+        private String routeName;
+        private int difficulty;
+        private String routeImageUrl;
+
+        public RouteGetResponseDto(Route route) {
+            this.sectorId = route.getSector().getId();
+            this.sectorName = route.getSector().getSectorName();
+            this.routeId = route.getId();
+            this.routeName = route.getName();
+            this.difficulty = route.getDifficulty();
+            this.routeImageUrl = route.getRouteImageUrl();
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -26,5 +26,5 @@ public class Sector extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ClimbingGym climbingGym;
 
-    private String sectionName;
+    private String sectorName;
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,7 +27,8 @@ public class Sector extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ClimbingGym climbingGym;
 
+    @NotNull
     private String sectorName;
 
-    private int floor;
+    private int floor = 0;
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -27,4 +27,6 @@ public class Sector extends BaseTimeEntity {
     private ClimbingGym climbingGym;
 
     private String sectorName;
+
+    private int floor;
 }


### PR DESCRIPTION
## 요약

- Route 테이블의 컬럼 생성 로직 구현
- Route 테이블의 컬럼 조회 로직(Route Id로 특정하여 조회 / Gym Id로 해당하는 모든 Route 조회) 구현

## 상세 내용

- 요구사항에 따라 수정되어야 할 부분도 있을 것 같지만, Spring으로 처음 개발을 진행하는거다보니 기능 구현과 Spring Framework의 이해에 초점을 맞추어 API를 개발하였습니다. (훈수, 조언 등등 모두 환영합니다!)

### Sector 엔티티 변경
- sectorName이 sectionName으로 오기되어 변경하였습니다.
- floor 컬럼을 추가하였고, 입력 값이 없다면 0을 기본값으로 입력하도록 하였습니다.
``` java
    @NotNull
    private String sectorName;

    private int floor = 0;
```

### 루트 생성 기능 구현
- 다음과 같이 routeCreateRequestDto를 추가하여 값을 입력받았습니다.
- gymId는 기능 구현상으로는 사용하지 않지만, 추후 sector의 gymId와 값이 맞지 않을 시에 예외처리를 위해 입력받고 있습니다.
- 현재는 routeCreateRequestDto를 Controller에서 풀어서 createRoute로 보내는데, createRoute로 보내는 인자를 그냥 routeCreateRequestDto 자체로 보내는게 더 깔끔할거같다는 생각도 듭니다.
``` java
// 암장 루트 추가
    @PostMapping("/gym/{gymId}/route")
    public ApiResponse<String> createRoute(@PathVariable Long gymId,
        @RequestBody RouteCreateRequestDto routeCreateRequestDto) {
        routeService.createRoute(
            gymId,
            routeCreateRequestDto.getSectorId(),
            routeCreateRequestDto.getName(),
            routeCreateRequestDto.getDifficulty(),
            routeCreateRequestDto.getRouteImageUrl());
        return ApiResponse.onSuccess("새로운 Route를 추가했습니다.");
    }
```

### 루트 조회 기능 구현
- routeId로 조회, gymId로 조회는 있는데, sectorId로 조회 기능도 필요할지 고민입니다.
- RouteGetResponseDto를 두 API에 공통으로 사용하고, 전체 조회는 List로 보내는 방식을 생각했습니다.
- 특정 암장 루트 리스트 정보를 조회할 때 너무 많은 정보를 가져오는건가 하는 생각이 들기도 하는데, Figma 보면 전체가 다 필요한거같기도 하고, 언제 데이터를 로딩할 것인지에 따라 Return DTO는 변경될 수 있을 것 같습니다.
``` java
    // 암장 특정 루트 정보 조회 (Route ID로 조회)
    @GetMapping("/gym/route/{routeId}")
    public ApiResponse<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
        return ApiResponse.onSuccess(routeService.getRoute(routeId));
    }

    // 특정 암장 루트 리스트 정보 조회 (Gym ID로 조회)
    @GetMapping("/gym/{gymId}/routes")
    public ApiResponse<List<RouteGetResponseDto>> findAllRouteByGymId(@PathVariable Long gymId) {
        return ApiResponse.onSuccess(routeService.getRouteList(gymId));
    }
```

## 테스트 확인 내용

- dev로 운영되고 있는 RDS상에서 동작을 모두 확인하였습니다.
- 다만 현재 아직 ClimbingGym 테이블과 Sector 테이블의 CRUD가 구현이 되어있지 않아 임의의 더미 데이터를 추가하고 진행했습니다.
<img width="818" alt="스크린샷 2024-01-07 오후 11 44 14" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/f3ffe662-f417-45dc-8526-f35cfa71f5c2">
<img width="1057" alt="스크린샷 2024-01-07 오후 11 44 35" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/7cbd92ee-d647-447c-bf28-4ac5662ed88c">


## 질문 및 이외 사항

- Spring으로 개발하는 첫 프로젝트이다보니 구성이 많이 달라 이해하는데 좀 오래걸렸습니다. 다른 개발사항부터는 속도가 빨라질것으로 예상됩니다.
- 아직 수정 삭제는 구현하지 않았습니다. 아직 Figma 상에 루트를 수정하고, 삭제하는 과정의 설명이 없어서 그랬고, 추후 추가되면 개발 진행하겠습니다.
- 예외처리를 어떻게 해야할지는 따로 생각을 해두었고, merge 이후 바로 추가할 수 있도록 하겠습니다.
``` java
    // 예외처리 부분
        Sector sector = sectorRepository.findById(sectorId).orElseThrow(() -> new GeneralException(
            ErrorStatus._EMPTY_SECTOR));
        if (sector.getClimbingGym().getId() != gymId) {
            throw new GeneralException(ErrorStatus._INVALID_GYM_FOR_SECTOR);
        }
```
- 다음과 같이 예외처리를 하려고 하는데(1. Empty-Sector error, 2. Sector의 GymId와 입력된 gymId와의 값이 다를 때 에러) 2번에서 sector.getClimbingGym().getId() != gymId 부분을 !=와 같은 비교연산자를 사용해도 되는지 궁금합니다. Java에서는 equals와 같은 함수를 생성하여 사용하는 것으로도 아는데, 일반적으로는 어떻게 구현하나요?
