### PR TITLE
[SPR-40] feat: 암장 루트 생성/조회 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.route;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
@@ -40,4 +42,14 @@ public class Route extends BaseTimeEntity {
 
     @ColumnDefault("0")
     private int selectionCount;
+
+    public static Route toEntity(CreateRouteRequest requestDto, Sector sector,
+        String routeImageUrl) {
+        return Route.builder()
+            .sector(sector)
+            .name(requestDto.getName())
+            .difficulty(requestDto.getDifficulty())
+            .routeImageUrl(routeImageUrl)
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Builder
@@ -37,5 +38,6 @@ public class Route extends BaseTimeEntity {
 
     private String routeImageUrl;
 
-    private int selectionCount = 0;
+    @ColumnDefault("0")
+    private int selectionCount;
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -1,7 +1,7 @@
 package com.climeet.climeet_backend.domain.route;
 
-import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateRequestDto;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,21 +28,21 @@ public class RouteController {
     @PostMapping("/route")
     public ApiResponse<String> createRoute(
         @RequestPart(value = "image") MultipartFile routeImage,
-        @RequestPart(value = "routeCreatePostReq") RouteCreateRequestDto routeCreateRequestDto
+        @RequestPart CreateRouteRequest createRouteRequest
     ) {
-        routeService.createRoute(routeCreateRequestDto, routeImage);
+        routeService.createRoute(createRouteRequest, routeImage);
         return ApiResponse.onSuccess("루트를 추가했습니다.");
     }
 
     @Operation(summary = "클라이밍 루트 조회")
     @GetMapping("/route/{routeId}")
-    public ApiResponse<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
+    public ApiResponse<RouteSimpleResponse> getRoute(@PathVariable Long routeId) {
         return ApiResponse.onSuccess(routeService.getRoute(routeId));
     }
 
     @Operation(summary = "클라이밍 암장 루트 목록 조회")
     @GetMapping("/{gymId}/routes")
-    public ApiResponse<List<RouteGetResponseDto>> findAllRouteByGymId(@PathVariable Long gymId) {
+    public ApiResponse<List<RouteSimpleResponse>> getRouteList(@PathVariable Long gymId) {
         return ApiResponse.onSuccess(routeService.getRouteList(gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -10,9 +10,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "ClimbingRoute", description = "클라이밍 루트 API")
@@ -25,10 +26,13 @@ public class RouteController {
 
     @Operation(summary = "클라이밍 루트 생성")
     @PostMapping("/{gymId}/route")
-    public ApiResponse<String> createRoute(@PathVariable Long gymId,
-        @RequestBody RouteCreateRequestDto routeCreateRequestDto) {
-        routeService.createRoute(gymId, routeCreateRequestDto);
-        return ApiResponse.onSuccess("새로운 Route를 추가했습니다.");
+    public ApiResponse<String> createRoute(
+        @PathVariable Long gymId,
+        @RequestPart(value = "image") MultipartFile routeImage,
+        @RequestPart(value = "routeCreatePostReq") RouteCreateRequestDto routeCreateRequestDto
+    ) {
+        routeService.createRoute(gymId, routeCreateRequestDto, routeImage);
+        return ApiResponse.onSuccess("루트를 추가했습니다.");
     }
 
     @Operation(summary = "클라이밍 루트 조회")

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -25,13 +25,12 @@ public class RouteController {
     private final RouteService routeService;
 
     @Operation(summary = "클라이밍 루트 생성")
-    @PostMapping("/{gymId}/route")
+    @PostMapping("/route")
     public ApiResponse<String> createRoute(
-        @PathVariable Long gymId,
         @RequestPart(value = "image") MultipartFile routeImage,
         @RequestPart(value = "routeCreatePostReq") RouteCreateRequestDto routeCreateRequestDto
     ) {
-        routeService.createRoute(gymId, routeCreateRequestDto, routeImage);
+        routeService.createRoute(routeCreateRequestDto, routeImage);
         return ApiResponse.onSuccess("루트를 추가했습니다.");
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -3,42 +3,42 @@ package com.climeet.climeet_backend.domain.route;
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateRequestDto;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 
+@Tag(name = "ClimbingRoute", description = "클라이밍 루트 API")
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/gym")
 public class RouteController {
 
     private final RouteService routeService;
 
-    // 암장 루트 추가
-    @PostMapping("/gym/{gymId}/route")
+    @Operation(summary = "클라이밍 루트 생성")
+    @PostMapping("/{gymId}/route")
     public ApiResponse<String> createRoute(@PathVariable Long gymId,
         @RequestBody RouteCreateRequestDto routeCreateRequestDto) {
-        routeService.createRoute(
-            gymId,
-            routeCreateRequestDto.getSectorId(),
-            routeCreateRequestDto.getName(),
-            routeCreateRequestDto.getDifficulty(),
-            routeCreateRequestDto.getRouteImageUrl());
+        routeService.createRoute(gymId, routeCreateRequestDto);
         return ApiResponse.onSuccess("새로운 Route를 추가했습니다.");
     }
 
-    // 암장 루트 정보 조회
-    @GetMapping("/gym/route/{routeId}")
+    @Operation(summary = "클라이밍 루트 조회")
+    @GetMapping("/route/{routeId}")
     public ApiResponse<RouteGetResponseDto> findRouteByRouteId(@PathVariable Long routeId) {
         return ApiResponse.onSuccess(routeService.getRoute(routeId));
     }
 
-    // 암장 루트 리스트 정보 조회
-    @GetMapping("/gym/{gymId}/routes")
+    @Operation(summary = "클라이밍 암장 루트 목록 조회")
+    @GetMapping("/{gymId}/routes")
     public ApiResponse<List<RouteGetResponseDto>> findAllRouteByGymId(@PathVariable Long gymId) {
         return ApiResponse.onSuccess(routeService.getRouteList(gymId));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.route;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RouteRepository extends JpaRepository<Route, Long> {
     Optional<Route> findById(Long id);
     List<Route> findBySectorClimbingGymId(Long gymId);
+
+    List<Route> findBySectorId(Long sectorId);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -38,14 +38,17 @@ public class RouteService {
     }
 
     public RouteGetResponseDto getRoute(Long routeId) {
-        Route route = routeRepository.findById(routeId).orElseThrow();
+        Route route = routeRepository.findById(routeId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE));
 
         return new RouteGetResponseDto(route);
     }
 
     public List<RouteGetResponseDto> getRouteList(Long gymId) {
         List<Route> routeList = routeRepository.findBySectorClimbingGymId(gymId);
-
+        if(routeList.isEmpty()){
+            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
+        }
         return routeList.stream()
             .map(RouteGetResponseDto::new)
             .collect(Collectors.toList());

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -4,6 +4,9 @@ import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateR
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
+import com.climeet.climeet_backend.global.response.code.BaseErrorCode;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +22,11 @@ public class RouteService {
 
     @Transactional
     public void createRoute(Long gymId, RouteCreateRequestDto routeCreateRequestDto) {
-        Sector sector = sectorRepository.findById(routeCreateRequestDto.getSectorId()).orElseThrow();
+        Sector sector = sectorRepository.findById(routeCreateRequestDto.getSectorId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SECTOR));
+        if (!sector.getClimbingGym().getId().equals(gymId)) {
+            throw new GeneralException(ErrorStatus._GYM_ID_MISMATCH);
+        }
         Route route = Route.builder()
             .sector(sector)
             .name(routeCreateRequestDto.getName())

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -37,14 +37,8 @@ public class RouteService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SECTOR));
 
         String routeImageUrl = s3Service.uploadFile(routeImage).getImgUrl();
-        Route route = Route.builder()
-            .sector(sector)
-            .name(createRouteRequest.getName())
-            .difficulty(createRouteRequest.getDifficulty())
-            .routeImageUrl(routeImageUrl)
-            .build();
 
-        routeRepository.save(route);
+        routeRepository.save(Route.toEntity(createRouteRequest, sector, routeImageUrl));
     }
 
     public RouteSimpleResponse getRoute(Long routeId) {

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.route;
 
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.RouteCreateRequestDto;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
@@ -17,14 +18,13 @@ public class RouteService {
     private final SectorRepository sectorRepository;
 
     @Transactional
-    public void createRoute(Long gymId, Long sectorId, String name, int difficulty,
-        String routeImageUrl) {
-        Sector sector = sectorRepository.findById(sectorId).orElseThrow();
+    public void createRoute(Long gymId, RouteCreateRequestDto routeCreateRequestDto) {
+        Sector sector = sectorRepository.findById(routeCreateRequestDto.getSectorId()).orElseThrow();
         Route route = Route.builder()
             .sector(sector)
-            .name(name)
-            .difficulty(difficulty)
-            .routeImageUrl(routeImageUrl)
+            .name(routeCreateRequestDto.getName())
+            .difficulty(routeCreateRequestDto.getDifficulty())
+            .routeImageUrl(routeCreateRequestDto.getRouteImageUrl())
             .build();
 
         routeRepository.save(route);

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -7,7 +7,7 @@ public class RouteRequestDto {
 
     @Getter
     @NoArgsConstructor
-    public static class RouteCreateRequestDto {
+    public static class CreateRouteRequest {
 
         private Long sectorId;
         private String name;

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -11,6 +11,6 @@ public class RouteRequestDto {
 
         private Long sectorId;
         private String name;
-        private Integer difficulty;
+        private int difficulty;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -11,7 +11,6 @@ public class RouteRequestDto {
 
         private Long sectorId;
         private String name;
-        private int difficulty;
-        private String routeImageUrl;
+        private Integer difficulty;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -9,7 +9,7 @@ public class RouteResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RouteGetResponseDto {
+    public static class RouteSimpleResponse {
 
         private Long sectorId;
         private String sectorName;
@@ -18,7 +18,7 @@ public class RouteResponseDto {
         private int difficulty;
         private String routeImageUrl;
 
-        public RouteGetResponseDto(Route route) {
+        public RouteSimpleResponse(Route route) {
             this.sectorId = route.getSector().getId();
             this.sectorName = route.getSector().getSectorName();
             this.routeId = route.getId();

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -31,6 +31,5 @@ public class Sector extends BaseTimeEntity {
     @NotNull
     private String sectorName;
 
-    @ColumnDefault("0")
-    private int floor;
+    private int floor = 0;
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor
@@ -30,5 +31,6 @@ public class Sector extends BaseTimeEntity {
     @NotNull
     private String sectorName;
 
-    private int floor = 0;
+    @ColumnDefault("0")
+    private int floor;
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -28,7 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //루트 관련
     _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),
-    _EMPTY_ROUTE_LIST(HttpStatus.CONFLICT, "Route_002", "암장의 루트 정보를 찾을 수 없습니다."),
+    _EMPTY_ROUTE_LIST(HttpStatus.CONFLICT, "ROUTE_002", "암장의 루트 정보를 찾을 수 없습니다."),
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //루트 관련
     _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),
+    _EMPTY_ROUTE_LIST(HttpStatus.CONFLICT, "Route_002", "암장의 루트 정보를 찾을 수 없습니다."),
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -24,11 +24,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),
-    _GYM_ID_MISMATCH(HttpStatus.CONFLICT, "SECTOR_002", "벽면과 암장 정보가 일치하지 않습니다."),
 
     //루트 관련
     _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),
     _EMPTY_ROUTE_LIST(HttpStatus.CONFLICT, "ROUTE_002", "암장의 루트 정보를 찾을 수 없습니다."),
+    _DUPLICATE_ROUTE_NAME(HttpStatus.CONFLICT, "ROUTE_004", "루트 이름이 중복됩니다."),
 
     //인증 관련
     _EMPTY_JWT(HttpStatus.UNAUTHORIZED, "AUTH_001", "JWT가 존재하지 않습니다."),
@@ -45,10 +45,10 @@ public enum ErrorStatus implements BaseErrorCode {
     @Override
     public ErrorReasonDto getReasonHttpStatus() {
         return ErrorReasonDto.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .build();
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .build();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),
+    _GYM_ID_MISMATCH(HttpStatus.CONFLICT, "SECTOR_002", "벽면과 암장 정보가 일치하지 않습니다."),
 
     //루트 관련
     _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),


### PR DESCRIPTION
## 요약

- 기존에 개발 완료된 사항에서 수정했습니다.

## 상세 내용

- 이전 PR 에서 수정 요청사항을 반영했습니다.
>-  Swagger 설명을 추가했습니다.
>- ColumnDefault를 Sector의 Floor에 적용했습니다.
>기존의 ```floor = 0```과 다른점은 ColumnDefault는 테이블 생성시에 컬럼 자체에 옵션을 추가하는 것이며, ```floor = 0```은 테이블에 데이터를 삽입할 때 입력된 값이 없으면 추가하는 것으로 이해했습니다.
>- RouteController에 RequestMapping을 적용했습니다.
>- RouteService에 createRoute에서 RouteCreateRequestDto를 바로 받아서 사용하도록 적용했습니다.

- 예외처리를 추가했습니다.
>- Sector 데이터가 Empty일 때 예외처리 추가했습니다.
>- Parameter로 받은 gymId값이 Sector에 저장된 gymId와 일치하지 않을 때 예외처리 추가했습니다.
>- Route 데이터가 Empty일 때 예외처리 추가했습니다.
>- Route List를 불러왔을 때 값이 없으면 에러 반환하도록 예외처리 추가했습니다.

- RouteController에서 MultiPart 이미지 파일을 받아서 S3에 올리도록 추가했습니다.
>- Postman에서 같은 JSON인데 인식을 못해서 몇시간동안 끙끙대다가 해결했습니다.


## 테스트 확인 내용

- Notion API 문서에 수정사항 반영하겠습니다.
 <img width="654" alt="스크린샷 2024-01-13 오후 2 49 11" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/4702d765-6d02-4683-a4a3-9c671e7f81bd">
DB 확인했고, 이미지 잘 올라간 것 확인했습니다.
- 각 예외상황에 맞는 값 입력해서 확인 완료했습니다.

## 질문 및 이외 사항
- RouteCreateRequestDto로 Dto 클래스를 사용하고 있는데, 쇼츠 업로드 API와 Dto 형식을 맞추는게 나을 것 같아 value 값으로 routeCreatePostReq를 사용하도록 했습니다. 추후 내부 형식이 정립되면 수정하겠습니다.
- 암장 정보 부분도 열심히 작업중입니다! 작업 완료되면 또 PR 날리러 오겠습니다!
