### PR TITLE
[SPR-60] feat: 섹터 추가/ 조회 기능

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.sector;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -33,4 +34,12 @@ public class Sector extends BaseTimeEntity {
     private String sectorName;
 
     private int floor = 0;
+
+    public static Sector toEntity(CreateSectorRequest requestDto, ClimbingGym climbingGym){
+        return Sector.builder()
+            .climbingGym(climbingGym)
+            .sectorName(requestDto.getName())
+            .floor(requestDto.getFloor())
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class Sector extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -1,10 +1,41 @@
 package com.climeet.climeet_backend.domain.sector;
 
+import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.SectorCreateRequestDto;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorGetResponseDto;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "ClimbingSector", description = "클라이밍 섹터 API")
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/gym")
 public class SectorController {
 
+    private final SectorService sectorService;
+
+    @Operation(summary = "클라이밍 섹터 생성")
+    @PostMapping("/sector")
+    public ApiResponse<String> createSector(
+        @RequestBody SectorCreateRequestDto sectorCreateRequestDto) {
+        sectorService.createSector(sectorCreateRequestDto);
+        return ApiResponse.onSuccess("새로운 Sector를 추가했습니다.");
+    }
+
+    @Operation(summary = "특정 암장 전체 섹터 조회")
+    @GetMapping("/{gymId}/sector")
+    public ApiResponse<List<SectorGetResponseDto>> getAllRoutesBySectorId(
+        @PathVariable Long gymId
+    ) {
+        List<SectorGetResponseDto> sectorList = sectorService.getAllSectorByGymId(gymId);
+        return ApiResponse.onSuccess(sectorList);
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -1,7 +1,7 @@
 package com.climeet.climeet_backend.domain.sector;
 
-import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.SectorCreateRequestDto;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorGetResponseDto;
+import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,17 +25,17 @@ public class SectorController {
     @Operation(summary = "클라이밍 섹터 생성")
     @PostMapping("/sector")
     public ApiResponse<String> createSector(
-        @RequestBody SectorCreateRequestDto sectorCreateRequestDto) {
-        sectorService.createSector(sectorCreateRequestDto);
+        @RequestBody CreateSectorRequest createSectorRequest) {
+        sectorService.createSector(createSectorRequest);
         return ApiResponse.onSuccess("새로운 Sector를 추가했습니다.");
     }
 
     @Operation(summary = "특정 암장 전체 섹터 조회")
     @GetMapping("/{gymId}/sector")
-    public ApiResponse<List<SectorGetResponseDto>> getAllRoutesBySectorId(
+    public ApiResponse<List<SectorDetailResponse>> getSectorList(
         @PathVariable Long gymId
     ) {
-        List<SectorGetResponseDto> sectorList = sectorService.getAllSectorByGymId(gymId);
+        List<SectorDetailResponse> sectorList = sectorService.getSectorList(gymId);
         return ApiResponse.onSuccess(sectorList);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorRepository.java
@@ -1,7 +1,8 @@
 package com.climeet.climeet_backend.domain.sector;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectorRepository extends JpaRepository<Sector, Long> {
-
+    List<Sector> findSectorByClimbingGymId(Long gymId);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -32,13 +32,8 @@ public class SectorService {
 
         ClimbingGym climbingGym = climbingGymRepository.findById(createSectorRequest.getGymId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
-        Sector sector = Sector.builder()
-            .climbingGym(climbingGym)
-            .sectorName(createSectorRequest.getName())
-            .floor(createSectorRequest.getFloor())
-            .build();
 
-        sectorRepository.save(sector);
+        sectorRepository.save(Sector.toEntity(createSectorRequest, climbingGym));
     }
 
     public List<SectorDetailResponse> getSectorList(Long gymId) {

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -21,6 +21,9 @@ public class SectorService {
 
     @Transactional
     public void createSector(CreateSectorRequest createSectorRequest) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(createSectorRequest.getGymId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
         // 루트 이름 중복 체크 (같은 섹터에서 중복일 경우)
         List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
             createSectorRequest.getGymId());
@@ -29,9 +32,6 @@ public class SectorService {
                 throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
             }
         }
-
-        ClimbingGym climbingGym = climbingGymRepository.findById(createSectorRequest.getGymId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
         sectorRepository.save(Sector.toEntity(createSectorRequest, climbingGym));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -1,10 +1,54 @@
 package com.climeet.climeet_backend.domain.sector;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
+import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.SectorCreateRequestDto;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorGetResponseDto;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class SectorService {
 
+    private final ClimbingGymRepository climbingGymRepository;
+    private final SectorRepository sectorRepository;
+
+    @Transactional
+    public void createSector(SectorCreateRequestDto sectorCreateRequestDto) {
+        // 루트 이름 중복 체크 (같은 섹터에서 중복일 경우)
+        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
+            sectorCreateRequestDto.getGymId());
+        for (Sector sector : sectorList) {
+            if (sector.getSectorName().equals(sectorCreateRequestDto.getName())) {
+                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
+            }
+        }
+
+        ClimbingGym climbingGym = climbingGymRepository.findById(sectorCreateRequestDto.getGymId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+        Sector sector = Sector.builder()
+            .climbingGym(climbingGym)
+            .sectorName(sectorCreateRequestDto.getName())
+            .floor(sectorCreateRequestDto.getFloor())
+            .build();
+
+        sectorRepository.save(sector);
+    }
+
+    public List<SectorGetResponseDto> getAllSectorByGymId(Long gymId){
+        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(gymId);
+
+
+        return sectorList.stream()
+            .map(SectorGetResponseDto::new)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -2,10 +2,8 @@ package com.climeet.climeet_backend.domain.sector;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
-import com.climeet.climeet_backend.domain.route.Route;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteGetResponseDto;
-import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.SectorCreateRequestDto;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorGetResponseDto;
+import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import java.util.List;
@@ -22,33 +20,32 @@ public class SectorService {
     private final SectorRepository sectorRepository;
 
     @Transactional
-    public void createSector(SectorCreateRequestDto sectorCreateRequestDto) {
+    public void createSector(CreateSectorRequest createSectorRequest) {
         // 루트 이름 중복 체크 (같은 섹터에서 중복일 경우)
         List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
-            sectorCreateRequestDto.getGymId());
+            createSectorRequest.getGymId());
         for (Sector sector : sectorList) {
-            if (sector.getSectorName().equals(sectorCreateRequestDto.getName())) {
+            if (sector.getSectorName().equals(createSectorRequest.getName())) {
                 throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
             }
         }
 
-        ClimbingGym climbingGym = climbingGymRepository.findById(sectorCreateRequestDto.getGymId())
+        ClimbingGym climbingGym = climbingGymRepository.findById(createSectorRequest.getGymId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
         Sector sector = Sector.builder()
             .climbingGym(climbingGym)
-            .sectorName(sectorCreateRequestDto.getName())
-            .floor(sectorCreateRequestDto.getFloor())
+            .sectorName(createSectorRequest.getName())
+            .floor(createSectorRequest.getFloor())
             .build();
 
         sectorRepository.save(sector);
     }
 
-    public List<SectorGetResponseDto> getAllSectorByGymId(Long gymId){
+    public List<SectorDetailResponse> getSectorList(Long gymId) {
         List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(gymId);
 
-
         return sectorList.stream()
-            .map(SectorGetResponseDto::new)
+            .map(SectorDetailResponse::new)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
@@ -1,0 +1,15 @@
+package com.climeet.climeet_backend.domain.sector.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SectorRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class SectorCreateRequestDto {
+        private Long gymId;
+        private String name;
+        private int floor;
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
@@ -7,7 +7,8 @@ public class SectorRequestDto {
 
     @Getter
     @NoArgsConstructor
-    public static class SectorCreateRequestDto {
+    public static class CreateSectorRequest {
+
         private Long gymId;
         private String name;
         private int floor;

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
@@ -1,0 +1,27 @@
+package com.climeet.climeet_backend.domain.sector.dto;
+
+import com.climeet.climeet_backend.domain.sector.Sector;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class SectorResponseDto {
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SectorGetResponseDto {
+
+        private String name;
+        private int floor;
+
+        public SectorGetResponseDto(Sector sector) {
+            this.name = sector.getSectorName();
+            this.floor = sector.getFloor();
+        }
+    }
+
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
@@ -12,12 +12,12 @@ public class SectorResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SectorGetResponseDto {
+    public static class SectorDetailResponse {
 
         private String name;
         private int floor;
 
-        public SectorGetResponseDto(Sector sector) {
+        public SectorDetailResponse(Sector sector) {
             this.name = sector.getSectorName();
             this.floor = sector.getFloor();
         }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),
+    _DUPLICATE_SECTOR_NAME(HttpStatus.CONFLICT, "SECTOR_002", "섹터 이름이 중복됩니다."),
 
     //루트 관련
     _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),


### PR DESCRIPTION
## 요약

- Sector 추가, 조회 기능입니다.
- Route 관련 기능과 구조가 거의 비슷합니다.

## 상세 내용

1. /gym/sector 에서 섹터를 생성할 수 있습니다.
  ``` java
  @Operation(summary = "클라이밍 섹터 생성")
      @PostMapping("/sector")
      public ApiResponse<String> createSector(
          @RequestBody CreateSectorRequest createSectorRequest) {
          sectorService.createSector(createSectorRequest);
          return ApiResponse.onSuccess("새로운 Sector를 추가했습니다.");
      }
  ```
2. /gym/{gymId}/sector 에서 특정 gymId에 해당하는 전체 Sector 목록을 불러올 수 있습니다.
  ``` java
  @Operation(summary = "특정 암장 전체 섹터 조회")
    @GetMapping("/{gymId}/sector")
    public ApiResponse<List<SectorDetailResponse>> getSectorList(
        @PathVariable Long gymId
    ) {
        List<SectorDetailResponse> sectorList = sectorService.getSectorList(gymId);
        return ApiResponse.onSuccess(sectorList);
    }
  ```
3. Sector를 생성할 때 이름 중복 예외처리 추가했습니다.
``` java
  for (Sector sector : sectorList) {
        if (sector.getSectorName().equals(createSectorRequest.getName())) {
            throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
        }
   }
```
4. 코딩 컨벤션에 맞추어 적용했습니다.

## 테스트 확인 내용
- Postman으로 두 API 호출 후 실행 확인 하였고, 같은 암장에서 섹터 이름이 중복되었을 때 예외처리 결과도 확인 완료했습니다.

## 질문 및 이외 사항
- 조언과 훈수, 의견 모두 달게 받겠습니다! 감사합니다!
