### PR TITLE
[SPR-78] feat: [기록생성순] 금주 인기 암장 & [기록생성순] 금주 인기 루트 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGym.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class BestFollowGym {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -34,5 +35,5 @@ public class BestFollowGym {
 
     private Float rating;
 
-    private int reviewCount=0;
+    private int reviewCount = 0;
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGymController.java
@@ -18,6 +18,9 @@ public class BestFollowGymController {
 
     private final BestFollowGymService bestFollowGymService;
 
+    /**
+     * [GET] [팔로우 순] 이번주 짐 랭킹 조회
+     */
     @Operation(summary = "[팔로우 순] 이번주 짐 랭킹 조회")
     @GetMapping("/follow")
     public ApiResponse<List<BestFollowGymSimpleDto>> findGymRankingOrderFollowCount() {

--- a/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGymRepository.java
@@ -4,5 +4,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BestFollowGymRepository extends JpaRepository<BestFollowGym, Long> {
+
     List<BestFollowGym> findAllByOrderByRankingAsc();
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/dto/BestFollowGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/dto/BestFollowGymResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class BestFollowGymResponseDto {
+
     @Getter
     @NoArgsConstructor
     public static class BestFollowGymSimpleDto {

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGym.java
@@ -1,0 +1,38 @@
+package com.climeet.climeet_backend.domain.bestrecordgym;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BestRecordGym {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private ClimbingGym climbingGym;
+
+    private int ranking = 0;
+
+    private int thisWeekSelectionCount = 0;
+
+    private String profileImageUrl;
+
+    private String gymName;
+
+    private Float rating;
+
+    private int reviewCount=0;
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymController.java
@@ -1,0 +1,31 @@
+package com.climeet.climeet_backend.domain.bestrecordgym;
+
+import com.climeet.climeet_backend.domain.bestfollowgym.BestFollowGymService;
+import com.climeet.climeet_backend.domain.bestfollowgym.dto.BestFollowGymResponseDto.BestFollowGymSimpleDto;
+import com.climeet.climeet_backend.domain.bestrecordgym.dto.BestRecordGymResponseDto.BestRecordGymSimpleDto;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BestRecordGym", description = "[기록된 순(selected된 순)] 금주 베스트 운동 기록 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/rank/week/gym")
+public class BestRecordGymController {
+    private final BestRecordGymService bestRecordGymService;
+
+    /**
+     * [GET] [기록된 순(selected된 순)] 이번주 짐 랭킹 조회
+     */
+    @Operation(summary = "[기록된 순(selected된 순)] 이번주 짐 랭킹 조회")
+    @GetMapping("/record")
+    public ApiResponse<List<BestRecordGymSimpleDto>> findGymRankingOrderSelectionCount() {
+        return ApiResponse.onSuccess(bestRecordGymService.findGymRankingOrderSelectionCount());
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymRepository.java
@@ -4,5 +4,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BestRecordGymRepository extends JpaRepository<BestRecordGym, Long> {
+
     List<BestRecordGym> findAllByOrderByRankingAsc();
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymRepository.java
@@ -1,0 +1,8 @@
+package com.climeet.climeet_backend.domain.bestrecordgym;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BestRecordGymRepository extends JpaRepository<BestRecordGym, Long> {
+    List<BestRecordGym> findAllByOrderByRankingAsc();
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymService.java
@@ -1,0 +1,21 @@
+package com.climeet.climeet_backend.domain.bestrecordgym;
+
+import com.climeet.climeet_backend.domain.bestrecordgym.dto.BestRecordGymResponseDto.BestRecordGymSimpleDto;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BestRecordGymService {
+
+    private final BestRecordGymRepository bestRecordGymRepository;
+
+    public List<BestRecordGymSimpleDto> findGymRankingOrderSelectionCount() {
+        List<BestRecordGym> ranking = bestRecordGymRepository.findAllByOrderByRankingAsc();
+        return ranking.stream()
+            .map(bestRecordGym -> new BestRecordGymSimpleDto(bestRecordGym))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/dto/BestRecordGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/dto/BestRecordGymResponseDto.java
@@ -1,0 +1,30 @@
+package com.climeet.climeet_backend.domain.bestrecordgym.dto;
+
+import com.climeet.climeet_backend.domain.bestrecordgym.BestRecordGym;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BestRecordGymResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class BestRecordGymSimpleDto {
+
+        private int ranking;
+        private String profileImageUrl;
+        private String gymName;
+        private int thisWeekSelectionCount;
+        private Float rating;
+        private int reviewCount;
+
+        public BestRecordGymSimpleDto(BestRecordGym bestRecordGym) {
+            this.ranking = bestRecordGym.getRanking();
+            this.thisWeekSelectionCount = bestRecordGym.getThisWeekSelectionCount();
+            this.profileImageUrl = bestRecordGym.getProfileImageUrl();
+            this.gymName = bestRecordGym.getGymName();
+            this.rating = bestRecordGym.getRating();
+            this.reviewCount = bestRecordGym.getReviewCount();
+        }
+    }
+}
+

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRoute.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRoute.java
@@ -7,7 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,6 +23,22 @@ public class BestRoute extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     private Route route;
+
+    private int ranking;
+
+    private String routeImageUrl;
+
+    private int thisWeekSelectionCount;
+
+    private String gymName;
+
+    private String sectorName;
+
+    private int level;
+
+    private String levelColor;
+
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteController.java
@@ -15,10 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/rank/week/routes")
 public class BestRouteController {
+
     private final BestRouteService bestRouteService;
 
     @GetMapping
-    public ApiResponse<List<BestRouteSimpleDto>> findRouteRankingOrderSelectionCount(){
+    public ApiResponse<List<BestRouteSimpleDto>> findRouteRankingOrderSelectionCount() {
         return ApiResponse.onSuccess(bestRouteService.findBestRouteList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteController.java
@@ -1,0 +1,24 @@
+package com.climeet.climeet_backend.domain.bestroute;
+
+import com.climeet.climeet_backend.domain.bestroute.dto.BestRouteResponseDto.BestRouteSimpleDto;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BestRoute", description = "[기록된 순(selected된 순)] 금주 베스트 루트 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/rank/week/routes")
+public class BestRouteController {
+    private final BestRouteService bestRouteService;
+
+    @GetMapping
+    public ApiResponse<List<BestRouteSimpleDto>> findRouteRankingOrderSelectionCount(){
+        return ApiResponse.onSuccess(bestRouteService.findBestRouteList());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteRepository.java
@@ -1,0 +1,8 @@
+package com.climeet.climeet_backend.domain.bestroute;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BestRouteRepository extends JpaRepository<BestRoute, Long> {
+    List<BestRoute> findAllByOrderByRankingAsc();
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteRepository.java
@@ -4,5 +4,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BestRouteRepository extends JpaRepository<BestRoute, Long> {
+
     List<BestRoute> findAllByOrderByRankingAsc();
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteService.java
@@ -1,0 +1,20 @@
+package com.climeet.climeet_backend.domain.bestroute;
+
+import com.climeet.climeet_backend.domain.bestroute.dto.BestRouteResponseDto.BestRouteSimpleDto;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BestRouteService {
+    private final BestRouteRepository bestRouteRepository;
+
+    public List<BestRouteSimpleDto> findBestRouteList(){
+        List<BestRoute> routeList = bestRouteRepository.findAllByOrderByRankingAsc();
+        return routeList.stream()
+            .map(BestRouteSimpleDto::new)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteService.java
@@ -9,9 +9,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class BestRouteService {
+
     private final BestRouteRepository bestRouteRepository;
 
-    public List<BestRouteSimpleDto> findBestRouteList(){
+    public List<BestRouteSimpleDto> findBestRouteList() {
         List<BestRoute> routeList = bestRouteRepository.findAllByOrderByRankingAsc();
         return routeList.stream()
             .map(BestRouteSimpleDto::new)

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
@@ -1,11 +1,11 @@
 package com.climeet.climeet_backend.domain.bestroute.dto;
 
-import com.climeet.climeet_backend.domain.bestrecordgym.BestRecordGym;
 import com.climeet.climeet_backend.domain.bestroute.BestRoute;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class BestRouteResponseDto {
+
     @Getter
     @NoArgsConstructor
     public static class BestRouteSimpleDto {

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
@@ -1,0 +1,29 @@
+package com.climeet.climeet_backend.domain.bestroute.dto;
+
+import com.climeet.climeet_backend.domain.bestrecordgym.BestRecordGym;
+import com.climeet.climeet_backend.domain.bestroute.BestRoute;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BestRouteResponseDto {
+    @Getter
+    @NoArgsConstructor
+    public static class BestRouteSimpleDto {
+
+        private int ranking;
+        private String routeImageUrl;
+        private int thisWeekSelectionCount;
+        private String gymName;
+        private String sectorName;
+        private int level;
+
+        public BestRouteSimpleDto(BestRoute bestRoute) {
+            this.ranking = bestRoute.getRanking();
+            this.thisWeekSelectionCount = bestRoute.getThisWeekSelectionCount();
+            this.routeImageUrl = bestRoute.getRouteImageUrl();
+            this.gymName = bestRoute.getGymName();
+            this.sectorName = bestRoute.getSectorName();
+            this.level = bestRoute.getLevel();
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -39,4 +39,20 @@ public class ClimbingGym extends BaseTimeEntity {
     private int thisWeekFollowCount = 0;
 
     private int thisWeekSelectionCount = 0;
+
+    public void thisWeekFollowCountUp(){
+        this.thisWeekFollowCount++;
+    }
+
+    public void thisWeekFollowCountDown(){
+        this.thisWeekFollowCount--;
+    }
+
+    public void thisWeekSelectionCountUp(){
+        this.thisWeekSelectionCount++;
+    }
+
+    public void thisWeekSelectionCountDown(){
+        this.thisWeekSelectionCount--;
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -28,6 +28,7 @@ public class ClimbingRecordController {
 
     private final ClimbingRecordService climbingRecordService;
 
+
     @Operation(summary = "클라이밍 기록 생성")
     @PostMapping
     public ApiResponse<String> addClimbingRecord(@RequestBody CreateClimbingRecordDto requestDto) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
+import com.climeet.climeet_backend.domain.bestrecordgym.BestRecordGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.UpdateClimbingRecordDto;
@@ -34,6 +35,9 @@ public class ClimbingRecordService {
 
         ClimbingRecord savedClimbingRecord = climbingRecordRepository
             .save(ClimbingRecord.toEntity(requestDto, climbingGym));
+
+        //선택받았으니 하나 추가
+        climbingGym.thisWeekSelectionCountUp();
 
         List<CreateRouteRecordDto> routeRecords = requestDto.getRouteRecordRequestDtoList();
         // 루트기록 리퀘스트 돌면서 루트 리퀘스트 저장
@@ -106,9 +110,13 @@ public class ClimbingRecordService {
 
     @Transactional
     public ApiResponse<String> deleteClimbingRecord(Long id) {
-        climbingRecordRepository.findById(id)
+        ClimbingRecord climbingRecord = climbingRecordRepository.findById(id)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD));
+
         climbingRecordRepository.deleteById(id);
+
+        climbingRecord.getGym().thisWeekSelectionCountDown();
+
         return ApiResponse.onSuccess("클라이밍기록이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -57,4 +57,12 @@ public class Route extends BaseTimeEntity {
             .routeImageUrl(routeImageUrl)
             .build();
     }
+
+    public void thisWeekSelectionCountUp(){
+        this.thisWeekSelectionCount++;
+    }
+
+    public void thisWeekSelectionCountDown(){
+        this.thisWeekSelectionCount--;
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -37,6 +37,8 @@ public class RouteRecordService {
 
         climbingRecord.setAttemptCount(count);
 
+        route.thisWeekSelectionCountDown();
+
         if (requestDto.getIsCompleted()) {
             climbingRecord.totalCompletedCountUp();
         }
@@ -129,6 +131,8 @@ public class RouteRecordService {
 
         //climbingRecord의 시도 횟수 업데이트
         climbingRecord.setAttemptCount(-routeRecord.getAttemptCount());
+
+        routeRecord.getRoute().thisWeekSelectionCountDown();
 
         routeRecordRepository.delete(routeRecord);
         return ApiResponse.onSuccess("루트기록이 삭제되었습니다.");


### PR DESCRIPTION
## 요약
- [기록생성순] 금주 인기 암장 구현
- [기록생성순] 금주 인기 루트 구현

## 상세 내용
- #26 과 마찬가지로 람다에서 업데이트를 진행하고 Spring Boot와 JPA를 통해 조회하는 로직을 구현하였습니다.
- "[기록생성순] 금주 인기 암장" 구현의 경우 "[팔로워순] 금주 인기 암장"과 거의 같은 코드로 작성되었습니다.
- 다른 점은 운동기록을 생성하고 삭제하는 로직에 thisWeekSelectionCount & thisFollowSelectionCount 를 재설정하는 로직을 추가하고 적용하였습니다.

## 테스트 확인 내용
- 현재는 postman과 swagger를 이용하여 테스트를 진행 중입니다.
- 베스트 관련 기능들(총 6개)에 대하여 @authenticationprincipa의 커스텀 어노테이션이 작성되면 BestClimber(3가지 경우)를 구현한 후 TDD를 적용하겠습니다.

## 질문 및 이외 사항
- 지난 pr 수정사항에 말씀드렸다시피 조회 시 N+1 호출에 대한 쿼리 최적화를 진행하였고 이번 PR의 코드에도 진행하였습니다.
- 다음 PR에는 현재 로컬에 작성된 파이썬 코드를 AWS Lambda에 작성하고 이벤트브릿지 연결 및  테스트를 진행하겠습니다.
### 주의사항
- 현재 루트 랭킹의 경우 루트에 대한 암장 고유의 색상이 매핑되어있지 않습니다.
- 이는 암장 생성 시 루트 색상에 대한 구현이 완료되지 않았기에 백로그에 적어두겠습니다.
