### PR TITLE
[SPR-69] feat: 숏츠 댓글 작성

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -59,6 +59,7 @@ public class ClimbingGym extends BaseTimeEntity {
         if (manager != null) {
             manager.setClimbingGym(this);
         }
+    }
 
     private int thisWeekFollowCount = 0;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -7,7 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> {
 
-    Optional<ClimbingGym> findById(Long gymId);
-
-    ClimbingGym findByName(String gymName);
+    Optional<ClimbingGym> findByName(String gymName);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
 import com.climeet.climeet_backend.domain.shorts.Shorts;
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
 import com.climeet.climeet_backend.domain.user.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,13 +12,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class ShortsComment {
 
     @Id
@@ -32,4 +36,19 @@ public class ShortsComment {
 
     @NotNull
     private String comment;
+
+    private Long parentCommentId;
+
+    public static ShortsComment toEntity(CreateShortsCommentRequest createShortsCommentRequest,
+        Shorts shorts) {
+        return ShortsComment.builder()
+            .comment(createShortsCommentRequest.getContent())
+            //.user(user)
+            .shorts(shorts)
+            .build();
+    }
+
+    public void updateParentCommentId(Long parentCommentId) {
+        this.parentCommentId = parentCommentId;
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -5,7 +5,6 @@ import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +20,7 @@ public class ShortsCommentController {
     private final ShortsCommentService shortsCommentService;
 
     /**
-     * [POST] 숏츠 댓글 작성 (commentId가 null일 경우 대댓글 작성)
+     * [POST] 숏츠 댓글 작성 (commentId가 null일 경우 대댓글 아닌 일반 댓글 작성)
      */
     @Operation(summary = "숏츠 댓글 작성")
     @PostMapping("/shorts/{shortsId}/shortsComments")

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -1,10 +1,36 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+
+@Tag(name = "ShortsComment", description = "숏츠 댓글 API")
 @RequiredArgsConstructor
 @RestController
 public class ShortsCommentController {
 
+    private final ShortsCommentService shortsCommentService;
+
+    /**
+     * [POST] 숏츠 댓글 작성 (commentId가 null일 경우 대댓글 작성)
+     */
+    @Operation(summary = "숏츠 댓글 작성")
+    @PostMapping("/shorts/{shortsId}/shortsComments")
+    public ApiResponse<String> createShortsComment(
+        @PathVariable Long shortsId,
+        @RequestBody CreateShortsCommentRequest createShortsCommentRequest,
+        @RequestParam(required = false) Long parentCommentId) {
+        shortsCommentService.createShortsComment(shortsId, createShortsCommentRequest,
+            parentCommentId, parentCommentId != null);
+        return ApiResponse.onSuccess("댓글 작성에 성공했습니다.");
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -1,5 +1,11 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
+import com.climeet.climeet_backend.domain.shorts.Shorts;
+import com.climeet.climeet_backend.domain.shorts.ShortsRepository;
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,4 +13,22 @@ import org.springframework.stereotype.Service;
 @Service
 public class ShortsCommentService {
 
+    private final ShortsRepository shortsRepository;
+    private final ShortsCommentRepository shortsCommentRepository;
+
+    @Transactional
+    public void createShortsComment(Long shortsId,
+        CreateShortsCommentRequest createShortsCommentRequest, Long parentCommentId,
+        boolean isReply) {
+
+        Shorts shorts = shortsRepository.findById(shortsId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SHORTS));
+
+        ShortsComment shortsComment = ShortsComment.toEntity(createShortsCommentRequest, shorts);
+        if (isReply) {
+            shortsComment.updateParentCommentId(parentCommentId);
+        }
+
+        shortsCommentRepository.save(shortsComment);
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/dto/ShortsCommentRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/dto/ShortsCommentRequestDto.java
@@ -1,0 +1,14 @@
+package com.climeet.climeet_backend.domain.shortscomment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShortsCommentRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateShortsCommentRequest {
+
+        private String content;
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -50,9 +50,12 @@ public enum ErrorStatus implements BaseErrorCode {
         "시점상 시작 날짜는 종료 날짜보다 같거나 앞서야 합니다."),
 
     //루트 기록 관련
-    _EMPTY_ROUTE_RECORD(HttpStatus.CONFLICT, "ROUTE_RECORD_001", "존재하지 않는 루트운동기록입니다.");
+    _EMPTY_ROUTE_RECORD(HttpStatus.CONFLICT, "ROUTE_RECORD_001", "존재하지 않는 루트운동기록입니다."),
 
+    //숏츠 관련
+    _EMPTY_SHORTS(HttpStatus.CONFLICT, "SHORTS_001", "존재하지 않는 쇼츠입니다.")
 
+    ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/test/java/com/climeet/climeet_backend/domain/shorts/ShortsControllerTest.java
+++ b/src/test/java/com/climeet/climeet_backend/domain/shorts/ShortsControllerTest.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.hibernate.Hibernate;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -100,13 +99,6 @@ class ShortsControllerTest {
             .build();
     }
 
-    @AfterEach
-    public void AfterEach() {
-        Pageable pageable = PageRequest.of(0, 5);
-        Slice<Shorts> shortsSlice = shortsRepository.findAllByOrderByCreatedAtDesc(pageable);
-        shortsRepository.deleteAll(shortsSlice.getContent());
-    }
-
     @DisplayName("숏츠 최신순 조회에 성공한다")
     @Test
     public void findLatestShorts() throws Exception {
@@ -122,7 +114,6 @@ class ShortsControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.page").value(2))
             .andExpect(jsonPath("$.result.hasNext").value(true));
-
     }
 
     @DisplayName("숏츠 인기순 조회에 성공한다")
@@ -131,8 +122,10 @@ class ShortsControllerTest {
         //given
         final String url = "/shorts/popular?page=0&size=2";
         Pageable pageable = PageRequest.of(0, 5);
-        Shorts shorts = shortsRepository.findAllByRankingNotZeroOrderByRankingAscCreatedAtDesc(pageable).getContent().get(0);
-        ClimbingGym climbingGym = climbingGymRepository.findById(shorts.getClimbingGym().getId()).get();
+        Shorts shorts = shortsRepository.findAllByIsPublicTrueANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(
+            pageable).getContent().get(0);
+        ClimbingGym climbingGym = climbingGymRepository.findById(shorts.getClimbingGym().getId())
+            .get();
         Hibernate.initialize(climbingGym);
         String expectedHighestRankingShortsGymName = climbingGym.getName();
 
@@ -143,6 +136,7 @@ class ShortsControllerTest {
         //then
         resultActions
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.result.result[0].gymName").value(expectedHighestRankingShortsGymName));
+            .andExpect(
+                jsonPath("$.result.result[0].gymName").value(expectedHighestRankingShortsGymName));
     }
 }

--- a/src/test/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentControllerTest.java
+++ b/src/test/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentControllerTest.java
@@ -1,0 +1,86 @@
+package com.climeet.climeet_backend.domain.shortscomment;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(Lifecycle.PER_CLASS)
+@ActiveProfiles("dev")
+class ShortsCommentControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeAll
+    void beforeAll() {
+        //추후 Get, Patch 테스트에 사용
+    }
+
+    @BeforeEach
+    public void mockMvcSetup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+            .build();
+    }
+
+    @AfterEach
+    public void AfterEach() {
+        //추후 Get, Patch 테스트에 사용
+    }
+
+    @DisplayName("숏츠 댓글 생성에 성공한다")
+    @Test
+    void createShortsComment() throws Exception {
+        //given
+        Long shortsId = 1L;
+        Long shortsCommentId = 1L;
+
+        CreateShortsCommentRequest createShortsCommentRequest = new CreateShortsCommentRequest();
+        Field field = createShortsCommentRequest.getClass().getDeclaredField("content");
+        field.setAccessible(true);
+        field.set(createShortsCommentRequest, "댓글 내용");
+
+        String content = objectMapper.writeValueAsString(createShortsCommentRequest);
+        String url = "/shorts/" + shortsId + "/shortsComments";
+
+        //when
+        final ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .param("parentCommentId",
+                    shortsCommentId != null ? shortsCommentId.toString() : null));
+
+        //then
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result").value("댓글 작성에 성공했습니다."));
+    }
+}


### PR DESCRIPTION
## 요약

- 숏츠 댓글 작성

## 상세 내용

- 일반적인 POST 로직입니다.
- 댓글과 대댓글 작성을 한번에 하고 reqeustParam값으로 구분했습니다.,
- 프론트에서 ParentCommentId를 null로 줄 경우 `댓글`, 아닌 경우 부모 댓글로 id를 통해 설정했습니다.

## 테스트 확인 내용
<img width="480" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/117848386/11679fed-d6ca-482e-8a94-f4603a5d5c94">

- 부모 댓글이 null일때와 값이 주어졌을 때 모두 확인
    - 둘 다 정상 작동확인했습니다~!

## 질문 및 이외 사항

- 지금까지 작성한 테스트코드가 DB값에 따라 달라지는데 누가 더미 데이터를 삽입, 삭제할때 달라지기때문에 지금처럼 하는게 맞는지 모르겠네요(지금 방식은 스프링부트 책 2권을 참고해서 작성했습니다.) 더 찾아보겠습니다!
- 협업 방식과 관련해 pr올릴 때 코드 줄이 200~300자 넘기지 않게, 또 주기는 짧게 가져가라는 글을 보고 평소 (작성,수정,삭제)를 한번에 올렸지만 이번에는 바로 올렸는데 보기 편하신가요? 의견을 내주시면 참고하겠습니다 ~!
++ toEntity에 user 주석은 추후 현재 유저를 받아오는 커스텀 어노테이션 적용후에 사용할 예정입니다!