### PR TITLE
[FEAT] @CurrentUser 커스텀 어노테이션 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/BestFollowGymController.java
@@ -1,11 +1,11 @@
 package com.climeet.climeet_backend.domain.bestfollowgym;
 
 import com.climeet.climeet_backend.domain.bestfollowgym.dto.BestFollowGymResponseDto.BestFollowGymSimpleDto;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +23,7 @@ public class BestFollowGymController {
      */
     @Operation(summary = "[팔로우 순] 이번주 짐 랭킹 조회")
     @GetMapping("/follow")
-    public ApiResponse<List<BestFollowGymSimpleDto>> findGymRankingOrderFollowCount() {
-        return ApiResponse.onSuccess(bestFollowGymService.findGymRankingOrderFollowCount());
+    public ResponseEntity<List<BestFollowGymSimpleDto>> findGymRankingOrderFollowCount() {
+        return ResponseEntity.ok(bestFollowGymService.findGymRankingOrderFollowCount());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/BestRecordGymController.java
@@ -1,13 +1,11 @@
 package com.climeet.climeet_backend.domain.bestrecordgym;
 
-import com.climeet.climeet_backend.domain.bestfollowgym.BestFollowGymService;
-import com.climeet.climeet_backend.domain.bestfollowgym.dto.BestFollowGymResponseDto.BestFollowGymSimpleDto;
 import com.climeet.climeet_backend.domain.bestrecordgym.dto.BestRecordGymResponseDto.BestRecordGymSimpleDto;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,8 +22,8 @@ public class BestRecordGymController {
      */
     @Operation(summary = "[기록된 순(selected된 순)] 이번주 짐 랭킹 조회")
     @GetMapping("/record")
-    public ApiResponse<List<BestRecordGymSimpleDto>> findGymRankingOrderSelectionCount() {
-        return ApiResponse.onSuccess(bestRecordGymService.findGymRankingOrderSelectionCount());
+    public ResponseEntity<List<BestRecordGymSimpleDto>> findGymRankingOrderSelectionCount() {
+        return ResponseEntity.ok(bestRecordGymService.findGymRankingOrderSelectionCount());
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRouteController.java
@@ -1,11 +1,10 @@
 package com.climeet.climeet_backend.domain.bestroute;
 
 import com.climeet.climeet_backend.domain.bestroute.dto.BestRouteResponseDto.BestRouteSimpleDto;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +18,7 @@ public class BestRouteController {
     private final BestRouteService bestRouteService;
 
     @GetMapping
-    public ApiResponse<List<BestRouteSimpleDto>> findRouteRankingOrderSelectionCount() {
-        return ApiResponse.onSuccess(bestRouteService.findBestRouteList());
+    public ResponseEntity<List<BestRouteSimpleDto>> findRouteRankingOrderSelectionCount() {
+        return ResponseEntity.ok(bestRouteService.findBestRouteList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
@@ -2,17 +2,11 @@ package com.climeet.climeet_backend.domain.climber;
 
 import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.CreateClimberRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto;
-import com.climeet.climeet_backend.domain.climber.enums.SocialType;
-import com.climeet.climeet_backend.global.response.ApiResponse;
-import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
-import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -34,14 +28,14 @@ public class ClimberController {
      */
     @PostMapping("/login")
     @Operation(summary = "OAuth 2.0 소셜 로그인", description = "**Enum 설명**\n\n**ClimbingLevel** : BEGINNER, NOVICE, INTERMEDIATE, ADVANCED, EXPERT\n\n**DiscoveryChannel** : INSTAGRAM_FACEBOOK, YOUTUBE, FRIEND_RECOMMENDATION, BLOG_CAFE_COMMUNITY, OTHER\n\n**SocialType(provider에 입력)**: KAKAO, NAVER \n\n **로그인 시 climberRequestDto 빈 값으로 보내기, 회원가입 시에만 채워서 보내기!**")
-    public ApiResponse<ClimberResponseDto> login(@RequestParam String provider, @RequestHeader("Authorization") String accessToken, @RequestBody(required = false)
+    public ResponseEntity<ClimberResponseDto> login(@RequestParam String provider, @RequestHeader("Authorization") String accessToken, @RequestBody(required = false)
     CreateClimberRequest climberRequestDto){
         if (accessToken != null && accessToken.startsWith("Bearer ")) {
             accessToken = accessToken.substring("Bearer ".length());
         }
         ClimberResponseDto climberResponseDto = climberService.handleSocialLogin(provider, accessToken, climberRequestDto);
 
-        return ApiResponse.onSuccess(climberResponseDto);
+        return ResponseEntity.ok(climberResponseDto);
 
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -3,13 +3,13 @@ package com.climeet.climeet_backend.domain.climbingrecord;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.UpdateClimbingRecordDto;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.CreateClimbingRecordDto;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,48 +31,48 @@ public class ClimbingRecordController {
 
     @Operation(summary = "클라이밍 기록 생성")
     @PostMapping
-    public ApiResponse<String> addClimbingRecord(@RequestBody CreateClimbingRecordDto requestDto) {
+    public ResponseEntity<String> addClimbingRecord(@RequestBody CreateClimbingRecordDto requestDto) {
         climbingRecordService.createClimbingRecord(requestDto);
-        return ApiResponse.onSuccess("클라이밍 기록을 생성하였습니다.");
+        return ResponseEntity.ok("클라이밍 기록을 생성하였습니다.");
     }
 
     @Operation(summary = "클라이밍 간편 기록 전체 조회")
     @GetMapping
-    public ApiResponse<List<ClimbingRecordSimpleInfo>> getClimbingRecords() {
-        return ApiResponse.onSuccess(climbingRecordService.getClimbingRecords());
+    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecords() {
+        return ResponseEntity.ok(climbingRecordService.getClimbingRecords());
     }
 
 
     @Operation(summary = "클라이밍 기록 날짜 조회")
     @GetMapping("/between-dates")
-    public ApiResponse<List<ClimbingRecordSimpleInfo>> getClimbingRecordsBetweenDates(
+    public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordsBetweenDates(
         @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
         @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
         List<ClimbingRecordSimpleInfo> climbingRecords = climbingRecordService.getClimbingRecordsBetweenLocalDates(
             startDate, endDate);
-        return ApiResponse.onSuccess(climbingRecords);
+        return ResponseEntity.ok(climbingRecords);
     }
 
     @Operation(summary = "클라이밍 기록 id 조회")
     @GetMapping("/{id}")
-    public ApiResponse<ClimbingRecordSimpleInfo> addClimbingRecord(@PathVariable Long id) {
-        return ApiResponse.onSuccess(climbingRecordService.getClimbingRecord(id));
+    public ResponseEntity<ClimbingRecordSimpleInfo> addClimbingRecord(@PathVariable Long id) {
+        return ResponseEntity.ok(climbingRecordService.getClimbingRecord(id));
     }
 
 
     @Operation(summary = "ClimbingRecord 수정")
     @PatchMapping("/{id}")
-    public ApiResponse<ClimbingRecordSimpleInfo> updateClimbingRecord(
+    public ResponseEntity<ClimbingRecordSimpleInfo> updateClimbingRecord(
         @PathVariable Long id,
         @RequestBody UpdateClimbingRecordDto updateClimbingRecordDto) {
-        return ApiResponse.onSuccess(
+        return ResponseEntity.ok(
             climbingRecordService.updateClimbingRecord(id, updateClimbingRecordDto));
     }
 
     @Operation(summary = "ClimbingRecord 삭제")
     @DeleteMapping("/{id}")
-    public ApiResponse<String> deleteClimbingRecord(@PathVariable Long id) {
+    public ResponseEntity<String> deleteClimbingRecord(@PathVariable Long id) {
         climbingRecordService.deleteClimbingRecord(id);
-        return ApiResponse.onSuccess("클라이밍 기록을 삭제하였습니다.");
+        return ResponseEntity.ok("클라이밍 기록을 삭제하였습니다.");
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -1,6 +1,5 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
-import com.climeet.climeet_backend.domain.bestrecordgym.BestRecordGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.UpdateClimbingRecordDto;
@@ -8,7 +7,6 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordReque
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecordService;
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto.CreateRouteRecordDto;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
@@ -17,6 +15,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -29,7 +28,7 @@ public class ClimbingRecordService {
 
 
     @Transactional
-    public ApiResponse<String> createClimbingRecord(CreateClimbingRecordDto requestDto) {
+    public ResponseEntity<String> createClimbingRecord(CreateClimbingRecordDto requestDto) {
         ClimbingGym climbingGym = gymRepository.findById(requestDto.getGymId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
@@ -45,7 +44,7 @@ public class ClimbingRecordService {
         routeRecords.forEach(
             routeRecord -> routeRecordService.addRouteRecord(routeRecord, savedClimbingRecord));
 
-        return ApiResponse.onSuccess("클라이밍 기록생성 성공");
+        return ResponseEntity.ok("클라이밍 기록생성 성공");
     }
 
     public List<ClimbingRecordSimpleInfo> getClimbingRecords() {
@@ -109,7 +108,7 @@ public class ClimbingRecordService {
     }
 
     @Transactional
-    public ApiResponse<String> deleteClimbingRecord(Long id) {
+    public ResponseEntity<String> deleteClimbingRecord(Long id) {
         ClimbingRecord climbingRecord = climbingRecordRepository.findById(id)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD));
 
@@ -117,6 +116,6 @@ public class ClimbingRecordService {
 
         climbingRecord.getGym().thisWeekSelectionCountDown();
 
-        return ApiResponse.onSuccess("클라이밍기록이 삭제되었습니다.");
+        return ResponseEntity.ok("클라이밍기록이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -1,11 +1,9 @@
 package com.climeet.climeet_backend.domain.manager;
 
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateManagerRequest;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,10 +26,10 @@ public class ManagerController {
      */
     @PostMapping("/signup")
     @Operation(summary = "관리자 회원가입", description = "관리자 회원가입 API")
-    public ApiResponse<String> signUp(@RequestBody
+    public ResponseEntity<String> signUp(@RequestBody
         CreateManagerRequest createManagerRequest){
         managerService.signUp(createManagerRequest);
-       return ApiResponse.onSuccess("관리자 회원가입이 성공적으로 완료되었습니다. ");
+       return ResponseEntity.ok("관리자 회원가입이 성공적으로 완료되었습니다. ");
     }
 
 
@@ -40,9 +38,9 @@ public class ManagerController {
      */
     @Operation(summary = "암장 등록 중복 확인", description = "이미 관리자가 등록된 암장인지 확인하는 API \n\n **이미 관리자 등록 되어있음** : false \n\n **관리자 등록 안되어 있음** : true")
     @GetMapping("/isRegistered/{gymName}")
-    public ApiResponse<Boolean> isRegistered(@PathVariable String gymName){
+    public ResponseEntity<Boolean> isRegistered(@PathVariable String gymName){
         boolean isRegistered = !managerService.checkManagerRegistration(gymName);
-        return ApiResponse.onSuccess(isRegistered);
+        return ResponseEntity.ok(isRegistered);
     }
 
 
@@ -51,9 +49,9 @@ public class ManagerController {
      */
     @GetMapping("/check-id/{loginId}")
     @Operation(summary = "관리자 ID 중복 확인", description = "**이미 존재하는 ID** : false \n\n **사용 가능한 ID** : true")
-    public ApiResponse<Boolean> checkLoginId(@PathVariable String loginId){
+    public ResponseEntity<Boolean> checkLoginId(@PathVariable String loginId){
         boolean isDuplicated = !managerService.checkLoginDuplication(loginId);
-        return ApiResponse.onSuccess(isDuplicated);
+        return ResponseEntity.ok(isDuplicated);
 
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -2,11 +2,11 @@ package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,23 +26,23 @@ public class RouteController {
 
     @Operation(summary = "클라이밍 루트 생성")
     @PostMapping("/route")
-    public ApiResponse<String> createRoute(
+    public ResponseEntity<String> createRoute(
         @RequestPart(value = "image") MultipartFile routeImage,
         @RequestPart CreateRouteRequest createRouteRequest
     ) {
         routeService.createRoute(createRouteRequest, routeImage);
-        return ApiResponse.onSuccess("루트를 추가했습니다.");
+        return ResponseEntity.ok("루트를 추가했습니다.");
     }
 
     @Operation(summary = "클라이밍 루트 조회")
     @GetMapping("/route/{routeId}")
-    public ApiResponse<RouteSimpleResponse> getRoute(@PathVariable Long routeId) {
-        return ApiResponse.onSuccess(routeService.getRoute(routeId));
+    public ResponseEntity<RouteSimpleResponse> getRoute(@PathVariable Long routeId) {
+        return ResponseEntity.ok(routeService.getRoute(routeId));
     }
 
     @Operation(summary = "클라이밍 암장 루트 목록 조회")
     @GetMapping("/{gymId}/routes")
-    public ApiResponse<List<RouteSimpleResponse>> getRouteList(@PathVariable Long gymId) {
-        return ApiResponse.onSuccess(routeService.getRouteList(gymId));
+    public ResponseEntity<List<RouteSimpleResponse>> getRouteList(@PathVariable Long gymId) {
+        return ResponseEntity.ok(routeService.getRouteList(gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordController.java
@@ -3,11 +3,11 @@ package com.climeet.climeet_backend.domain.routerecord;
 
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto.UpdateRouteRecordDto;
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto.RouteRecordSimpleInfo;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -29,28 +29,28 @@ public class RouteRecordController {
 
     @Operation(summary = "루트 기록 전체 조회")
     @GetMapping
-    public ApiResponse<List<RouteRecordSimpleInfo>> getRouteRecords() {
-        return ApiResponse.onSuccess(routeRecordService.getRouteRecords());
+    public ResponseEntity<List<RouteRecordSimpleInfo>> getRouteRecords() {
+        return ResponseEntity.ok(routeRecordService.getRouteRecords());
     }
 
     @Operation(summary = "루트 기록 Id 조회")
     @GetMapping("/{id}")
-    public ApiResponse<RouteRecordSimpleInfo> getRouteRecord(@PathVariable Long id) {
-        return ApiResponse.onSuccess(routeRecordService.getRouteRecord(id));
+    public ResponseEntity<RouteRecordSimpleInfo> getRouteRecord(@PathVariable Long id) {
+        return ResponseEntity.ok(routeRecordService.getRouteRecord(id));
     }
 
     @Operation(summary = "RouteRecord 수정")
     @PatchMapping("/{id}")
-    public ApiResponse<RouteRecordSimpleInfo> updateRouteRecord(
+    public ResponseEntity<RouteRecordSimpleInfo> updateRouteRecord(
         @PathVariable Long id,
         @RequestBody UpdateRouteRecordDto updateRouteRecordDto) {
-        return ApiResponse.onSuccess(routeRecordService.updateRouteRecord(id, updateRouteRecordDto));
+        return ResponseEntity.ok(routeRecordService.updateRouteRecord(id, updateRouteRecordDto));
     }
 
     @Operation(summary = "RouteRecord 삭제")
     @DeleteMapping("/{id}")
-    public ApiResponse<String> deleteRouteRecord(@PathVariable Long id){
+    public ResponseEntity<String> deleteRouteRecord(@PathVariable Long id){
         routeRecordService.deleteRouteRecord(id);
-        return ApiResponse.onSuccess("루트기록이 삭제되었습니다.");
+        return ResponseEntity.ok("루트기록이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -7,12 +7,12 @@ import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto.
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordRequestDto.CreateRouteRecordDto;
 
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto.RouteRecordSimpleInfo;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,7 +25,7 @@ public class RouteRecordService {
     private final RouteRepository routeRepository;
 
     @Transactional
-    public ApiResponse<String> addRouteRecord(CreateRouteRecordDto requestDto,
+    public ResponseEntity<String> addRouteRecord(CreateRouteRecordDto requestDto,
         ClimbingRecord climbingRecord) {
 
         Route route = routeRepository.findById(requestDto.getRouteId())
@@ -42,7 +42,7 @@ public class RouteRecordService {
         if (requestDto.getIsCompleted()) {
             climbingRecord.totalCompletedCountUp();
         }
-        return ApiResponse.onSuccess("루트 기록 성공");
+        return ResponseEntity.ok("루트 기록 성공");
 
     }
 
@@ -114,7 +114,7 @@ public class RouteRecordService {
     }
 
     @Transactional
-    public ApiResponse<String> deleteRouteRecord(Long id) {
+    public ResponseEntity<String> deleteRouteRecord(Long id) {
         RouteRecord routeRecord = routeRecordRepository.findById(id)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE_RECORD));
         ClimbingRecord climbingRecord = routeRecord.getClimbingRecord();
@@ -135,7 +135,7 @@ public class RouteRecordService {
         routeRecord.getRoute().thisWeekSelectionCountDown();
 
         routeRecordRepository.delete(routeRecord);
-        return ApiResponse.onSuccess("루트기록이 삭제되었습니다.");
+        return ResponseEntity.ok("루트기록이 삭제되었습니다.");
     }
 
     private int newAvgDifficulty(int routeDifficulty, int oldAvgDifficulty, int oldCount,

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -2,11 +2,11 @@ package com.climeet.climeet_backend.domain.sector;
 
 import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,18 +24,18 @@ public class SectorController {
 
     @Operation(summary = "클라이밍 섹터 생성")
     @PostMapping("/sector")
-    public ApiResponse<String> createSector(
+    public ResponseEntity<String> createSector(
         @RequestBody CreateSectorRequest createSectorRequest) {
         sectorService.createSector(createSectorRequest);
-        return ApiResponse.onSuccess("새로운 Sector를 추가했습니다.");
+        return ResponseEntity.ok("새로운 Sector를 추가했습니다.");
     }
 
     @Operation(summary = "특정 암장 전체 섹터 조회")
     @GetMapping("/{gymId}/sector")
-    public ApiResponse<List<SectorDetailResponse>> getSectorList(
+    public ResponseEntity<List<SectorDetailResponse>> getSectorList(
         @PathVariable Long gymId
     ) {
         List<SectorDetailResponse> sectorList = sectorService.getSectorList(gymId);
-        return ApiResponse.onSuccess(sectorList);
+        return ResponseEntity.ok(sectorList);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -3,11 +3,11 @@ package com.climeet.climeet_backend.domain.shorts;
 import com.climeet.climeet_backend.domain.shorts.dto.ShortsRequestDto.CreateShortsRequest;
 import com.climeet.climeet_backend.domain.shorts.dto.ShortsResponseDto.ShortsSimpleInfo;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,23 +24,23 @@ public class ShortsController {
 
     @PostMapping("/shorts")
     @Operation(summary = "숏츠 업로드")
-    public ApiResponse<String> uploadShorts(@RequestPart(value = "video") MultipartFile video,
+    public ResponseEntity<String> uploadShorts(@RequestPart(value = "video") MultipartFile video,
         @RequestPart MultipartFile thumbnailImage, @RequestPart CreateShortsRequest createShortsRequest) {
         shortsService.uploadShorts(video, thumbnailImage, createShortsRequest);
-        return ApiResponse.onSuccess("업로드 성공");
+        return ResponseEntity.ok("업로드 성공");
     }
 
     @GetMapping("/shorts/latest")
     @Operation(summary = "숏츠 최신순 조회")
-    public ApiResponse<PageResponseDto<List<ShortsSimpleInfo>>> findLatestShorts(@RequestParam int page,
+    public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findLatestShorts(@RequestParam int page,
         @RequestParam int size) {
-        return ApiResponse.onSuccess(shortsService.findShortsLatest(page, size));
+        return ResponseEntity.ok(shortsService.findShortsLatest(page, size));
     }
 
     @GetMapping("/shorts/popular")
     @Operation(summary = "숏츠 인기순 조회")
-    public ApiResponse<PageResponseDto<List<ShortsSimpleInfo>>> findPopularShorts(@RequestParam int page,
+    public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findPopularShorts(@RequestParam int page,
         @RequestParam int size) {
-        return ApiResponse.onSuccess(shortsService.findShortsPopular(page, size));
+        return ResponseEntity.ok(shortsService.findShortsPopular(page, size));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -1,10 +1,10 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
 import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,12 +24,12 @@ public class ShortsCommentController {
      */
     @Operation(summary = "숏츠 댓글 작성")
     @PostMapping("/shorts/{shortsId}/shortsComments")
-    public ApiResponse<String> createShortsComment(
+    public ResponseEntity<String> createShortsComment(
         @PathVariable Long shortsId,
         @RequestBody CreateShortsCommentRequest createShortsCommentRequest,
         @RequestParam(required = false) Long parentCommentId) {
         shortsCommentService.createShortsComment(shortsId, createShortsCommentRequest,
             parentCommentId, parentCommentId != null);
-        return ApiResponse.onSuccess("댓글 작성에 성공했습니다.");
+        return ResponseEntity.ok("댓글 작성에 성공했습니다.");
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/global/s3/S3Controller.java
+++ b/src/main/java/com/climeet/climeet_backend/global/s3/S3Controller.java
@@ -1,10 +1,10 @@
 package com.climeet.climeet_backend.global.s3;
 
-import com.climeet.climeet_backend.global.response.ApiResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.s3.dto.S3Result;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,10 +17,10 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @PostMapping("/file")
-    public ApiResponse<S3Result> uploadFile(@RequestPart(value = "file") MultipartFile file) {
+    public ResponseEntity<S3Result> uploadFile(@RequestPart(value = "file") MultipartFile file) {
         try {
             S3Result result = s3Service.uploadFile(file);
-            return ApiResponse.onSuccess(result);
+            return ResponseEntity.ok(result);
         }
         catch (Exception e) {
             throw new GeneralException(ErrorStatus._FILE_UPLOAD_ERROR);

--- a/src/main/java/com/climeet/climeet_backend/global/security/CurrentUser.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.climeet.climeet_backend.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/climeet/climeet_backend/global/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/CurrentUserArgumentResolver.java
@@ -1,0 +1,69 @@
+package com.climeet.climeet_backend.global.security;
+
+import com.climeet.climeet_backend.domain.climber.ClimberRepository;
+import com.climeet.climeet_backend.domain.climber.JwtTokenProvider;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.domain.user.UserRepository;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final UserRepository userRepository;
+
+    public CurrentUserArgumentResolver(JwtTokenProvider jwtTokenProvider,
+        UserRepository userRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(CurrentUser.class) != null
+            && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            System.out.println(headerName + ": " + request.getHeader(headerName)); // 로깅
+        }
+
+        String authorizationHeader = webRequest.getHeader("authorization");
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7); // "Bearer " 이후 문자열
+            return loadUserFromToken(token);
+        }
+        throw new GeneralException(ErrorStatus._FILE_UPLOAD_ERROR);
+    }
+
+    public User loadUserFromToken(String token) {
+        try {
+            Claims claims = Jwts.parser().setSigningKey(jwtTokenProvider.getSecretKey())
+                .parseClaimsJws(token).getBody();
+
+            String userId = claims.getSubject();
+
+            return userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_JWT));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            throw new GeneralException(ErrorStatus._INVALID_JWT);
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/global/security/WebConfig.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/WebConfig.java
@@ -1,0 +1,26 @@
+package com.climeet.climeet_backend.global.security;
+
+import com.climeet.climeet_backend.domain.climber.ClimberService;
+import com.climeet.climeet_backend.domain.climber.JwtTokenProvider;
+import com.climeet.climeet_backend.domain.user.UserRepository;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public WebConfig(UserRepository userRepository, JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new CurrentUserArgumentResolver(jwtTokenProvider, userRepository));
+    }
+}


### PR DESCRIPTION

## 상세 내용

까먹어서 죄송합니다 ㅎ
스프링 시큐리티에 대한 이해가 적고, 어떻게 빨리 하려다보니 블로그에서 많이 찾아본 일반 방법과 약간 다르게 구현했습니다.
양해 부탁드려욥ㅎㅎㅎㅎㅎㅎ

보기 편하도록 코드와 같이 설명하겠습니다.

크게 3가지 파일을 만들었습니다

1. CurrentUser
2. CurrentUserArgumentResolver
3. WebConfig


### CurrentUser

```java
@Target({ElementType.METHOD, ElementType.PARAMETER})
@Retention(RetentionPolicy.RUNTIME)
@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
public @interface CurrentUser {
}
```

- **Target** : 어노테이션이 메소드 또는 파라미터에 적용되게 함(파라미터만 사용하면 될 듯)
- **Retention** : 어노테이션 정보가 런타임에 유지
- **AuthenticationPrincipal** : 스프링 시큐리티에서 현재 인증된 사용자를 참조하는 데 사용
- **expression** : 현재 사용자가 익명일 경우 null을 반환 그렇지 않으면 user반환
    - 이 경우 이전 웹 프로젝트에서는 비회원도 조회가 가능하였기에 null을 통한 권한 처리를 했는데, 이번에는 무조건 로그인을 해야하기에 null 이전에 jwt파싱단에서 예외를 잡습니다.
    - 사용 이유? : @AuthenticationPrincipal의 expression속성을 사용하지 않으면 기본적으로 Authentication Principal에 바인딩되기 때문에 스웨거가 분석할 때 User를 넣도록 뜹니다. 만약 expression속성을 사용하면 스웨거가 볼 때 파라미터를 통해 User를 넣는 것이 아닌 스프링 시큐리티의 인증 과정을 통해 받는 것으로 해석해 뜨지 않게됩니다!
    - 스웨거 설정하기 위해 넣었으므로 저희 코드에서는 사실상 의미가 없습니다!

---

### CurrentUserArgumentResolver

```java
public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {

    private final JwtTokenProvider jwtTokenProvider;

    private final UserRepository userRepository;

    public CurrentUserArgumentResolver(JwtTokenProvider jwtTokenProvider,
        UserRepository userRepository) {
        this.jwtTokenProvider = jwtTokenProvider;
        this.userRepository = userRepository;
    }

    @Override
    public boolean supportsParameter(MethodParameter parameter) {
        return parameter.getParameterAnnotation(CurrentUser.class) != null
            && parameter.getParameterType().equals(User.class);
    }

    @Override
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {

        String authorizationHeader = webRequest.getHeader("authorization");
        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
            String token = authorizationHeader.substring(7); // "Bearer " 이후 문자열
            return loadUserFromToken(token);
        }
        throw new GeneralException(ErrorStatus._FILE_UPLOAD_ERROR);
    }

    public User loadUserFromToken(String token) {
        try {
            Claims claims = Jwts.parser().setSigningKey(jwtTokenProvider.getSecretKey())
                .parseClaimsJws(token).getBody();

            String userId = claims.getSubject();

            return userRepository.findById(Long.valueOf(userId))
                .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_JWT));
        } catch (Exception ex) {
            throw new GeneralException(ErrorStatus._INVALID_JWT);
        }
    }
```

- **HandlerMehtodArgumentResolver** 인터페이스를 구현해 컨트롤러의 메소드를 파악하는데 사용합니다.
- 인터페이스를 implements했기 때문에 아래 두 함수 supportsParameter와 resolveArgument는 무조건 오버라이드로 구현해야합니다.
    - supportsParameter : 현재 파라미터가 CurrentUser를 사용하고 User(클밋) 객체인지 확인합니다.
    - resolveArgument : 실제 HTTP 요청에서 JWT토큰을 추출하고, 토큰을 사용해 사용자를 불러옵니다!
        - null인지 Bearer로 시작하는지 검증 후 에러를 던집니다(급하게 해서 FILE_UPLOAD_ERROR로 가는데 수정하겠습니다 ㅎ)
        - 토큰 검증 단은 원래 필터에서 처리해야하는걸로 알고 있습니다. 리팩토링시 더 알아본 후 가능하면 수정하겠습니다
- loadUserFromToken : 토큰으로부터 User를 찾는 함수입니다. 
    - parser에 미리가 만든 함수를 이용해 파서에 비밀키를 부여후 파싱해서 페이로드부븐을 빼낸 후 Claim객체로 반환합니다. claim객체는 페이로드에 있는 데이터를 키 - 값으로 접근할 수 있게 해줍니다(UserId  : 1)
    - 또한 토큰의 만료 또한 파싱과정에서 같이 검증합니다
 
 ---

### WebConfig

```java
 private final UserRepository userRepository;
    private final JwtTokenProvider jwtTokenProvider;

    public WebConfig(UserRepository userRepository, JwtTokenProvider jwtTokenProvider) {
        this.userRepository = userRepository;
        this.jwtTokenProvider = jwtTokenProvider;
    }

    @Override
    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
        argumentResolvers.add(new CurrentUserArgumentResolver(jwtTokenProvider, userRepository));
    }
}
```
- `WebMvcConfigurer`를 구현해 커스텀합니다. `addArgumentResolvers`를 통해 위에서 작성한 `CurrentUserArgumentResolver`를 스프링 MVC의 argumentResolver에추가합니다. 이를 통해 `@CurrentUser`가 사용될 때 해당 Resolver가 작동되도록 설정합니다.
    - 스프링에서 파라미터마다 리스트를 돌며 특정 어노테이션인지 확인합니다. 이걸 아까 리졸버 내부의 `supportsParameter를 통해 user객체인지와 currentUser어노테이션인지 확인합니다!!

---

#### 이해가 잘 될 수 있도록 흐름을 정리해봤습니다.
1. WebConfig를 통한 시큐리티 설정- CurrentUserArgument리졸버를 argumentResolvers리스트에 추가
2. JWT토큰을 'Authorization' 헤더에 담아 http 요청 
3. 컨트롤러에서 라우팅시 @CurrentUser 처리
4. argumentResolvers에서 supportParameter를 통해 CurrentUserArgument인지 확인하며 순회
5. CurrentUserArgumentResolver실행 
5 - 1. Jwt토큰 파싱 후 User 객체 반환
5 - 2. 토큰값이 null이거나 Beaer시작안하거나, 유효값이 만료될 경우 에러 반환

---
#### 추후 변경해야할 사항
- jwt 토큰 에러 코드 수정
- loadFromUser에서 유효기간 만료 에러 내려주기
- 토큰 검증성 시큐리티 필터로 앞단에서 처리하기