### PR TITLE
[SPR-63] 클라이머 회원가입 시 암장 팔로우 로직 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -58,24 +58,6 @@ public class Climber extends User {
     private boolean status = true;
 
 
-    @Builder
-    public Climber(String socialId, String accessToken, String refreshToken, String nickName, String profileImageUrl, ClimbingLevel climbingLevel, SocialType socialType, DiscoveryChannel discoveryChannel){
-        this.socialId = socialId;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-        this.nickName = nickName;
-        this.profileImageUrl = profileImageUrl;
-        this.climbingLevel = climbingLevel;
-        this.socialType = socialType;
-        this.discoveryChannel = discoveryChannel;
-    }
-
-    public void update(String nickname, ClimbingLevel climbingLevel, DiscoveryChannel discoveryChannel){
-        this.nickName = nickname;
-        this.climbingLevel = climbingLevel;
-        this.discoveryChannel = discoveryChannel;
-    }
-
     public void updateToken(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
@@ -91,10 +73,6 @@ public class Climber extends User {
 
     public void updateDiscoveryChannel(DiscoveryChannel discoveryChannel) {
         this.discoveryChannel = discoveryChannel;
-    }
-
-    public void updateSocialType(SocialType socialType) {
-        this.socialType = socialType;
     }
 
     public void updateProfileImageUrl(String profileImgUrl) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -67,7 +67,7 @@ public class ClimberService {
         }
         String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(climber.getSocialId()));
         String refreshToken = jwtTokenProvider.createRefreshToken();
-        climber.setToken(accessToken, refreshToken);
+        climber.updateToken(accessToken, refreshToken);
         climber.setNickName(climberRequestDto.getNickName());
         climber.setClimbingLevel(climberRequestDto.getClimbingLevel());
         climber.setDiscoveryChannel(climberRequestDto.getDiscoveryChannel());

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -123,7 +123,7 @@ public class ClimberService {
         } else if (providerName.equals("NAVER")) {
             Map<String, Object> userAttributesByToken = getClimberNaverAttributesByToken(userToken);
             NaverUserInfo naverUserInfo = new NaverUserInfo(userAttributesByToken);
-            social_id = naverUserInfo.getID();
+            social_id = naverUserInfo.getId();
             profile_img = naverUserInfo.getProfileImg();
         }
         //로그인 case

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -111,15 +111,12 @@ public class ClimberService {
         //가입 시 암장 팔로우
         List<String> gymFollowList = climberRequestDto.getGymFollowList();
         for(String gymName : gymFollowList){
-            Optional<ClimbingGym> optionalGym = climbingGymRepository.findByName(gymName);
-            if(optionalGym.isEmpty()){
-                throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM);
-            }
-            Optional<Manager> optionalManager = managerRepository.findByClimbingGym(optionalGym.get());
-            if(optionalManager.isEmpty()){
-                throw new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM);
-            }
-            followRelationshipService.createFollowRelationship(optionalManager.get(), climber);
+            ClimbingGym optionalGym = climbingGymRepository.findByName(gymName)
+                .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+            Manager manager = managerRepository.findByClimbingGym(optionalGym)
+                .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM));
+            followRelationshipService.createFollowRelationship(manager, climber);
 
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -4,6 +4,8 @@ package com.climeet.climeet_backend.domain.climber;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.CreateClimberRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto;
 import com.climeet.climeet_backend.domain.climber.enums.SocialType;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipService;
 import com.climeet.climeet_backend.domain.manager.Manager;
@@ -31,6 +33,7 @@ import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 public class ClimberService {
 
     private final ClimberRepository climberRepository;
+    private final ClimbingGymRepository climbingGymRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ManagerRepository managerRepository;
     private final FollowRelationshipService followRelationshipService;
@@ -106,21 +109,19 @@ public class ClimberService {
 
 
         //가입 시 암장 팔로우
-//        List<String> gymFollowList = climberRequestDto.getGymFollowList();
-//        for(String gymName : gymFollowList){
-//            Optional<Manager> optionalManager = managerRepository.findByName(gymName);
-//            System.out.println("Found manager: " + optionalManager.isPresent());
-//            if(optionalManager.isEmpty()){
-//                throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM);
-//            }
-//
-//            //Optional<Manager> optionalManager = managerRepository.findByName(gymName);
-////            if(optionalManager.isEmpty()){
-////                throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM);
-////            }
-//            followRelationshipService.createFollowRelationship(optionalManager.get(), climber);
-//
-//        }
+        List<String> gymFollowList = climberRequestDto.getGymFollowList();
+        for(String gymName : gymFollowList){
+            Optional<ClimbingGym> optionalGym = climbingGymRepository.findByName(gymName);
+            if(optionalGym.isEmpty()){
+                throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM);
+            }
+            Optional<Manager> optionalManager = managerRepository.findByClimbingGym(optionalGym.get());
+            if(optionalManager.isEmpty()){
+                throw new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM);
+            }
+            followRelationshipService.createFollowRelationship(optionalManager.get(), climber);
+
+        }
 
         Climber savedClimber = climberRepository.save(climber);
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -28,8 +28,7 @@ public class ClimbingGym extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
-    @JoinColumn(name="manager_id")
+    @OneToOne(mappedBy = "climbingGym")
     private Manager manager;
 
     @OneToMany(mappedBy = "climbingGym")

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
@@ -5,6 +5,8 @@ import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymService;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateManagerRequest;
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
@@ -50,6 +52,23 @@ public class Manager extends User {
 
     public void setClimbingGym(ClimbingGym climbingGym){
         this.climbingGym = climbingGym;
+    }
+
+    public static Manager toEntity(CreateManagerRequest createManagerRequest, ClimbingGym gym){
+
+        return Manager.builder()
+            .loginId(createManagerRequest.getLoginId())
+            .password(createManagerRequest.getPassword())
+            .name(createManagerRequest.getName())
+            .phoneNumber(createManagerRequest.getPhoneNumber())
+            .email(createManagerRequest.getEmail())
+            .isRegistered(true)
+            .climbingGym(gym)
+            .build();
+    }
+
+    public void updateClimbingGym(ClimbingGym gym){
+        this.climbingGym = gym;
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
@@ -24,7 +24,8 @@ import lombok.Setter;
 @Builder
 public class Manager extends User {
 
-    @OneToOne(mappedBy = "manager")
+    @OneToOne
+    @JoinColumn(name="climbing_gym_id")
     private ClimbingGym climbingGym;
 
     @NotNull

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
@@ -11,6 +11,7 @@ public interface ManagerRepository extends JpaRepository<Manager, Long> {
 
     Optional<Manager> findByName(String gymName);
     Optional<Manager> findByLoginId(String loginId);
+    Optional<Manager> findByClimbingGym(ClimbingGym climbingGym);
 
     boolean existsByClimbingGym(ClimbingGym gym);
 

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //암장 관련
     _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),
+    _EMPTY_MANAGER_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 존재하지 않는 암장입니다"),
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),
@@ -54,6 +55,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //숏츠 관련
     _EMPTY_SHORTS(HttpStatus.CONFLICT, "SHORTS_001", "존재하지 않는 쇼츠입니다.")
+
+
 
     ;
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 요약

- 토론의 결과로 Manager와 ClimbingGym 사이의 연관관계를 Manager가 주인 엔티티가 되는 방향으로 관계를 수정하였습니다
- 이에 따라 클라이머 회원가입 시 팔로우 로직 구현을 완료하였습니다.

## 상세 내용

- 일대일 연관관계(Manager-ClimbingGym, 기존 주인 엔티티 ClimbingGym에서 Manager로 변경)
- 팔로우 로직 구현 완료

