### PR TITLE
[SPR-66] 암장 검색기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "ClimbingGym", description = "암장 관련 API")
@@ -22,24 +23,25 @@ public class ClimbingGymController {
 
     /**
      * [GET] 암장검색 (Manager가 등록이 되어있지 않은 암장도 조회)
+     * Manager 유무도 함께 반환
      */
     @Operation(summary = "전국 암장 검색 기능(자체 목록화)")
-    @GetMapping("/search/all/{word}")
+    @GetMapping("/search/all")
     public ResponseEntity<List<ClimbingGymSimpleResponse>> getClimbingGymSearchingList(
-        @PathVariable String word
+        @RequestParam("gymname") String gymName
     ) {
-        return ResponseEntity.ok(climbingGymService.searchClimbingGym(word));
+        return ResponseEntity.ok(climbingGymService.searchClimbingGym(gymName));
     }
 
     /**
      * [GET] 암장검색 (Manager가 등록되어있는 암장만 조회)
      */
     @Operation(summary = "Manager가 등록된 암장 검색 기능")
-    @GetMapping("/search/{word}")
+    @GetMapping("/search")
     public ResponseEntity<List<ClimbingGymSimpleResponse>> getAcceptedClimbingGymSearchingList(
-        @PathVariable String word
+        @RequestParam("gymname") String gymName
     ) {
-        return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(word));
+        return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -1,10 +1,45 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequiredArgsConstructor
+@Tag(name = "ClimbingGym", description = "암장 관련 API")
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/gym")
 public class ClimbingGymController {
+
+    private final ClimbingGymService climbingGymService;
+
+    /**
+     * [GET] 암장검색 (Manager가 등록이 되어있지 않은 암장도 조회)
+     */
+    @Operation(summary = "전국 암장 검색 기능(자체 목록화)")
+    @GetMapping("/search/all/{word}")
+    public ResponseEntity<List<ClimbingGymSimpleResponse>> getClimbingGymSearchingList(
+        @PathVariable String word
+    ) {
+        return ResponseEntity.ok(climbingGymService.searchClimbingGym(word));
+    }
+
+    /**
+     * [GET] 암장검색 (Manager가 등록되어있는 암장만 조회)
+     */
+    @Operation(summary = "Manager가 등록된 암장 검색 기능")
+    @GetMapping("/search/{word}")
+    public ResponseEntity<List<ClimbingGymSimpleResponse>> getAcceptedClimbingGymSearchingList(
+        @PathVariable String word
+    ) {
+        return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(word));
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -8,8 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> {
 
-    Optional<ClimbingGym> findById(Long gymId);
-
     Optional<ClimbingGym> findByName(String gymName);
 
     List<ClimbingGym> findByNameContaining(String word);

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,8 @@ public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> 
     Optional<ClimbingGym> findById(Long gymId);
 
     Optional<ClimbingGym> findByName(String gymName);
+
+    List<ClimbingGym> findByNameContaining(String word);
+
+    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String word);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -10,7 +10,7 @@ public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> 
 
     Optional<ClimbingGym> findByName(String gymName);
 
-    List<ClimbingGym> findByNameContaining(String word);
+    List<ClimbingGym> findByNameContaining(String gymName);
 
-    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String word);
+    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String gymName);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -1,5 +1,8 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,4 +10,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class ClimbingGymService {
 
+    private final ClimbingGymRepository climbingGymRepository;
+
+    public List<ClimbingGymSimpleResponse> searchClimbingGym(String word) {
+        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(word);
+
+        return climbingGymList.stream()
+            .map(ClimbingGymSimpleResponse::new)
+            .collect(Collectors.toList());
+
+    }
+
+    public List<ClimbingGymSimpleResponse> searchAcceptedClimbingGym(String word) {
+        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(word);
+
+        return climbingGymList.stream()
+            .map(ClimbingGymSimpleResponse::new)
+            .collect(Collectors.toList());
+
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -2,9 +2,12 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.shorts.dto.ShortsResponseDto.ShortsSimpleInfo;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -13,8 +16,8 @@ public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
 
-    public List<ClimbingGymSimpleResponse> searchClimbingGym(String word) {
-        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(word);
+    public List<ClimbingGymSimpleResponse> searchClimbingGym(String gymName) {
+        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(gymName);
 
         return climbingGymList.stream()
             .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))
@@ -22,9 +25,9 @@ public class ClimbingGymService {
 
     }
 
-    public List<ClimbingGymSimpleResponse> searchAcceptedClimbingGym(String word) {
+    public List<ClimbingGymSimpleResponse> searchAcceptedClimbingGym(String gymName) {
         List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(
-            word);
+            gymName);
 
         return climbingGymList.stream()
             .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.shorts.dto.ShortsResponseDto.ShortsSimpleInfo;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -16,17 +17,17 @@ public class ClimbingGymService {
         List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(word);
 
         return climbingGymList.stream()
-            .map(ClimbingGymSimpleResponse::new)
-            .collect(Collectors.toList());
+            .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))
+            .toList();
 
     }
 
     public List<ClimbingGymSimpleResponse> searchAcceptedClimbingGym(String word) {
-        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(word);
+        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(
+            word);
 
         return climbingGymList.stream()
-            .map(ClimbingGymSimpleResponse::new)
-            .collect(Collectors.toList());
-
+            .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))
+            .toList();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -1,0 +1,26 @@
+package com.climeet.climeet_backend.domain.climbinggym.dto;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.route.Route;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ClimbingGymResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClimbingGymSimpleResponse {
+
+        private Long id;
+        private String name;
+
+        public ClimbingGymSimpleResponse(ClimbingGym climbingGym) {
+            this.id = climbingGym.getId();
+            this.name = climbingGym.getName();
+        }
+    }
+
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -17,11 +17,17 @@ public class ClimbingGymResponseDto {
 
         private Long id;
         private String name;
+        private Long managerId;
 
         public static ClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym) {
+            Long managerId = null;
+            if(climbingGym.getManager() != null){
+                managerId = climbingGym.getManager().getId();
+            }
             return ClimbingGymSimpleResponse.builder()
                 .id(climbingGym.getId())
                 .name(climbingGym.getName())
+                .managerId(managerId)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -3,11 +3,13 @@ package com.climeet.climeet_backend.domain.climbinggym.dto;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.route.Route;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class ClimbingGymResponseDto {
 
+    @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -16,9 +18,11 @@ public class ClimbingGymResponseDto {
         private Long id;
         private String name;
 
-        public ClimbingGymSimpleResponse(ClimbingGym climbingGym) {
-            this.id = climbingGym.getId();
-            this.name = climbingGym.getName();
+        public static ClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym) {
+            return ClimbingGymSimpleResponse.builder()
+                .id(climbingGym.getId())
+                .name(climbingGym.getName())
+                .build();
         }
     }
 


### PR DESCRIPTION
## 요약
1. manager가 등록되어있는 암장 검색 기능
2. manager에 상관없이 등록되어있는 암장 검색 기능 
총 두가지 구현하였습니다. 
추가로 암장 데이터 약 350개는 구글 시트에서 DB로 옮겨서 기본 값만 입력해 구현했습니다.

## 상세 내용
- 단순한 목록 조회 기능입니다!
- 헤일이 종합해준 암장 데이터가 DB의 ClimbingGym 테이블에 이름은 모두 입력되어있을 때를 기준으로 잡았습니다.
- 현재 테이블에 이름은 모두 입력해놓았고, 나머지는 Manager와 연결이 될 때 설정이 될 것이라고 생각했습니다.

``` java
    /**
     * [GET] 암장검색 (Manager가 등록이 되어있지 않은 암장도 조회)
     */
    @Operation(summary = "전국 암장 검색 기능(자체 목록화)")
    @GetMapping("/search/all/{word}")
    public ResponseEntity<List<ClimbingGymSimpleResponse>> getClimbingGymSearchingList(
        @PathVariable String word
    ) {
        return ResponseEntity.ok(climbingGymService.searchClimbingGym(word));
    }
```

``` java
    /**
     * [GET] 암장검색 (Manager가 등록되어있는 암장만 조회)
     */
    @Operation(summary = "Manager가 등록된 암장 검색 기능")
    @GetMapping("/search/{word}")
    public ResponseEntity<List<ClimbingGymSimpleResponse>> getAcceptedClimbingGymSearchingList(
        @PathVariable String word
    ) {
        return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(word));
    }
```

- 두 API에서 차이가 있는 부분입니다. (ClimbingGymRepository)
``` java
    List<ClimbingGym> findByNameContaining(String word);

    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String word);
```

## 테스트 확인 내용

- 각 상황을 가정하여 테스트를 해보았고,  모두 정상 처리되는것을 확인했습니다.
<img width="1369" alt="스크린샷 2024-01-20 오후 2 04 01" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/2e7a3f8f-5429-4c5d-9377-71153cc54e32">
<img width="1366" alt="스크린샷 2024-01-20 오후 2 04 38" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/debafb75-4cf5-4ef7-a2a0-0714f0aea289">


## 질문 및 이외 사항

- 전국 암장을 검색할 때 '클라이밍'을 검색하면, 거의 100개가 넘는 값이 검색되곤 합니다. 해당 API는 대부분 매니저가 가입할 때 암장 선택 과정에서 사용될 것이라고 생각하기 때문에 모든 결과값을 주는게 아닌 id 순서로 20개정도만 반환하는게 어떨까요?
- 예외처리를 해야할 부분은 딱히 보이지 않아서 안했는데, 반환값이 없을 때 빈 리스트를 반환하는게 아닌, 에러를 반환하는게 나을까요??
- 테스트코드 작성법 열심히 공부중입니다...!
