### PR TITLE
[SPR-79] 리뷰 작성 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -28,8 +28,7 @@ public class ClimbingGym extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
-    @JoinColumn(name = "manager_id")
+    @OneToOne(mappedBy = "climbingGym")
     private Manager manager;
 
     @OneToMany(mappedBy = "climbingGym")

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -29,7 +29,7 @@ public class ClimbingGym extends BaseTimeEntity {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name="manager_id")
+    @JoinColumn(name = "manager_id")
     private Manager manager;
 
     @OneToMany(mappedBy = "climbingGym")
@@ -40,11 +40,28 @@ public class ClimbingGym extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    private Float AverageRating = 0.0F;
-
     private String layoutImageUrl;
 
+    private Float AverageRating = 0.0F;
+
+    private Float sumRating = 0.0F;
+
     private int reviewCount = 0;
+
+    public void reviewCreate(Float rating) {
+        this.sumRating += rating;
+        this.reviewCount++;
+        this.averageRatingCalculate();
+    }
+
+    public void averageRatingCalculate() {
+        if (this.reviewCount > 0) {
+            this.AverageRating = this.sumRating / this.reviewCount;
+        } else {
+            this.AverageRating = 0.0F;
+        }
+    }
+
 
     private int selectionCount = 0;
 
@@ -66,19 +83,19 @@ public class ClimbingGym extends BaseTimeEntity {
 
     private int thisWeekSelectionCount = 0;
 
-    public void thisWeekFollowCountUp(){
+    public void thisWeekFollowCountUp() {
         this.thisWeekFollowCount++;
     }
 
-    public void thisWeekFollowCountDown(){
+    public void thisWeekFollowCountDown() {
         this.thisWeekFollowCount--;
     }
 
-    public void thisWeekSelectionCountUp(){
+    public void thisWeekSelectionCountUp() {
         this.thisWeekSelectionCount++;
     }
 
-    public void thisWeekSelectionCountDown(){
+    public void thisWeekSelectionCountDown() {
         this.thisWeekSelectionCount--;
 
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/Review.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/Review.java
@@ -2,7 +2,12 @@ package com.climeet.climeet_backend.domain.review;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climber.Climber;
+import com.climeet.climeet_backend.domain.review.dto.ReviewRequestDto.CreateReviewRequest;
+import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -12,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +25,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class Review extends BaseTimeEntity {
 
     @Id
@@ -32,8 +39,19 @@ public class Review extends BaseTimeEntity {
     private Climber climber;
 
     @NotNull
+    @Column(length = 1000)
     private String content;
 
     @NotNull
     private Float rating;
+
+    public static Review toEntity(CreateReviewRequest requestDto, ClimbingGym climbingGym,
+        Climber climber) {
+        return Review.builder()
+            .climbingGym(climbingGym)
+            .climber(climber)
+            .content(requestDto.getContent())
+            .rating(requestDto.getRating())
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewController.java
@@ -1,5 +1,32 @@
 package com.climeet.climeet_backend.domain.review;
 
+import com.climeet.climeet_backend.domain.review.dto.ReviewRequestDto.CreateReviewRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(name = "ClimbingReview", description = "암장 리뷰 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/gym/review")
 public class ReviewController {
 
+    private final ReviewService reviewService;
+
+    /**
+     * [POST] 암장 리뷰 작성
+     */
+    @Operation(summary = "암장 리뷰 작성")
+    @PostMapping("/")
+    public ResponseEntity<String> createReview(
+        @RequestBody CreateReviewRequest createReviewRequest) {
+        reviewService.createReview(createReviewRequest);
+        return ResponseEntity.ok("리뷰를 추가했습니다.");
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewRepository.java
@@ -1,7 +1,10 @@
 package com.climeet.climeet_backend.domain.review;
 
+import com.climeet.climeet_backend.domain.climber.Climber;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-
+    Optional<Review> findByClimbingGymAndClimber(ClimbingGym climbingGym, Climber climber);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
@@ -44,7 +44,7 @@ public class ReviewService {
 
         // 관리자가 등록된 암장인지 확인
         if(climbingGym.getManager() == null){
-            throw new GeneralException(ErrorStatus._UNREGISTERED_GYM);
+            throw new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM);
         }
 
         Climber climber = climberRepository.findById(createReviewRequest.getClimberId())

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
@@ -1,10 +1,61 @@
 package com.climeet.climeet_backend.domain.review;
 
+import com.climeet.climeet_backend.domain.climber.Climber;
+import com.climeet.climeet_backend.domain.climber.ClimberRepository;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.review.dto.ReviewRequestDto.CreateReviewRequest;
+import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.sector.Sector;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final ClimbingGymRepository climbingGymRepository;
+    private final ClimberRepository climberRepository;
+
+    @Transactional
+    public void createReview(CreateReviewRequest createReviewRequest) {
+        // 리뷰 내용 길이 초과 확인
+        if (createReviewRequest.getContent().length() > 1000) {
+            throw new GeneralException(ErrorStatus._CONTENT_TOO_LARGE);
+        }
+
+        // 리뷰 rating의 범위 확인
+        if (createReviewRequest.getRating() < 0 || createReviewRequest.getRating() > 5
+            || createReviewRequest.getRating() % 0.5 != 0) {
+            throw new GeneralException(ErrorStatus._RATING_OUT_OF_RANGE);
+        }
+
+        Climber climber = climberRepository.findById(createReviewRequest.getClimberId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
+
+        ClimbingGym climbingGym = climbingGymRepository.findById(
+                createReviewRequest.getClimbingGymId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        // 이미 작성된 리뷰가 있는지 확인 (1명의 유저는 1개의 암장에 1개의 리뷰만 가능)
+        Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimber(
+            climbingGym, climber);
+        if (optionalReview.isPresent()) {
+            throw new GeneralException(ErrorStatus._REVIEW_EXIST);
+        }
+
+        // 리뷰 추가로 인한 평균 리뷰 갱신
+        climbingGym.reviewCreate(createReviewRequest.getRating());
+
+        reviewRepository.save(Review.toEntity(createReviewRequest, climbingGym, climber));
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
@@ -38,12 +38,17 @@ public class ReviewService {
             throw new GeneralException(ErrorStatus._RATING_OUT_OF_RANGE);
         }
 
-        Climber climber = climberRepository.findById(createReviewRequest.getClimberId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
-
         ClimbingGym climbingGym = climbingGymRepository.findById(
                 createReviewRequest.getClimbingGymId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        // 관리자가 등록된 암장인지 확인
+        if(climbingGym.getManager() == null){
+            throw new GeneralException(ErrorStatus._UNREGISTERED_GYM);
+        }
+
+        Climber climber = climberRepository.findById(createReviewRequest.getClimberId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
         // 이미 작성된 리뷰가 있는지 확인 (1명의 유저는 1개의 암장에 1개의 리뷰만 가능)
         Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimber(

--- a/src/main/java/com/climeet/climeet_backend/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,18 @@
+package com.climeet.climeet_backend.domain.review.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ReviewRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateReviewRequest {
+
+        private Long climbingGymId;
+        private Long climberId;
+        private String content;
+        private Float rating; // (0 <= rating <= 5) 의 실수(0.5 단위)
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -21,6 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //암장 관련
     _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),
+    _UNREGISTERED_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 등록되지 않은 암장입니다."),
+
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -53,7 +53,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_ROUTE_RECORD(HttpStatus.CONFLICT, "ROUTE_RECORD_001", "존재하지 않는 루트운동기록입니다."),
 
     //숏츠 관련
-    _EMPTY_SHORTS(HttpStatus.CONFLICT, "SHORTS_001", "존재하지 않는 쇼츠입니다.")
+    _EMPTY_SHORTS(HttpStatus.CONFLICT, "SHORTS_001", "존재하지 않는 쇼츠입니다."),
+
+    //암장 리뷰 관련
+    _CONTENT_TOO_LARGE(HttpStatus.CONFLICT, "REVIEW_001", "리뷰 최대 입력 길이를 초과했습니다."),
+    _RATING_OUT_OF_RANGE(HttpStatus.CONFLICT, "REVIEW_002", "rating의 범위가 올바르지 않습니다."),
+    _REVIEW_EXIST(HttpStatus.CONFLICT, "REVIEW_003", "유저가 이미 해당 암장에 대한 리뷰를 남겼습니다.")
 
     ;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -21,7 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //암장 관련
     _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),
-    _UNREGISTERED_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 등록되지 않은 암장입니다."),
+    _EMPTY_MANAGER_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 존재하지 않는 암장입니다"),
 
 
     //벽면 관련


### PR DESCRIPTION
## 요약
- 리뷰 작성 기능을 구현했습니다.
- 적용된 예외처리는 총 5가지입니다.
1. Figma에서 확인했을 때 리뷰의 최대 길이는 1000자로, DB에서 content 길이를 1000으로 수정했습니다. 또한 service단에서 길이 1000을 넘겼을 때 예외처리 하였습니다.
2. rating이 범위 내에 존재하는지 확인하고 그렇지 않다면 예외처리 하였습니다.
3. 암장이 존재하지 않을 때 예외처리 했습니다.
4. 유저가 존재하지 않을 때 예외처리 했습니다.
5. 해당 암장에 대해 해당 유저의 리뷰가 이미 있을 경우 예외처리 했습니다. (수정은 수정 메서드를 만들 예정입니다.)
- ClimbingGym 파일에서 rating을 원할하게 관리하기 위해 sumRating  컬럼을 추가했습니다. DB에도 반영했습니다. reviewCreate와, averageRatingCalculate 함수를 통해서 Rating 값을 관리할 계획입니다.

## 상세 내용
- 예외처리 부분입니다. (ReviewService)
``` java
    // 리뷰 내용 길이 초과 확인
        if (createReviewRequest.getContent().length() > 1000) {
            throw new GeneralException(ErrorStatus._CONTENT_TOO_LARGE);
        }

        // 리뷰 rating의 범위 확인
        if (createReviewRequest.getRating() < 0 || createReviewRequest.getRating() > 5
            || createReviewRequest.getRating() % 0.5 != 0) {
            throw new GeneralException(ErrorStatus._RATING_OUT_OF_RANGE);
        }

        Climber climber = climberRepository.findById(createReviewRequest.getClimberId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));

        ClimbingGym climbingGym = climbingGymRepository.findById(
                createReviewRequest.getClimbingGymId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));

        // 이미 작성된 리뷰가 있는지 확인 (1명의 유저는 1개의 암장에 1개의 리뷰만 가능)
        Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimber(
            climbingGym, climber);
        if (optionalReview.isPresent()) {
            throw new GeneralException(ErrorStatus._REVIEW_EXIST);
        }
```
- rating 갱신 부분입니다. (ClimbingGym Domain)
``` java
    private Float AverageRating = 0.0F;

    private Float sumRating = 0.0F; // 새로 추가한 컬럼입니다.

    private int reviewCount = 0;

    public void reviewCreate(Float rating) {
        this.sumRating += rating;
        this.reviewCount++;
        this.averageRatingCalculate();
    }

    public void averageRatingCalculate() {
        if (this.reviewCount > 0) {
            this.AverageRating = this.sumRating / this.reviewCount;
        } else {
            this.AverageRating = 0.0F;
        }
    }
```


## 테스트 확인 내용

1. content의 길이가 1001일 때를 입력하여, 예외처리 정상 동작 확인했습니다.
   - 길이가 1000일 때에 정상 추가 되는 것 또한 확인했습니다.
2. rating 범위가 음수일 때, 5 초과일 때, 0.5단위로 입력되지 않았을 때 예외처리 동작 확인했습니다.
   - 리뷰가 여러개 추가되었을 때 average 값이 정상적으로 반영되고 있는 것 확인했습니다.
3. 암장이 존재하지 않을 때 예외처리 동작 확인했습니다
   - 여기서 만약 매니저가 없는 암장(가입이 안된 암장)의 경우에는 리뷰를 추가할 수 없도록 해야할까요??
4. 유저가 존재하지 않을 때에도 예외처리 동작 확인했습니다.
5. 유저가 해당 암장에 이미 리뷰를 남긴 상황 또한 예외처리 동작 확인했습니다.

## 질문 및 이외 사항
- 테스트 확인 내용에서 하나 있습니다!
> 3. 암장이 존재하지 않을 때 예외처리 동작 확인했습니다
   > - 여기서 만약 매니저가 없는 암장(가입이 안된 암장)의 경우에는 리뷰를 추가할 수 없도록 해야할까요??
- Error Status를 Swagger에 반영하는 것은 추후 추가하겠습니다!!
- 마찬가지로 테스트 코드 공부중입니다!
