### PR TITLE
[SPR-90] DifficultyMapping 테이블 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
@@ -1,12 +1,9 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,6 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class DifficultyMapping extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,12 +28,15 @@ public class DifficultyMapping extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ClimbingGym climbingGym;
 
-    @Enumerated(EnumType.STRING)
-    private ClimeetDifficulty climeetDifficulty;
+    @NotNull
+    private int climeetDifficulty;
+
+    @NotNull
+    private int gymDifficulty;
 
     @NotNull
     @Column(length = 10)
-    private String gymDifficulty;
+    private String gymDifficultyName;
 
     @NotNull
     @Column(length = 7)

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
@@ -1,0 +1,43 @@
+package com.climeet.climeet_backend.domain.difficultymapping;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
+import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DifficultyMapping extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ClimbingGym climbingGym;
+
+    @Enumerated(EnumType.STRING)
+    private ClimeetDifficulty climeetDifficulty;
+
+    @NotNull
+    @Column(length = 10)
+    private String gymDifficulty;
+
+    @NotNull
+    @Column(length = 7)
+    private String gymDifficultyColor;
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
@@ -1,5 +1,0 @@
-package com.climeet.climeet_backend.domain.difficultymapping.enums;
-
-public enum ClimeetDifficulty {
-        V1, V2, V3, V4, V5, V6, V7, V8
-}

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
@@ -1,0 +1,5 @@
+package com.climeet.climeet_backend.domain.difficultymapping.enums;
+
+public enum ClimeetDifficulty {
+        V1, V2, V3, V4, V5, V6, V7, V8
+}


### PR DESCRIPTION
## 요약
- 간단하게 테이블 추가했습니다.

## 상세 내용

- 코드의 내용이 전부입니다
- 추가한 컬럼은, id, climbingGym, climeetDifficulty, gymDifficulty, gymDifficultyColor입니다.
- climeetDifficulty는 클밋 자체에서 관리하는 난이도이기 때문에 enum으로 구성하였고, 일단, V1부터 V8까지로 넣어놨습니다.
- 암장 난이도 이름은 10자 제한을 걸어두었고, 난이도 색 코드도 #FFFFFF 로 String 7자리 제한 걸었습니다.
- 이상입니다.

## 테스트 확인 내용
 
<img width="521" alt="스크린샷 2024-01-22 오후 3 23 07" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/d38de519-7c1d-4cbe-ab6d-91bcaaf88f5f">
다음과 같이 테이블이 추가되었습니다.

## 질문 및 이외 사항

- 이름 수정사항, Enum 관련, 뭐 기타 등등 조언, 훈수 모두 감사합니다!
