### PR TITLE
[SPR-91] RouteVersion 테이블 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
@@ -1,0 +1,39 @@
+package com.climeet.climeet_backend.domain.routeversion;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.joda.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RouteVersion extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ClimbingGym climbingGym;
+
+    @NotNull
+    private LocalDate timePoint;
+
+    @NotNull
+    private String routeList;
+
+    @NotNull
+    private String sectorList;
+}


### PR DESCRIPTION
## 요약

- RouteVersion 테이블을 추가했습니다

## 상세 내용

- 간단하게 추가했습니다.
- id, climbingGym, timePoint, routeList, sectorList 가 들어갔습니다.

https://github.com/TheClimeet/climeet-spring/pull/37#discussion_r1461592403
> 아 그 부분을 설명을 빼먹었네요!! 전체적으로 설명도 해두는게 좋을 것 같아서 아래에 서술하겠습니다!

> 해당 암장의 특정 시간대를 기준으로 존재하는 Route Id와 Sector Id의 리스트가 들어가게 됩니다.
> 루트나 섹터의 데이터가 추가되거나, 수정되었을 때 새로운 루트와 섹터를 만든다고 했었고, 바로 이전 버전의 리스트에서 변경된 사항을 반> 영한 루트와 섹터의 리스트를 가지게 됩니다.

>좀 더 풀어서 설명하면,
> 1. 2023년 10월 1일이 가장 최신의 루트 버전일 때
> - Route List : "[1, 2, 3, 4, 5]"
> - Sector List: "[1, 2]"
>를 가지고 있다고 가정하겠습니다. (편의상 Id를 ~번 루트로 부르겠습니다. 1번 루트, 1번 섹터 등등)
>* 해당 List 데이터는 String 형태로, 사용하고자 할 때 parsing을 해야하며, 해당 convert 클래스를 만들 계획입니다!

>2. 2023년 11월 1일에 만약 
>- **1번 루트를 수정**하고, 
>- **2번 루트를 삭제**하며, 
>- **1번 섹터를 수정(1, 2번 루트랑 연관이 되어있을수도,,?)**한다고 하면, 
>1번 루트에서 수정된 6번 루트를 만들고, 1번 섹터에서 수정된 3번 섹터를 새로 생성하게 됩니다.

>3. 따라서 2023년 11월 1일에 관련된 데이터는
> - Route List: "[3, 4, 5, 6]"
> - Sector List: "[2, 3]"
> 을 가지게 됩니다.

>결론적으로 짧게 간추려서 RouteList와 SectorList가 무엇인가를 답하자면, 해당 시점에 존재하는 Route Id와 Sector Id를 배열로 가지는 문자열을 저장한다고 보면 될 것 같습니다!!

## 테스트 확인 내용

<img width="506" alt="스크린샷 2024-01-22 오후 3 36 27" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/787d5bb6-25b7-44c0-9714-11ac69084694">
다음과 같이 추가된 것을 확인할 수 있습니다.

## 질문 및 이외 사항

- 변경해야할 사항 말해주세요! (테이블 이름이 괜찮나 하는 생각이 들긴 합니다...)
