### PR TITLE
[SPR-76] [홈화면] 금주 베스트 클라이머 구현(완등, 고수, 시간)

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimber.java
@@ -1,0 +1,31 @@
+package com.climeet.climeet_backend.domain.bestclimber.clear;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BestClearClimber {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private int ranking = 0;
+
+    private int thisWeekClearCount = 0;
+
+    private String profileImageUrl;
+
+    private String profileName;
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimberController.java
@@ -1,0 +1,23 @@
+package com.climeet.climeet_backend.domain.bestclimber.clear;
+
+import com.climeet.climeet_backend.domain.bestclimber.clear.dto.BestClearClimberResponseDto.BestClearClimberSimpleResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BestClearClimber", description = "[완등순] 금주 베스트 클라이머 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rank/week/climber")
+public class BestClearClimberController {
+    private final BestClearClimberService bestClearClimberService;
+
+    @GetMapping("/clear")
+    public ResponseEntity<List<BestClearClimberSimpleResponse>> findClimberRankingOrderClearCount(){
+        return ResponseEntity.ok(bestClearClimberService.findClimberRankingOrderClearCount());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimberRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimberRepository.java
@@ -1,0 +1,8 @@
+package com.climeet.climeet_backend.domain.bestclimber.clear;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BestClearClimberRepository extends JpaRepository<BestClearClimber, Long> {
+    List<BestClearClimber> findAllByOrderByRankingAsc();
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/BestClearClimberService.java
@@ -1,0 +1,20 @@
+package com.climeet.climeet_backend.domain.bestclimber.clear;
+
+import com.climeet.climeet_backend.domain.bestclimber.clear.dto.BestClearClimberResponseDto.BestClearClimberSimpleResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class BestClearClimberService {
+    private final BestClearClimberRepository bestClearClimberRepository;
+
+    public List<BestClearClimberSimpleResponse> findClimberRankingOrderClearCount() {
+        List<BestClearClimber> ranking = bestClearClimberRepository.findAllByOrderByRankingAsc();
+        return ranking.stream()
+            .map(BestClearClimberSimpleResponse::toDTO)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/dto/BestClearClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/dto/BestClearClimberResponseDto.java
@@ -1,0 +1,34 @@
+package com.climeet.climeet_backend.domain.bestclimber.clear.dto;
+
+import com.climeet.climeet_backend.domain.bestclimber.clear.BestClearClimber;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BestClearClimberResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BestClearClimberSimpleResponse{
+
+        private int ranking;
+
+        private String profileImageUrl;
+
+        private String profileName;
+
+        private int thisWeekClearCount;
+
+        public static BestClearClimberSimpleResponse toDTO(BestClearClimber bestClearClimber){
+            return BestClearClimberSimpleResponse.builder()
+                .ranking(bestClearClimber.getRanking())
+                .profileImageUrl(bestClearClimber.getProfileImageUrl())
+                .thisWeekClearCount(bestClearClimber.getThisWeekClearCount())
+                .profileName(bestClearClimber.getProfileName())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimber.java
@@ -1,0 +1,30 @@
+package com.climeet.climeet_backend.domain.bestclimber.level;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class BestLevelClimber {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private int ranking = 0;
+
+    private int thisWeekHighDifficulty = 0;
+
+    private String profileImageUrl;
+
+    private String profileName;
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimberController.java
@@ -1,0 +1,23 @@
+package com.climeet.climeet_backend.domain.bestclimber.level;
+
+import com.climeet.climeet_backend.domain.bestclimber.level.dto.BestLevelClimberResponseDto.BestLevelClimberSimpleResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BestLevelClimber", description = "[레벨순] 금주 베스트 클라이머 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rank/week/climber")
+public class BestLevelClimberController {
+    private final BestLevelClimberService bestLevelClimberService;
+
+    @GetMapping("/level")
+    public ResponseEntity<List<BestLevelClimberSimpleResponse>> findClimberRankingOrderLevel(){
+        return ResponseEntity.ok(bestLevelClimberService.findClimberRankingOrderLevel());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimberRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimberRepository.java
@@ -1,0 +1,8 @@
+package com.climeet.climeet_backend.domain.bestclimber.level;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BestLevelClimberRepository extends JpaRepository<BestLevelClimber, Long> {
+    List<BestLevelClimber> findAllByOrderByRankingAsc();
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimberService.java
@@ -1,0 +1,20 @@
+package com.climeet.climeet_backend.domain.bestclimber.level;
+
+
+import com.climeet.climeet_backend.domain.bestclimber.level.dto.BestLevelClimberResponseDto.BestLevelClimberSimpleResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BestLevelClimberService {
+    private final BestLevelClimberRepository bestLevelClimberRepository;
+    public List<BestLevelClimberSimpleResponse> findClimberRankingOrderLevel() {
+        List<BestLevelClimber> ranking = bestLevelClimberRepository.findAllByOrderByRankingAsc();
+        return ranking.stream()
+            .map(BestLevelClimberSimpleResponse::toDTO)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/dto/BestLevelClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/dto/BestLevelClimberResponseDto.java
@@ -1,0 +1,35 @@
+package com.climeet.climeet_backend.domain.bestclimber.level.dto;
+
+import com.climeet.climeet_backend.domain.bestclimber.level.BestLevelClimber;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BestLevelClimberResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BestLevelClimberSimpleResponse{
+
+        private int ranking;
+
+        private String profileImageUrl;
+
+        private String profileName;
+
+        private int thisWeekHighDifficulty;
+
+        public static BestLevelClimberSimpleResponse toDTO(
+            BestLevelClimber bestLevelClimber){
+            return BestLevelClimberSimpleResponse.builder()
+                .ranking(bestLevelClimber.getRanking())
+                .profileImageUrl(bestLevelClimber.getProfileImageUrl())
+                .thisWeekHighDifficulty(bestLevelClimber.getThisWeekHighDifficulty())
+                .profileName(bestLevelClimber.getProfileName())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimber.java
@@ -1,0 +1,30 @@
+package com.climeet.climeet_backend.domain.bestclimber.time;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BestTimeClimber {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private int ranking = 0;
+
+    private Long thisWeekTotalClimbingTime = 0L;
+
+    private String profileImageUrl;
+
+    private String profileName;
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimberController.java
@@ -1,0 +1,24 @@
+package com.climeet.climeet_backend.domain.bestclimber.time;
+
+import com.climeet.climeet_backend.domain.bestclimber.time.dto.BestTimeClimberResponseDto.BestTimeClimberSimpleResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BestTimeClimber", description = "[시간순] 금주 베스트 클라이머 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rank/week/climber")
+public class BestTimeClimberController {
+
+    private final BestTimeClimberService bestTimeClimberService;
+
+    @GetMapping("/time")
+    public ResponseEntity<List<BestTimeClimberSimpleResponse>> findClimberRankingOrderLevel(){
+        return ResponseEntity.ok(bestTimeClimberService.findClimberRankingOrderTime());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimberRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimberRepository.java
@@ -1,0 +1,8 @@
+package com.climeet.climeet_backend.domain.bestclimber.time;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BestTimeClimberRepository extends JpaRepository<BestTimeClimber, Long> {
+    List<BestTimeClimber> findAllByOrderByRankingAsc();
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/BestTimeClimberService.java
@@ -1,0 +1,21 @@
+package com.climeet.climeet_backend.domain.bestclimber.time;
+
+import com.climeet.climeet_backend.domain.bestclimber.time.dto.BestTimeClimberResponseDto.BestTimeClimberSimpleResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BestTimeClimberService {
+
+    private final BestTimeClimberRepository bestTimeClimberRepository;
+
+    public List<BestTimeClimberSimpleResponse> findClimberRankingOrderTime(){
+        List<BestTimeClimber> ranking = bestTimeClimberRepository.findAllByOrderByRankingAsc();
+        return ranking.stream()
+            .map(BestTimeClimberSimpleResponse::toDTO)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/dto/BestTimeClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/dto/BestTimeClimberResponseDto.java
@@ -1,0 +1,35 @@
+package com.climeet.climeet_backend.domain.bestclimber.time.dto;
+
+import com.climeet.climeet_backend.domain.bestclimber.time.BestTimeClimber;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BestTimeClimberResponseDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BestTimeClimberSimpleResponse{
+
+        private int ranking;
+
+        private String profileImageUrl;
+
+        private String profileName;
+
+        private Long thisWeekTotalClimbingTime;
+
+        public static BestTimeClimberSimpleResponse toDTO(
+            BestTimeClimber bestTimeClimber){
+            return BestTimeClimberSimpleResponse.builder()
+                .ranking(bestTimeClimber.getRanking())
+                .profileImageUrl(bestTimeClimber.getProfileImageUrl())
+                .thisWeekTotalClimbingTime(bestTimeClimber.getThisWeekTotalClimbingTime())
+                .profileName(bestTimeClimber.getProfileName())
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- [완등] 금주 베스트클라이머 조회 구현
- [고수] 금주 베스트클라이머 조회 구현
- [시간] 금주 베스트클라이머 조회 구현

## 상세 내용
- 우선 해당 PR에 속한 기능들을 이해하는 데 아래 '참고'를 보시면 도움이 됩니다.
- 참고: #26 , #27 
- 위 세가지 기능에 대해 이 전  각각 테이블을 생성하여 Spring boot와 JPA 를 사용해 랭킹 조회 로직을 구현하였습니다.

![스크린샷 2024-01-23 오후 7 29 35](https://github.com/TheClimeet/climeet-spring/assets/100510247/8d9a6e02-b6e1-4ac1-8629-31a11bc65e48)

- 랭킹의 업데이트는 '참고'와 마찬가지로 람다와 이벤트브릿지를 활용해 일주일에 한 번 업데이트 하는 방식으로 구현하였습니다.
- 기능 자체가 order by (각각의 순서를 결정짓는 필드) 된 테이블을 한 번 돌면서 상위 10 or 15개의 항목을 가져오는 작업이라 하나의 람다함수에 작성할까도 했습니다.
- 하지만 각각의 함수를 분리하는 것이 로그 분석이나 단일장애지점을 극복하는 데에 이점이 있을 것이라 생각하여 분리한 상태로 남기는 쪽을 선택했습니다.
- 대신 아래 스크린샷처럼 태그를 걸어 관리하도록 하겠습니다.

![스크린샷 2024-01-23 오후 7 36 05](https://github.com/TheClimeet/climeet-spring/assets/100510247/2246243e-5d42-4a07-96fd-380e4aa88b7e)


## 테스트 확인 내용
- 해당 테스트를 postman을 통해 확인하였습니다.

### [완등] 베스트클라이머 테스트
<img width="1016" alt="스크린샷 2024-01-23 오후 7 38 01" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/bb309fef-b1f6-4f5d-ac98-a80fe6898c87">

### [고수] 베스트클라이머 테스트
<img width="1009" alt="스크린샷 2024-01-23 오후 7 38 16" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/87158edf-d2dc-4a39-800a-a86142c45f9c">

### [시간] 베스트클라이머 테스트
<img width="997" alt="스크린샷 2024-01-23 오후 7 38 39" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/05b1733c-77d4-413e-ace4-03abe5b66664">


## 질문 및 이외 사항
### 주의사항 1
- 현재 람다에 작성된 코드는 금주의 랭킹을 결정짓는 각각의 필드를 초기화하지 않고 있습니다.
- 그 이유는 테스트함에 있어 해당 함수를 실행할 때마다 모두 초기화되었을 때 불편한 사항들이 있기 때문입니다.
- 해당 이슈를 백로그에 적어놓겠습니다.

### 주의사항 2
- 베스트클라이머 시간의 경우 LocalTime이 아닌 Long으로 처리해야 될 것 같습니다.
- 그 이유는 23시간이 넘어가는 숫자는 불가능하기 때문입니다.
- LocalDateTime이 안되는 이유는 hour이 23이 넘어가도 24, 25, ~~~ , 100 h 와 같이 표현해달라고 요청받았기 때문입니다.
- 이에 따라 초를 시:분:초로 변경하는 converter가 필요하고 "전체 프로젝트"를 통틀어서 변경이 필요할 것 같습니다!