### PR TITLE
[SPR-71] 쇼츠 댓글 & 대댓글 조회

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/ShortsCommentLike/ShortsCommentLike.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/ShortsCommentLike/ShortsCommentLike.java
@@ -1,0 +1,39 @@
+package com.climeet.climeet_backend.domain.ShortsCommentLike;
+
+import com.climeet.climeet_backend.domain.shortscomment.CommentLikeStatus;
+import com.climeet.climeet_backend.domain.shortscomment.ShortsComment;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ShortsCommentLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ShortsComment shortsComment;
+
+    @Enumerated(EnumType.STRING)
+    private CommentLikeStatus commentLikeStatus;
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/ShortsCommentLike/ShortsCommentLikeRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/ShortsCommentLike/ShortsCommentLikeRepository.java
@@ -1,0 +1,14 @@
+package com.climeet.climeet_backend.domain.ShortsCommentLike;
+
+import com.climeet.climeet_backend.domain.shortscomment.ShortsComment;
+import com.climeet.climeet_backend.domain.user.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ShortsCommentLikeRepository extends JpaRepository<ShortsCommentLike, Long> {
+
+    @Query("SELECT scl.shortsComment.id, scl.commentLikeStatus FROM ShortsCommentLike scl WHERE scl.user = :user AND scl.shortsComment IN :comments")
+    List<Object[]> findCommentLikeStatusByUserAndCommentsIn(@Param("user") User user, @Param("comments") List<ShortsComment> comments);
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/ShortsCommentLike/ShortsCommentLikeService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/ShortsCommentLike/ShortsCommentLikeService.java
@@ -1,0 +1,30 @@
+package com.climeet.climeet_backend.domain.ShortsCommentLike;
+
+import com.climeet.climeet_backend.domain.shortscomment.CommentLikeStatus;
+import com.climeet.climeet_backend.domain.shortscomment.ShortsComment;
+import com.climeet.climeet_backend.domain.user.User;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShortsCommentLikeService {
+
+    private final ShortsCommentLikeRepository shortsCommentLikeRepository;
+
+    private static final int COMMENT_INDEX = 0;
+    private static final int LIKE_STATUS_INDEX = 1;
+    public Map<Long, CommentLikeStatus> fetchUserLikeStatuses(
+        User user, List<ShortsComment> comments) {
+        List<Object[]> likeStatusList = shortsCommentLikeRepository.findCommentLikeStatusByUserAndCommentsIn(user, comments);
+
+        return likeStatusList.stream()
+            .collect(Collectors.toMap(
+                result -> (Long) result[COMMENT_INDEX], // 댓글 ID
+                result -> (CommentLikeStatus) result[LIKE_STATUS_INDEX] // 좋아요/싫어요 상태
+            ));
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/CommentLikeStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/CommentLikeStatus.java
@@ -1,0 +1,5 @@
+package com.climeet.climeet_backend.domain.shortscomment;
+
+public enum CommentLikeStatus {
+    LIKE, DISLIKE, NONE
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
@@ -67,7 +67,7 @@ public class ShortsComment extends BaseTimeEntity {
 
     public void updateIsFirstChildTrue() {
         this.isFirstChild = true;
-    };
+    }
 
     public boolean isParentComment() {
         return childCommentCount != 0;

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
@@ -40,11 +40,13 @@ public class ShortsComment extends BaseTimeEntity {
     @ManyToOne
     private ShortsComment parentComment;
 
-    private int childCommentCount;
+    private int childCommentCount = 0;
 
-    private int likeCount;
+    private int likeCount = 0;
 
-    private int dislikeCount;
+    private int dislikeCount = 0;
+
+    private Boolean isFirstChild = false;
 
     public static ShortsComment toEntity(User user, CreateShortsCommentRequest createShortsCommentRequest,
         Shorts shorts) {

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.shortscomment;
 import com.climeet.climeet_backend.domain.shorts.Shorts;
 import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,14 +16,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Builder
-public class ShortsComment {
+public class ShortsComment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,20 +35,35 @@ public class ShortsComment {
     private Shorts shorts;
 
     @NotNull
-    private String comment;
+    private String content;
 
-    private Long parentCommentId;
+    @ManyToOne
+    private ShortsComment parentComment;
 
-    public static ShortsComment toEntity(CreateShortsCommentRequest createShortsCommentRequest,
+    private int childCommentCount;
+
+    private int likeCount;
+
+    private int dislikeCount;
+
+    public static ShortsComment toEntity(User user, CreateShortsCommentRequest createShortsCommentRequest,
         Shorts shorts) {
         return ShortsComment.builder()
-            .comment(createShortsCommentRequest.getContent())
-            //.user(user)
+            .content(createShortsCommentRequest.getContent())
+            .user(user)
             .shorts(shorts)
             .build();
     }
 
-    public void updateParentCommentId(Long parentCommentId) {
-        this.parentCommentId = parentCommentId;
+    public void updateParentComment(ShortsComment parentComment) {
+        this.parentComment = parentComment;
+    }
+
+    public void updateChildCommentCount() {
+        this.childCommentCount++;
+    }
+
+    public boolean isParentComment() {
+        return childCommentCount != 0;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsComment.java
@@ -65,6 +65,10 @@ public class ShortsComment extends BaseTimeEntity {
         this.childCommentCount++;
     }
 
+    public void updateIsFirstChildTrue() {
+        this.isFirstChild = true;
+    };
+
     public boolean isParentComment() {
         return childCommentCount != 0;
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -1,7 +1,8 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
 import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
-import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentResponseDto.ShortsCommentResponse;
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentResponseDto.ShortsCommentChildResponse;
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentResponseDto.ShortsCommentParentResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -42,7 +43,7 @@ public class ShortsCommentController {
     @Operation(summary = "숏츠 댓글 조회")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._DUPLICATE_LOGINID, ErrorStatus._DUPLICATE_LOGINID})
     @GetMapping("/shorts/{shortsId}")
-    public ResponseEntity<PageResponseDto<List<ShortsCommentResponse>>> findShortsCommentList(
+    public ResponseEntity<PageResponseDto<List<ShortsCommentParentResponse>>> findShortsCommentList(
         @CurrentUser User user,
         @PathVariable Long shortsId,
         @RequestParam int page, @RequestParam int size
@@ -51,4 +52,15 @@ public class ShortsCommentController {
             shortsCommentService.findShortsCommentList(user, shortsId, page, size));
     }
 
+    @Operation(summary = "숏츠 대댓글 조회")
+    @GetMapping("/shorts/{shortsId}/{parentCommentId}")
+    public ResponseEntity<PageResponseDto<List<ShortsCommentChildResponse>>> findShortsChildCommentList(
+        @CurrentUser User user,
+        @PathVariable Long shortsId,
+        @PathVariable Long parentCommentId,
+        @RequestParam int page, @RequestParam int size
+    ) {
+        return ResponseEntity.ok(
+            shortsCommentService.findShortsChildCommentList(user, shortsId, parentCommentId, page, size));
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -29,6 +29,7 @@ public class ShortsCommentController {
     private final ShortsCommentService shortsCommentService;
 
     @Operation(summary = "숏츠 댓글 작성")
+    @SwaggerApiError({ErrorStatus._EMPTY_SHORTS, ErrorStatus._EMPTY_SHORTS_COMMENT})
     @PostMapping("/shorts/{shortsId}/shortsComments")
     public ResponseEntity<String> createShortsComment(
         @CurrentUser User user,
@@ -41,7 +42,7 @@ public class ShortsCommentController {
     }
 
     @Operation(summary = "숏츠 댓글 조회")
-    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._DUPLICATE_LOGINID, ErrorStatus._DUPLICATE_LOGINID})
+    @SwaggerApiError({ErrorStatus._EMPTY_SHORTS_COMMENT})
     @GetMapping("/shorts/{shortsId}")
     public ResponseEntity<PageResponseDto<List<ShortsCommentParentResponse>>> findShortsCommentList(
         @CurrentUser User user,
@@ -53,6 +54,7 @@ public class ShortsCommentController {
     }
 
     @Operation(summary = "숏츠 대댓글 조회")
+    @SwaggerApiError({ErrorStatus._EMPTY_SHORTS_COMMENT})
     @GetMapping("/shorts/{shortsId}/{parentCommentId}")
     public ResponseEntity<PageResponseDto<List<ShortsCommentChildResponse>>> findShortsChildCommentList(
         @CurrentUser User user,

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -1,9 +1,17 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
 import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentResponseDto.ShortsCommentResponse;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,17 +27,28 @@ public class ShortsCommentController {
 
     private final ShortsCommentService shortsCommentService;
 
-    /**
-     * [POST] 숏츠 댓글 작성 (commentId가 null일 경우 대댓글 아닌 일반 댓글 작성)
-     */
     @Operation(summary = "숏츠 댓글 작성")
     @PostMapping("/shorts/{shortsId}/shortsComments")
     public ResponseEntity<String> createShortsComment(
+        @CurrentUser User user,
         @PathVariable Long shortsId,
         @RequestBody CreateShortsCommentRequest createShortsCommentRequest,
         @RequestParam(required = false) Long parentCommentId) {
-        shortsCommentService.createShortsComment(shortsId, createShortsCommentRequest,
+        shortsCommentService.createShortsComment(user, shortsId, createShortsCommentRequest,
             parentCommentId, parentCommentId != null);
         return ResponseEntity.ok("댓글 작성에 성공했습니다.");
     }
+
+    @Operation(summary = "숏츠 댓글 조회")
+    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._DUPLICATE_LOGINID, ErrorStatus._DUPLICATE_LOGINID})
+    @GetMapping("/shorts/{shortsId}")
+    public ResponseEntity<PageResponseDto<List<ShortsCommentResponse>>> findShortsCommentList(
+        @CurrentUser User user,
+        @PathVariable Long shortsId,
+        @RequestParam int page, @RequestParam int size
+    ) {
+        return ResponseEntity.ok(
+            shortsCommentService.findShortsCommentList(user, shortsId, page, size));
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
@@ -1,7 +1,5 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
-import com.climeet.climeet_backend.domain.user.User;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
@@ -13,9 +13,13 @@ public interface ShortsCommentRepository extends JpaRepository<ShortsComment, Lo
 
 
     @Query("SELECT sc FROM ShortsComment sc WHERE sc.shorts.id = :shortsId AND sc.parentComment IS NULL ORDER BY sc.createdAt ASC")
-    Optional<Slice<ShortsComment>> findParentCommentsByShortsIdOrderedByCreatedAtAsc(@Param("shortsId") Long shortsId, Pageable pageable);
+    Optional<Slice<ShortsComment>> findParentCommentsByShortsIdOrderedByCreatedAtAsc(
+        @Param("shortsId") Long shortsId, Pageable pageable);
 
     @Query("SELECT sc FROM ShortsComment sc WHERE sc.parentComment.id = :parentId AND sc.id != :parentId ORDER BY sc.createdAt ASC limit 1")
-    Optional<ShortsComment> findFirstChildCommentByIdAndNotParentOrderByCreatedAtAsc(@Param("parentId") Long parentId);
+    Optional<ShortsComment> findFirstChildCommentByIdAndNotParentOrderByCreatedAtAsc(
+        @Param("parentId") Long parentId);
 
+    Optional<Slice<ShortsComment>> findChildCommentsByShortsIdAndParentCommentIdAndIsFirstChildFalseOrderByCreatedAtAsc(
+        Long shortsId, Long parentCommentId, Pageable pageable);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
@@ -1,7 +1,21 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
+import com.climeet.climeet_backend.domain.user.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ShortsCommentRepository extends JpaRepository<ShortsComment, Long> {
+
+
+    @Query("SELECT sc FROM ShortsComment sc WHERE sc.shorts.id = :shortsId AND sc.parentComment IS NULL ORDER BY sc.createdAt ASC")
+    Optional<Slice<ShortsComment>> findParentCommentsByShortsIdOrderedByCreatedAtAsc(@Param("shortsId") Long shortsId, Pageable pageable);
+
+    @Query("SELECT sc FROM ShortsComment sc WHERE sc.parentComment.id = :parentId AND sc.id != :parentId ORDER BY sc.createdAt ASC limit 1")
+    Optional<ShortsComment> findFirstChildCommentByIdAndNotParentOrderByCreatedAtAsc(@Param("parentId") Long parentId);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -72,7 +72,7 @@ public class ShortsCommentService {
                 comment.getUser().getProfileImageUrl(),
                 comment.getContent(),
                 likeStatusMap.getOrDefault(comment.getId(), CommentLikeStatus.NONE),
-                comment.getChildCommentCount() != 0,
+                comment.isParentComment(),
                 comment.getLikeCount(),
                 comment.getDislikeCount(),
                 fetchParentCommentId(comment),
@@ -94,7 +94,7 @@ public class ShortsCommentService {
             // 댓글의 가장 오래된 대댓글 가져와 부모 댓글 바로 뒤에 추가
             shortsCommentRepository.findFirstChildCommentByIdAndNotParentOrderByCreatedAtAsc(
                     parentComment.getId())
-                .ifPresent(childComment -> commentListWithChild.add((ShortsComment) childComment));
+                .ifPresent(commentListWithChild::add);
         });
 
         return commentListWithChild;

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -1,12 +1,25 @@
 package com.climeet.climeet_backend.domain.shortscomment;
 
+import static com.climeet.climeet_backend.global.utils.DateTimeConverter.convertToDisplayTime;
+
+import com.climeet.climeet_backend.domain.ShortsCommentLike.ShortsCommentLikeService;
 import com.climeet.climeet_backend.domain.shorts.Shorts;
 import com.climeet.climeet_backend.domain.shorts.ShortsRepository;
 import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentRequestDto.CreateShortsCommentRequest;
+import com.climeet.climeet_backend.domain.shortscomment.dto.ShortsCommentResponseDto.ShortsCommentResponse;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -15,20 +28,84 @@ public class ShortsCommentService {
 
     private final ShortsRepository shortsRepository;
     private final ShortsCommentRepository shortsCommentRepository;
+    private final ShortsCommentLikeService shortsCommentLikeService;
+    private static final int ADJUSTED_CHILD_COUNT = 1;
 
     @Transactional
-    public void createShortsComment(Long shortsId,
+    public void createShortsComment(User user, Long shortsId,
         CreateShortsCommentRequest createShortsCommentRequest, Long parentCommentId,
         boolean isReply) {
 
         Shorts shorts = shortsRepository.findById(shortsId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SHORTS));
 
-        ShortsComment shortsComment = ShortsComment.toEntity(createShortsCommentRequest, shorts);
+        ShortsComment shortsComment = ShortsComment.toEntity(user, createShortsCommentRequest,
+            shorts);
+
         if (isReply) {
-            shortsComment.updateParentCommentId(parentCommentId);
+            ShortsComment parentComment = shortsCommentRepository.findById(parentCommentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._Empty_SHORTS_COMMENT));
+            parentComment.updateChildCommentCount();
+            shortsComment.updateParentComment(parentComment);
         }
 
         shortsCommentRepository.save(shortsComment);
     }
+
+    public PageResponseDto<List<ShortsCommentResponse>> findShortsCommentList(User user,
+        Long shortsId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<ShortsComment> parentCommentList = shortsCommentRepository.findParentCommentsByShortsIdOrderedByCreatedAtAsc(
+                shortsId, pageable)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._Empty_SHORTS_COMMENT));
+
+        List<ShortsComment> shortsCommentIncludeChildList = fetchParentAndFirstChildComments(
+            parentCommentList.getContent());
+
+        Map<Long, CommentLikeStatus> likeStatusMap = shortsCommentLikeService.fetchUserLikeStatuses(
+            user, shortsCommentIncludeChildList);
+
+        List<ShortsCommentResponse> responses = shortsCommentIncludeChildList.stream()
+            .map(comment -> ShortsCommentResponse.toDto(
+                comment.getId(),
+                comment.getUser().getProfileName(),
+                comment.getUser().getProfileImageUrl(),
+                comment.getContent(),
+                likeStatusMap.getOrDefault(comment.getId(), CommentLikeStatus.NONE),
+                comment.getChildCommentCount() != 0,
+                comment.getLikeCount(),
+                comment.getDislikeCount(),
+                fetchParentCommentId(comment),
+                comment.getChildCommentCount() - ADJUSTED_CHILD_COUNT,
+                convertToDisplayTime(comment.getCreatedAt())
+            ))
+            .collect(Collectors.toList());
+
+        return new PageResponseDto<>(pageable.getPageNumber(), parentCommentList.hasNext(),
+            responses);
+    }
+
+    private List<ShortsComment> fetchParentAndFirstChildComments(
+        List<ShortsComment> parentComments) {
+        List<ShortsComment> commentListWithChild = new ArrayList<>();
+
+        parentComments.forEach(parentComment -> {
+            commentListWithChild.add(parentComment);
+            // 댓글의 가장 오래된 대댓글 가져와 부모 댓글 바로 뒤에 추가
+            shortsCommentRepository.findFirstChildCommentByIdAndNotParentOrderByCreatedAtAsc(
+                    parentComment.getId())
+                .ifPresent(childComment -> commentListWithChild.add((ShortsComment) childComment));
+        });
+
+        return commentListWithChild;
+    }
+
+    private Long fetchParentCommentId(ShortsComment comment) {
+        if (comment.getParentComment() != null) {
+            return comment.getParentComment().getId();
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -46,6 +46,9 @@ public class ShortsCommentService {
         if (isReply) {
             ShortsComment parentComment = shortsCommentRepository.findById(parentCommentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._Empty_SHORTS_COMMENT));
+            if(parentComment.getChildCommentCount() == 0) {
+                shortsComment.updateIsFirstChildTrue();
+            }
             parentComment.updateChildCommentCount();
             shortsComment.updateParentComment(parentComment);
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -45,7 +45,7 @@ public class ShortsCommentService {
 
         if (isReply) {
             ShortsComment parentComment = shortsCommentRepository.findById(parentCommentId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._Empty_SHORTS_COMMENT));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SHORTS_COMMENT));
             if(parentComment.getChildCommentCount() == 0) {
                 shortsComment.updateIsFirstChildTrue();
             }
@@ -61,7 +61,7 @@ public class ShortsCommentService {
         Pageable pageable = PageRequest.of(page, size);
         Slice<ShortsComment> parentCommentList = shortsCommentRepository.findParentCommentsByShortsIdOrderedByCreatedAtAsc(
                 shortsId, pageable)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._Empty_SHORTS_COMMENT));
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SHORTS_COMMENT));
 
         List<ShortsComment> shortsCommentIncludeChildList = fetchParentAndFirstChildComments(
             parentCommentList.getContent());
@@ -94,7 +94,7 @@ public class ShortsCommentService {
         Pageable pageable = PageRequest.of(page, size);
         Slice<ShortsComment> childCommentList = shortsCommentRepository.findChildCommentsByShortsIdAndParentCommentIdAndIsFirstChildFalseOrderByCreatedAtAsc(
                 shortsId, parentCommentId, pageable)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._Empty_SHORTS_COMMENT));
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SHORTS_COMMENT));
 
         Map<Long, CommentLikeStatus> likeStatusMap = shortsCommentLikeService.fetchUserLikeStatuses(
             user, childCommentList.getContent());

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/dto/ShortsCommentResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/dto/ShortsCommentResponseDto.java
@@ -1,0 +1,46 @@
+package com.climeet.climeet_backend.domain.shortscomment.dto;
+
+import com.climeet.climeet_backend.domain.shortscomment.CommentLikeStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ShortsCommentResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class ShortsCommentResponse {
+
+        Long commentId;
+        String nickname;
+        String profileImageUrl;
+        String content;
+        CommentLikeStatus commentLikeStatus;
+        int likeCount;
+        int dislikeCount;
+        Boolean isParent;
+        Long parentCommentId;
+        int childCommentCount;
+        String createdDate;
+
+        public static ShortsCommentResponse toDto(Long commentId,String nickname, String profileImageUrl,
+            String content, CommentLikeStatus commentLikeStatus, Boolean isParent,
+            int likeCount, int dislikeCount,
+            Long parentCommentId, int childCommentCount, String createdDate) {
+            return ShortsCommentResponse.builder()
+                .commentId(commentId)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .content(content)
+                .commentLikeStatus(commentLikeStatus)
+                .likeCount(likeCount)
+                .dislikeCount(dislikeCount)
+                .isParent(isParent)
+                .parentCommentId(parentCommentId)
+                .childCommentCount(childCommentCount)
+                .createdDate(createdDate)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/dto/ShortsCommentResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/dto/ShortsCommentResponseDto.java
@@ -10,7 +10,7 @@ public class ShortsCommentResponseDto {
     @Builder
     @Getter
     @AllArgsConstructor
-    public static class ShortsCommentResponse {
+    public static class ShortsCommentParentResponse {
 
         Long commentId;
         String nickname;
@@ -24,11 +24,12 @@ public class ShortsCommentResponseDto {
         int childCommentCount;
         String createdDate;
 
-        public static ShortsCommentResponse toDto(Long commentId,String nickname, String profileImageUrl,
+        public static ShortsCommentParentResponse toDto(Long commentId, String nickname,
+            String profileImageUrl,
             String content, CommentLikeStatus commentLikeStatus, Boolean isParent,
             int likeCount, int dislikeCount,
             Long parentCommentId, int childCommentCount, String createdDate) {
-            return ShortsCommentResponse.builder()
+            return ShortsCommentParentResponse.builder()
                 .commentId(commentId)
                 .nickname(nickname)
                 .profileImageUrl(profileImageUrl)
@@ -39,6 +40,40 @@ public class ShortsCommentResponseDto {
                 .isParent(isParent)
                 .parentCommentId(parentCommentId)
                 .childCommentCount(childCommentCount)
+                .createdDate(createdDate)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class ShortsCommentChildResponse {
+
+        Long commentId;
+        String nickname;
+        String profileImageUrl;
+        String content;
+        CommentLikeStatus commentLikeStatus;
+        int likeCount;
+        int dislikeCount;
+        Long parentCommentId;
+        String createdDate;
+
+        public static ShortsCommentChildResponse toDto(Long commentId, String nickname,
+            String profileImageUrl,
+            String content, CommentLikeStatus commentLikeStatus,
+            int likeCount, int dislikeCount,
+            Long parentCommentId, String createdDate) {
+            return ShortsCommentChildResponse.builder()
+                .commentId(commentId)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .content(content)
+                .commentLikeStatus(commentLikeStatus)
+                .likeCount(likeCount)
+                .dislikeCount(dislikeCount)
+                .parentCommentId(parentCommentId)
                 .createdDate(createdDate)
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/climeet/climeet_backend/global/config/SecurityConfig.java
@@ -23,5 +23,4 @@ public class SecurityConfig {
 
             return http.build();
         }
-
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -62,11 +62,13 @@ public enum ErrorStatus implements BaseErrorCode {
     //암장 리뷰 관련
     _CONTENT_TOO_LARGE(HttpStatus.CONFLICT, "REVIEW_001", "리뷰 최대 입력 길이를 초과했습니다."),
     _RATING_OUT_OF_RANGE(HttpStatus.CONFLICT, "REVIEW_002", "rating의 범위가 올바르지 않습니다."),
-    _REVIEW_EXIST(HttpStatus.CONFLICT, "REVIEW_003", "유저가 이미 해당 암장에 대한 리뷰를 남겼습니다.")
+    _REVIEW_EXIST(HttpStatus.CONFLICT, "REVIEW_003", "유저가 이미 해당 암장에 대한 리뷰를 남겼습니다."),
 
+    //유저 관련
+    _EMPTY_USER(HttpStatus.CONFLICT, "USER_001", "존재하지 않는 유저입니다."),
 
-
-    ;
+    //숏츠 댓글 관련
+    _Empty_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001" , "존재하지 않는 쇼츠 댓글입니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -68,7 +68,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_USER(HttpStatus.CONFLICT, "USER_001", "존재하지 않는 유저입니다."),
 
     //숏츠 댓글 관련
-    _Empty_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001" , "존재하지 않는 쇼츠 댓글입니다.");
+    _EMPTY_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001" , "존재하지 않는 쇼츠 댓글입니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/climeet/climeet_backend/global/utils/DateTimeConverter.java
+++ b/src/main/java/com/climeet/climeet_backend/global/utils/DateTimeConverter.java
@@ -1,0 +1,21 @@
+package com.climeet.climeet_backend.global.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+public class DateTimeConverter {
+
+    public static String convertToDisplayTime(LocalDateTime dateTime) {
+        LocalDateTime currentTime = LocalDateTime.now();
+        long minutes = ChronoUnit.MINUTES.between(dateTime, currentTime);
+        long hours = ChronoUnit.HOURS.between(dateTime, currentTime);
+
+        if (minutes < 60) {
+            return minutes + "분 전";
+        } else if (hours < 24) {
+            return hours + "시간 전";
+        } else
+            return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
+}


### PR DESCRIPTION
## 요약

- DateTimeConverter 생성
- 숏츠 댓글 조회
- 숏츠 대댓글 조회

## 상세 내용

### DateTimeConver 

```java
public static String convertToDisplayTime(LocalDateTime dateTime) {
        LocalDateTime currentTime = LocalDateTime.now();
        long minutes = ChronoUnit.MINUTES.between(dateTime, currentTime);
        long hours = ChronoUnit.HOURS.between(dateTime, currentTime);

        if (minutes < 60) {
            return minutes + "분 전";
        } else if (hours < 24) {
            return hours + "시간 전";
        } else
            return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
    }
```
- LocalDateTime을 인자로 받아 시간에 따라 `분 전`, `시간 전` `yyyy.MM.dd` 형식 String으로 바꿔줍니다.

---

### 쇼츠 댓글 조회
<img width="330" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/117848386/07dd32cc-c967-461e-a219-9fa71e0cad7e">

- 생각보다 까다로운 부분이 많아 오래걸렸습니다.
    - 유저의 기본정보
    - 댓글의 생성시간(DateTimeConver사용)
    - 댓글의 가장 먼저 생긴 대댓글
    - 대댓글이 있다면 위 대댓글을 제외하고 몇개인지
    - 현재 로그인한 유저가 각 댓글에 대해 좋아요/싫어요를 눌렀는지
    - 댓글의 좋아요/싫어요 개수
    - 오래된순으로 조회해야하며 만약 대댓글이 있다면 순서는 해당 부모댓글 다음으로 해야한다.
-  위 정보를 조회할 때 편하게 하기 위해 생성, 수정시에 절차가 복잡해지더라도 `ShortsComment`에 컬럼을 추가했습니다.

```java
private int childCommentCount = 0;

private Boolean isFirstChild = false;
```
- 대댓글을 생성할 경우 childCommentCount를 증가, 만약 첫번째 대댓글일 경우 isFirstChild를 true로 바꿉니다.

#### 서비스 코드


- 다른 메소드에서 사용되는 find와 동일한 의미의 메소드는 구분을 위해 fetch라는 접두사를 사용했습니다.
    - `fetchParentAndFirstChildComments` : 댓글 리스트를 받아 해당 댓글리스트를 돌며 만약 대댓글이 있다면 가장 오래된 댓글을 가져와 부모 댓글 뒤에 추가합니다. 이 함수를 통해 댓글을 오래된 순으로 불러오면서 대댓글이 있다면 부모 댓글 바로 뒤 순서로 유지가 가능합니다.
    - 서브 쿼리를 같이 사용해 쿼리 접근을 줄이는 식으로 리팩토링시에 변경하겠습니다.(노션에 추가)
    - `fectchUserLikeStatuses` : 댓글 리스트를 받아 현재 로그인한 유저의 해당 댓글에 대한 좋아요 상태 enum값을 가져옵니다. 여기서 Object[] 배열을 통해 [댓글id, 좋아요enum]값을 가져옵니다. Object로 가져온 이유는 둘의 자료형이 다르기 때문입니다! Map[Object1, Object2]로 가져와 상수로 설정된 변수로 값을 가져오면서 형변환을 해줍니다. [진로 블로그 ㅎ - [자바] Obejct class](https://velog.io/@gourd_erased/%EC%9E%90%EB%B0%94-Obejct-class)
    - `fetchParentCommentId` : 댓글마다 ParentComment가 있는지 확인 후 있다면 id를 반환하고 없다면 null을 반환합니다.

- findShortsCommentList(댓글과 대댓글이 있다면 하나씩 가져온다.)
    - 먼저 `findParentCommentsByShortsIdOrderedByCreatedAtAsc`를 통해 부모 댓글들만 가져옵니다. 여기서 부모 댓글만 가져오는 이유는 이후 대댓글을 가져오는 과정에서 겹쳐 동일한 댓글을 가져오지 않게 하기 위해서입니다. 
    - `fetchParentAndFirstChildComments`메소드를 이용해 대댓글까지 가져온 리스트인 `shortsCommentIncludeChildList`를 얻습니다.
    - shortsCommentLikeService의 `fetchUserLikeStatuses`메소드로 각각 댓글에 대한 [댓글id, LikeStatus] 값인 `likeStatusMap`을 받아옵니다.
    - 이후 `shortsCommentIncludeChildList`을 stream으로 댓글에 대한 기본 정보와 유저 정보, `likeStatusMap`을 통해 현재 stream도는 댓글에 대한 유저의 좋아요 상태를 얻습니다. 여기서 프론트 요청에 따라 getOrDefault를 통해 테이블에 없어 map에도 없는 경우 null이 아닌 NONE을 설정해줍니다. 대댓글의 개수의 경우 이미 대댓글 하나를 가져오기에 총 대댓글에서 1을 빼줍니다.

```java
public PageResponseDto<List<ShortsCommentParentResponse>> findShortsCommentList(User user,
        Long shortsId, int page, int size) {
        Pageable pageable = PageRequest.of(page, size);
        //부모 댓글만 가져오기
        Slice<ShortsComment> parentCommentList = shortsCommentRepository.findParentCommentsByShortsIdOrderedByCreatedAtAsc(
                shortsId, pageable)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SHORTS_COMMENT));
        //부모댓글을 통해 대댓글 순서 맞춰서 가져오기
        List<ShortsComment> shortsCommentIncludeChildList = fetchParentAndFirstChildComments(
            parentCommentList.getContent());
        //해당 리스트에 현재 유저의 좋아요 상태 Map 가져오기
        Map<Long, CommentLikeStatus> likeStatusMap = shortsCommentLikeService.fetchUserLikeStatuses(
            user, shortsCommentIncludeChildList);
        //dto변환
        List<ShortsCommentParentResponse> responses = shortsCommentIncludeChildList.stream()
            .map(comment -> ShortsCommentParentResponse.toDto(
                comment.getId(),
                comment.getUser().getProfileName(),
                comment.getUser().getProfileImageUrl(),
                comment.getContent(),
                likeStatusMap.getOrDefault(comment.getId(), CommentLikeStatus.NONE),
                comment.isParentComment(),
                comment.getLikeCount(),
                comment.getDislikeCount(),
                fetchParentCommentId(comment),
                comment.getChildCommentCount() - ADJUSTED_CHILD_COUNT,
                convertToDisplayTime(comment.getCreatedAt())
            ))
            .collect(Collectors.toList());

        return new PageResponseDto<>(pageable.getPageNumber(), parentCommentList.hasNext(),
            responses);
    }
```

---

### 쇼츠 대댓글 조회

위 화면에서 답글 N개 더보기에 대한 API입니다. 위 댓글 조회에서 대댓글하나씩 가져오는 부분을 빼고서는 동일합니다!

---

## 테스트 확인 내용

- Postman으로 테스트 완료했습니다. 댓글과 대댓글 순서 모두 정상적으로 조회할 수 있습니다.
- 테스트 코드의 경우 작성하지 못했습니다ㅠ 방식에 대해 조금 더 고민을 하고 말씀드리겠습니다. 이전에 작성하던 테스트코드 방식이 DB에 값을 insert했다가 delete하는 방식인데 이 방식에 대해 고민을 하고 있습니다. 좋은 방식을 찾게 된다면 공유해드리도록 하겠습니다! 

---

## 질문 및 이외 사항

- 이번 PR의 경우 작성하다 토큰과 스웨거 어노테이션 작성으로 브랜치를 많이 왔다갔다해 커밋 단위가 이쁘지 않습니다 ㅎ File changed로 봐주시면 감사하겠습니다
- 이 로직이 제가 작성했으면서도 보기에 복잡해서  상세히 적었습니다. 혹시 이해안되시면 질문해주세욥!
