### PR TITLE
[SPR-66] 암장 조회 기능 개선

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -4,12 +4,10 @@ import com.climeet.climeet_backend.domain.climbinggymimage.ClimbingGymBackground
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,7 +39,7 @@ public class ClimbingGymController {
      */
     @Operation(summary = "Manager가 등록된 암장 검색 기능")
     @GetMapping("/search")
-    public ResponseEntity<List<ClimbingGymSimpleResponse>> getAcceptedClimbingGymSearchingList(
+    public ResponseEntity<List<AcceptedClimbingGymSimpleResponse>> getAcceptedClimbingGymSearchingList(
         @RequestParam("gymname") String gymName
     ) {
         return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName));

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -2,14 +2,13 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
-import com.climeet.climeet_backend.global.response.ApiResponse;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,27 +21,20 @@ public class ClimbingGymController {
 
     private final ClimbingGymService climbingGymService;
 
-    /**
-     * [GET] 암장검색 (Manager가 등록이 되어있지 않은 암장도 조회)
-     * Manager 유무도 함께 반환
-     */
     @Operation(summary = "전국 암장 검색 기능(자체 목록화)")
     @GetMapping("/search/all")
-    public ResponseEntity<List<ClimbingGymSimpleResponse>> getClimbingGymSearchingList(
-        @RequestParam("gymname") String gymName
+    public ResponseEntity<PageResponseDto<List<ClimbingGymSimpleResponse>>> getClimbingGymSearchingList(
+        @RequestParam("gymname") String gymName, @RequestParam int page, @RequestParam int size
     ) {
-        return ResponseEntity.ok(climbingGymService.searchClimbingGym(gymName));
+        return ResponseEntity.ok(climbingGymService.searchClimbingGym(gymName, page, size));
     }
 
-    /**
-     * [GET] 암장검색 (Manager가 등록되어있는 암장만 조회)
-     */
     @Operation(summary = "Manager가 등록된 암장 검색 기능")
     @GetMapping("/search")
-    public ResponseEntity<List<AcceptedClimbingGymSimpleResponse>> getAcceptedClimbingGymSearchingList(
-        @RequestParam("gymname") String gymName
+    public ResponseEntity<PageResponseDto<List<AcceptedClimbingGymSimpleResponse>>> getAcceptedClimbingGymSearchingList(
+        @RequestParam("gymname") String gymName, @RequestParam int page, @RequestParam int size
     ) {
-        return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName));
+        return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName, page, size));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +11,7 @@ public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> 
 
     Optional<ClimbingGym> findByName(String gymName);
 
-    List<ClimbingGym> findByNameContaining(String gymName);
+    List<ClimbingGym> findByNameContaining(String gymName, Pageable pageable);
 
-    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String gymName);
+    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String gymName, Pageable pageable);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymRepository.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,7 @@ public interface ClimbingGymRepository extends JpaRepository<ClimbingGym, Long> 
 
     Optional<ClimbingGym> findByName(String gymName);
 
-    List<ClimbingGym> findByNameContaining(String gymName, Pageable pageable);
+    Page<ClimbingGym> findByNameContaining(String gymName, Pageable pageable);
 
-    List<ClimbingGym> findByNameContainingAndManagerIsNotNull(String gymName, Pageable pageable);
+    Page<ClimbingGym> findByNameContainingAndManagerIsNotNull(String gymName, Pageable pageable);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -2,10 +2,12 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -14,25 +16,33 @@ public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
 
-    public List<ClimbingGymSimpleResponse> searchClimbingGym(String gymName) {
-        Pageable pageable = PageRequest.of(0, 20);
-        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(gymName, pageable);
+    public PageResponseDto<List<ClimbingGymSimpleResponse>> searchClimbingGym(String gymName,
+        int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<ClimbingGym> climbingGymSlice = climbingGymRepository.findByNameContaining(gymName,
+            pageable);
 
-        return climbingGymList.stream()
+        List<ClimbingGymSimpleResponse> climbingGymList = climbingGymSlice.stream()
             .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))
             .toList();
 
+        return new PageResponseDto<>(pageable.getPageNumber(), climbingGymSlice.hasNext(),
+            climbingGymList);
+
     }
 
-    public List<AcceptedClimbingGymSimpleResponse> searchAcceptedClimbingGym(String gymName) {
-        Pageable pageable = PageRequest.of(0, 20);
-        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(
+    public PageResponseDto<List<AcceptedClimbingGymSimpleResponse>> searchAcceptedClimbingGym(
+        String gymName, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<ClimbingGym> climbingGymSlice = climbingGymRepository.findByNameContainingAndManagerIsNotNull(
             gymName, pageable);
 
-        return climbingGymList.stream()
+        List<AcceptedClimbingGymSimpleResponse> climbingGymList = climbingGymSlice.stream()
             .map(climbingGym -> AcceptedClimbingGymSimpleResponse.toDTO(climbingGym))
             .toList();
 
+        return new PageResponseDto<>(pageable.getPageNumber(), climbingGymSlice.hasNext(),
+            climbingGymList);
 
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -2,10 +2,7 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
-import com.climeet.climeet_backend.domain.shorts.dto.ShortsResponseDto.ShortsSimpleInfo;
-import com.climeet.climeet_backend.global.common.PageResponseDto;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +15,8 @@ public class ClimbingGymService {
     private final ClimbingGymRepository climbingGymRepository;
 
     public List<ClimbingGymSimpleResponse> searchClimbingGym(String gymName) {
-        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(gymName);
+        Pageable pageable = PageRequest.of(0, 20);
+        List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContaining(gymName, pageable);
 
         return climbingGymList.stream()
             .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))
@@ -27,8 +25,9 @@ public class ClimbingGymService {
     }
 
     public List<AcceptedClimbingGymSimpleResponse> searchAcceptedClimbingGym(String gymName) {
+        Pageable pageable = PageRequest.of(0, 20);
         List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(
-            gymName);
+            gymName, pageable);
 
         return climbingGymList.stream()
             .map(climbingGym -> AcceptedClimbingGymSimpleResponse.toDTO(climbingGym))

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.shorts.dto.ShortsResponseDto.ShortsSimpleInfo;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
@@ -25,12 +26,14 @@ public class ClimbingGymService {
 
     }
 
-    public List<ClimbingGymSimpleResponse> searchAcceptedClimbingGym(String gymName) {
+    public List<AcceptedClimbingGymSimpleResponse> searchAcceptedClimbingGym(String gymName) {
         List<ClimbingGym> climbingGymList = climbingGymRepository.findByNameContainingAndManagerIsNotNull(
             gymName);
 
         return climbingGymList.stream()
-            .map(climbingGym -> ClimbingGymSimpleResponse.toDTO(climbingGym))
+            .map(climbingGym -> AcceptedClimbingGymSimpleResponse.toDTO(climbingGym))
             .toList();
+
+
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -38,7 +38,26 @@ public class ClimbingGymService {
             gymName, pageable);
 
         List<AcceptedClimbingGymSimpleResponse> climbingGymList = climbingGymSlice.stream()
-            .map(climbingGym -> AcceptedClimbingGymSimpleResponse.toDTO(climbingGym))
+            .map(climbingGym -> {
+                Long managerId = null;
+                Long follower = 0L;
+                String profileImageUrl = null;
+                // manager 유무 확인
+                if (climbingGym.getManager() != null) {
+                    managerId = climbingGym.getManager().getId();
+                    // manager가 있으면 follower 조회
+                    if (climbingGym.getManager().getFollowerCount() != null) {
+                        follower = climbingGym.getManager().getFollowerCount();
+                    }
+                }
+                // 프로필이 있으면 조회
+                if (climbingGym.getProfileImageUrl() != null) {
+                    profileImageUrl = climbingGym.getProfileImageUrl();
+                }
+
+                return AcceptedClimbingGymSimpleResponse.toDTO(climbingGym, managerId, follower,
+                    profileImageUrl);
+            })
             .toList();
 
         return new PageResponseDto<>(pageable.getPageNumber(), climbingGymSlice.hasNext(),

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -30,7 +30,38 @@ public class ClimbingGymResponseDto {
                 .managerId(managerId)
                 .build();
         }
+
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AcceptedClimbingGymSimpleResponse {
+
+        private Long id;
+        private String name;
+        private Long managerId;
+        private Long follower;
+
+        public static AcceptedClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym) {
+            Long managerId = null;
+            Long follower = 0L;
+            if(climbingGym.getManager() != null){
+                managerId = climbingGym.getManager().getId();
+                if(climbingGym.getManager().getFollowerCount() != null){
+                    follower = climbingGym.getManager().getFollowerCount();
+                }
+            }
+
+            return AcceptedClimbingGymSimpleResponse.builder()
+                .id(climbingGym.getId())
+                .name(climbingGym.getName())
+                .managerId(managerId)
+                .follower(follower)
+                .build();
+        }
+
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -45,19 +45,8 @@ public class ClimbingGymResponseDto {
         private Long follower;
         private String profileImageUrl;
 
-        public static AcceptedClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym) {
-            Long managerId = null;
-            Long follower = 0L;
-            String profileImageUrl = null;
-            if(climbingGym.getManager() != null){
-                managerId = climbingGym.getManager().getId();
-                if(climbingGym.getManager().getFollowerCount() != null){
-                    follower = climbingGym.getManager().getFollowerCount();
-                }
-            }
-            if(climbingGym.getProfileImageUrl() != null){
-                profileImageUrl = climbingGym.getProfileImageUrl();
-            }
+        public static AcceptedClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym,
+            Long managerId, Long follower, String profileImageUrl) {
 
             return AcceptedClimbingGymSimpleResponse.builder()
                 .id(climbingGym.getId())

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -43,15 +43,20 @@ public class ClimbingGymResponseDto {
         private String name;
         private Long managerId;
         private Long follower;
+        private String profileImageUrl;
 
         public static AcceptedClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym) {
             Long managerId = null;
             Long follower = 0L;
+            String profileImageUrl = null;
             if(climbingGym.getManager() != null){
                 managerId = climbingGym.getManager().getId();
                 if(climbingGym.getManager().getFollowerCount() != null){
                     follower = climbingGym.getManager().getFollowerCount();
                 }
+            }
+            if(climbingGym.getProfileImageUrl() != null){
+                profileImageUrl = climbingGym.getProfileImageUrl();
             }
 
             return AcceptedClimbingGymSimpleResponse.builder()
@@ -59,6 +64,7 @@ public class ClimbingGymResponseDto {
                 .name(climbingGym.getName())
                 .managerId(managerId)
                 .follower(follower)
+                .profileImageUrl(profileImageUrl)
                 .build();
         }
 


### PR DESCRIPTION
## 요약
1. 등록된 암장 검색 시에, follower, profileImageUrl 반환 추가 (follower: 홈짐 추가 화면, profileImageUrl: 암장 검색 화면 전체에서 사용)
  - 따라서 등록된 암장, 등록되지 않은 암장의 ResponseDto를 분리
2. Pagenation 추가 (인자로 page, size 값을 받음)

## 상세 내용

- Search All 입니다. (암장 등록 여부에 상관없이 검색)
아래 화면에서 사용되는데, 슬랙에서 profileImage는 빠지는 것으로 이야기가 되어, 일단 제외했습니다.
<img width="311" alt="스크린샷 2024-01-25 오후 12 02 40" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/b0ff613a-a367-423d-8a73-b959d93afbd9">
아래와 같이 ResponseDto가 구성되어 프론트로 전달해주게 됩니다.
<img width="763" alt="스크린샷 2024-01-25 오전 11 57 21" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/53d609bb-545f-4f3d-b881-f68b5b1162a6">

- Search 입니다. (등록된 암장만 검색)
아래 화면에서 사용됩니다.
<img width="327" alt="스크린샷 2024-01-25 오후 12 01 10" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/f8ae7042-eaed-4cf2-a3b7-a061f96636be">
아래와 같이 ResponseDto가 구성되어 프론트로 전달해주게 됩니다.
<img width="772" alt="스크린샷 2024-01-25 오전 11 58 43" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/7647e8fb-21f3-4975-a12a-33369769458b">

## 테스트 확인 내용
위 설명에서 Dto 확인하시면 될 것 같습니다!

## 질문 및 이외 사항

- 따로 예외처리는 고려할 사항이 없는 것 같아 하지 않았습니다. 생각나는 예외가 있다면 공유 부탁합니다!
