### PR TITLE
[SPR-94] feat: 암장별 베스트클라이머 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
@@ -48,6 +48,8 @@ public class ClimbingRecord extends BaseTimeEntity {
     //도전횟수가 아닌 시도한 루트의 개수
     private int attemptRouteCount = 0;
 
+    private int highDifficulty;
+
     public static ClimbingRecord toEntity(User user, CreateClimbingRecordDto requestDto,
         ClimbingGym climbingGym) {
         return ClimbingRecord.builder()
@@ -57,6 +59,7 @@ public class ClimbingRecord extends BaseTimeEntity {
             .gym(climbingGym)
             .totalAttemptCount(0)
             .totalCompletedCount(0)
+            .highDifficulty(0)
             .avgDifficulty(requestDto.getAvgDifficulty())
             .build();
     }
@@ -65,6 +68,10 @@ public class ClimbingRecord extends BaseTimeEntity {
     public void update(LocalDate climbingDate, LocalTime climbingTime) {
         this.climbingDate = climbingDate;
         this.climbingTime = climbingTime;
+    }
+
+    public void setHighDifficulty(int difficulty){
+        this.highDifficulty = difficulty;
     }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -110,18 +110,21 @@ public class ClimbingRecordController {
 
     @Operation(summary = "[완등순] 암장별 클라이머 랭킹")
     @GetMapping("/gym/{gymId}/rank/clear")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
     public ResponseEntity<List<BestClearUserSimple>> findUserClearRanking(@PathVariable Long gymId){
         return ResponseEntity.ok(climbingRecordService.findBestClearUserRanking(gymId));
     }
 
     @Operation(summary = "[시간순] 암장별 클라이머 랭킹")
     @GetMapping("/gym/{gymId}/rank/time")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
     public ResponseEntity<List<BestTimeUserSimple>> findUserTimeRanking(@PathVariable Long gymId){
         return ResponseEntity.ok(climbingRecordService.findBestTimeUserRanking(gymId));
     }
 
     @Operation(summary = "[높은 레벨순] 암장별 클라이머 랭킹")
     @GetMapping("/gym/{gymId}/rank/level")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
     public ResponseEntity<List<BestLevelUserSimple>> findUserLevelRanking(@PathVariable Long gymId){
         return ResponseEntity.ok(climbingRecordService.findBestLevelUserRanking(gymId));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -2,6 +2,9 @@ package com.climeet.climeet_backend.domain.climbingrecord;
 
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.UpdateClimbingRecordDto;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.CreateClimbingRecordDto;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.BestClearUserSimple;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.BestLevelUserSimple;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.BestTimeUserSimple;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordDetailInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfo;
@@ -104,4 +107,23 @@ public class ClimbingRecordController {
         @RequestParam int month) {
         return ResponseEntity.ok(climbingRecordService.getClimbingRecordStatistics(user, year, month));
     }
+
+    @Operation(summary = "[완등순] 암장별 클라이머 랭킹")
+    @GetMapping("/gym/{gymId}/rank/clear")
+    public ResponseEntity<List<BestClearUserSimple>> findUserClearRanking(@PathVariable Long gymId){
+        return ResponseEntity.ok(climbingRecordService.findBestClearUserRanking(gymId));
+    }
+
+    @Operation(summary = "[시간순] 암장별 클라이머 랭킹")
+    @GetMapping("/gym/{gymId}/rank/time")
+    public ResponseEntity<List<BestTimeUserSimple>> findUserTimeRanking(@PathVariable Long gymId){
+        return ResponseEntity.ok(climbingRecordService.findBestTimeUserRanking(gymId));
+    }
+
+    @Operation(summary = "[높은 레벨순] 암장별 클라이머 랭킹")
+    @GetMapping("/gym/{gymId}/rank/level")
+    public ResponseEntity<List<BestLevelUserSimple>> findUserLevelRanking(@PathVariable Long gymId){
+        return ResponseEntity.ok(climbingRecordService.findBestLevelUserRanking(gymId));
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
@@ -1,10 +1,12 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.security.CurrentUser;
 import jakarta.persistence.Tuple;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,6 +26,39 @@ public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, 
         "   SUM(cr.attemptRouteCount) as attemptRouteCount " +
         "FROM ClimbingRecord cr " +
         "WHERE cr.climbingDate BETWEEN :startDate AND :endDate AND cr.user = :user")
-    Tuple getStatisticsInfoBetween(@Param("user") User user, @Param("startDate") LocalDate startDate,
+    Tuple getStatisticsInfoBetween(@Param("user") User user,
+        @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate);
+
+
+    @Query("SELECT " +
+        "cr.user, SUM(cr.totalCompletedCount) as totalCount " +
+        "FROM ClimbingRecord cr " +
+        "WHERE cr.climbingDate BETWEEN :startDate AND :endDate " +
+        "AND cr.gym = :climbingGym " +
+        "GROUP BY cr.user " +
+        "ORDER BY totalCount DESC")
+    List<Object[]> findByClearRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
+        LocalDate endDate, ClimbingGym climbingGym);
+
+    @Query("SELECT " +
+        "cr.user, SUM(HOUR(cr.climbingTime) * 3600 + MINUTE(cr.climbingTime) * 60 + SECOND(cr.climbingTime)) as totalTime " +
+        "FROM ClimbingRecord cr " +
+        "WHERE cr.climbingDate BETWEEN :startDate AND :endDate " +
+        "AND cr.gym = :climbingGym " +
+        "GROUP BY cr.user " +
+        "ORDER BY totalTime DESC")
+    List<Object[]> findByTimeRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
+        LocalDate endDate, ClimbingGym climbingGym);
+
+    @Query("SELECT " +
+        "cr.user, MAX(cr.highDifficulty) as highDifficulty " +
+        "FROM ClimbingRecord cr " +
+        "WHERE cr.climbingDate BETWEEN :startDate AND :endDate " +
+        "AND cr.gym = :climbingGym " +
+        "GROUP BY cr.user " +
+        "ORDER BY highDifficulty DESC")
+    List<Object[]> findByLevelRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
+        LocalDate endDate, ClimbingGym climbingGym);
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -47,6 +47,10 @@ public class ClimbingRecordService {
     private final RouteRecordRepository routeRecordRepository;
 
     public static final int START_DAY_OF_MONTH = 1;
+    public static final int MONDAY = 0;
+    public static final int SUNDAY = 1;
+    public static final int RANKING_USER = 0;
+    public static final int RANKING_CONDITION = 1;
 
 
     /**
@@ -134,7 +138,6 @@ public class ClimbingRecordService {
     /**
      * 클라이밍 기록 수정
      */
-    // TODO: 2024/01/21 업데이트 될 때 routeRecordDate도 업데이트 -> ㄴㄴ 그냥 루트기록date 삭제하면 될 듯
     @Transactional
     public ClimbingRecordSimpleInfo updateClimbingRecord(User user, Long id,
         UpdateClimbingRecordDto requestDto) {
@@ -223,13 +226,13 @@ public class ClimbingRecordService {
         Object[] lastWeek = startDayAndLastDayOfLastWeek();
 
         List<Object[]> bestUserRanking = climbingRecordRepository.findByClearRankingClimbingDateBetweenAndClimbingGym(
-            (LocalDate)lastWeek[0], (LocalDate)lastWeek[1], climbingGym);
+            (LocalDate)lastWeek[MONDAY], (LocalDate)lastWeek[SUNDAY], climbingGym);
 
         int[] rank = {1};
         List<BestClearUserSimple> ranking = bestUserRanking.stream()
             .map(userRankMap -> {
-                User user = (User) userRankMap[0];
-                Long totalCount = (Long) userRankMap[1];
+                User user = (User) userRankMap[RANKING_USER];
+                Long totalCount = (Long) userRankMap[RANKING_CONDITION];
                 return BestClearUserSimple.toDTO(user, rank[0]++, totalCount);
             })
             .collect(Collectors.toList());
@@ -244,13 +247,13 @@ public class ClimbingRecordService {
         Object[] lastWeek = startDayAndLastDayOfLastWeek();
 
         List<Object[]> bestUserRanking = climbingRecordRepository.findByTimeRankingClimbingDateBetweenAndClimbingGym(
-            (LocalDate)lastWeek[0], (LocalDate)lastWeek[1], climbingGym);
+            (LocalDate)lastWeek[MONDAY], (LocalDate)lastWeek[SUNDAY], climbingGym);
 
         int[] rank = {1};
         List<BestTimeUserSimple> ranking = bestUserRanking.stream()
             .map(userRankMap -> {
-                User user = (User) userRankMap[0];
-                LocalTime totalTime = convertDoubleToTime((Double) userRankMap[1]);
+                User user = (User) userRankMap[RANKING_USER];
+                LocalTime totalTime = convertDoubleToTime((Double) userRankMap[RANKING_CONDITION]);
                 return BestTimeUserSimple.toDTO(user, rank[0]++, totalTime);
             })
             .collect(Collectors.toList());
@@ -265,13 +268,13 @@ public class ClimbingRecordService {
         Object[] lastWeek = startDayAndLastDayOfLastWeek();
 
         List<Object[]> bestUserRanking = climbingRecordRepository.findByLevelRankingClimbingDateBetweenAndClimbingGym(
-            (LocalDate)lastWeek[0], (LocalDate)lastWeek[1], climbingGym);
+            (LocalDate)lastWeek[MONDAY], (LocalDate)lastWeek[SUNDAY], climbingGym);
 
         int[] rank = {1};
         List<BestLevelUserSimple> ranking = bestUserRanking.stream()
             .map(userRankMap -> {
-                User user = (User) userRankMap[0];
-                int highDifficulty = (int) userRankMap[1];
+                User user = (User) userRankMap[RANKING_USER];
+                int highDifficulty = (int) userRankMap[RANKING_CONDITION];
                 return BestLevelUserSimple.toDTO(user, rank[0]++, highDifficulty);
             })
             .collect(Collectors.toList());
@@ -304,8 +307,8 @@ public class ClimbingRecordService {
 
         Object[] lastWeek = new Object[2];
 
-        lastWeek[0] = startOfLastWeek;
-        lastWeek[1] = endOfLastWeek;
+        lastWeek[MONDAY] = startOfLastWeek;
+        lastWeek[SUNDAY] = endOfLastWeek;
 
         return lastWeek;
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -2,6 +2,9 @@ package com.climeet.climeet_backend.domain.climbingrecord.dto;
 
 import com.climeet.climeet_backend.domain.climbingrecord.ClimbingRecord;
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto.RouteRecordSimpleInfo;
+import com.climeet.climeet_backend.domain.user.User;
+import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -91,6 +94,76 @@ public class ClimbingRecordResponseDto {
                 .totalCompletedCount(totalCompletedCount)
                 .attemptRouteCount(attemptRouteCount)
                 .difficulty(difficulty)
+                .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BestClearUserSimple {
+
+        private Long totalCompletedCount;
+        private Long userId;
+        protected String profileName;
+        protected String profileImageUrl;
+        private int ranking;
+
+        public static BestClearUserSimple toDTO(User user, int ranking, Long totalCompletedCount) {
+            return BestClearUserSimple.builder()
+                .ranking(ranking)
+                .userId(user.getId())
+                .profileImageUrl(user.getProfileImageUrl())
+                .profileName(user.getProfileName())
+                .totalCompletedCount(totalCompletedCount)
+                .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BestLevelUserSimple {
+
+        private int highDifficulty;
+        private Long userId;
+        protected String profileName;
+        protected String profileImageUrl;
+        private int ranking;
+
+        public static BestLevelUserSimple toDTO(User user, int ranking, int highDifficulty) {
+            return BestLevelUserSimple.builder()
+                .ranking(ranking)
+                .userId(user.getId())
+                .profileImageUrl(user.getProfileImageUrl())
+                .profileName(user.getProfileName())
+                .highDifficulty(highDifficulty)
+                .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BestTimeUserSimple {
+
+        private LocalTime totalTime;
+
+        private Long userId;
+        protected String profileName;
+        protected String profileImageUrl;
+        private int ranking;
+        public static BestTimeUserSimple toDTO(User user, int ranking, LocalTime totalTime) {
+
+            return BestTimeUserSimple.builder()
+                .ranking(ranking)
+                .userId(user.getId())
+                .profileImageUrl(user.getProfileImageUrl())
+                .profileName(user.getProfileName())
+                .totalTime(totalTime)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -158,6 +158,10 @@ public class RouteRecordService {
 
         int difficulty = routeRecord.getRoute().getDifficulty();
 
+        if(climbingRecord.getHighDifficulty() < difficulty){
+            climbingRecord.setHighDifficulty(difficulty);
+        }
+
         //climbingRecord의 평균 업데이트
         climbingRecord.setAvgDifficulty(
             newAvgDifficulty(difficulty, climbingRecord.getAvgDifficulty(),


### PR DESCRIPTION
## 요약
- 암장별 베스트클라이머(완등)
- 암장별 베스트클라이머(시간)
- 암장별 베스트클라이머(고수)
- startDayAndLastDayOfLastWeek: 지난 주 날짜범위 계산

## 상세 내용
- 세 가지의 방식이 쿼리문을 제외하고는 거의 비슷하기에 "[완등] 베스트클라이머" 대해서 자세하게 설명드리겠습니다.
### ClimbingRecordController.java
```java
 @Operation(summary = "[완등순] 암장별 클라이머 랭킹")
    @GetMapping("/gym/{gymId}/rank/clear")
    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
    public ResponseEntity<List<BestClearUserSimple>> findUserClearRanking(@PathVariable Long gymId){
        return ResponseEntity.ok(climbingRecordService.findBestClearUserRanking(gymId));
    }
```
- 먼저 컨트롤러입니다.
- 검색하고 싶은 암장의 id를 PathVariable값으로 하여 호출합니다.

### ClimbingRecordService.java
```java
public List<BestClearUserSimple> findBestClearUserRanking(Long climbingGymId) {
        ClimbingGym climbingGym = gymRepository.findById(climbingGymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));

        Object[] lastWeek = startDayAndLastDayOfLastWeek();

        List<Object[]> bestUserRanking = climbingRecordRepository.findByClearRankingClimbingDateBetweenAndClimbingGym(
            (LocalDate)lastWeek[0], (LocalDate)lastWeek[1], climbingGym);

        int[] rank = {1};
        List<BestClearUserSimple> ranking = bestUserRanking.stream()
            .map(userRankMap -> {
                User user = (User) userRankMap[0];
                Long totalCount = (Long) userRankMap[1];
                return BestClearUserSimple.toDTO(user, rank[0]++, totalCount);
            })
            .collect(Collectors.toList());

        return ranking;
    }
```
- 암장별 베스트 클라이머는 다음과 같은 공통된 두 가지 조건이 있습니다.
1. 팔로우가 되어있는 유저들로 제한한다.
2. 조회를 하는 금주 기준으로 지난 주 기록된 기록들로 랭킹을 책정한다.
- 우선 1번 조건은 아직 팔로우 기능이 완벽하게 완성되지는 않았기 때문에 해당 기능이 완성되면 ClimbingRecord에 팔로우가 되어있는 지 확인하는 필드를 넣어 구현할 생각입니다.
- 2번 조건을 만족시키기 위해 startDayAndLastDayOfLastWeek() 함수를 구현하였습니다.(구현 내용은 상세 내용 마지막에 정리하겠습니다.)
- 해당 함수로 지난 주의 월~일요일을 책정할 범위로 구하였습니다.
- 해당 범위는 climbingRecordRepository에서 User들의 리스트를 구하는 데에 사용됩니다.(해당 함수도 마지막에 정리하겠습니다.)
- 그렇게 구해온 User의 리스트를 BestClearUserSimple이라는 dto로 변환시켜 반환합니다.
- 참고로 각 유저들과 그에 맞는 clearCount 를 쿼리로 뽑아오기 위해 Object[] 자료구조를 활용하였습니다.

###  startDayAndLastDayOfLastWeek()
```java
public static Object[] startDayAndLastDayOfLastWeek(){
        // 현재 시점 날짜 정보 가져오기
        LocalDate today = LocalDate.now();

        // 금주의 월요일
        LocalDate startOfThisWeek = today.with(
            TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));

        // 지난 주의 월요일
        LocalDate startOfLastWeek = startOfThisWeek.minusDays(7);
        //지난 주의 일요일
        LocalDate endOfLastWeek = startOfThisWeek.minusDays(1);

        Object[] lastWeek = new Object[2];

        lastWeek[0] = startOfLastWeek;
        lastWeek[1] = endOfLastWeek;
        /Object[] 반환
        return lastWeek;
    }
```
### ClimbingRecordRepository.findByClearRankingClimbingDateBetweenAndClimbingGym()
```java
    @Query("SELECT " +
        "cr.user, SUM(cr.totalCompletedCount) as totalCount " +
        "FROM ClimbingRecord cr " +
        "WHERE cr.climbingDate BETWEEN :startDate AND :endDate " +
        "AND cr.gym = :climbingGym " +
        "GROUP BY cr.user " +
        "ORDER BY totalCount DESC")
    List<Object[]> findByClearRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
        LocalDate endDate, ClimbingGym climbingGym);
```
- 해당 쿼리는 ClimbingRecord테이블에서 범위 안에 있는 항목들을 뽑아옵니다.
- 해당 항목들에 대해 user그룹으로 묶습니다.
- 묶을 때 completeCount를 더해주고 해당 필드를 조건으로 내림차순 정렬을 진행합니다.

## 테스트 확인 내용
<img width="783" alt="스크린샷 2024-01-26 오후 6 36 12" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/0ee14576-468c-451b-9a1c-19aea35325b2">
- ClimbingRecord 테이블에는 여러 가지 필드가 있지만 그 중 total_completed_count, high_difficulty, Climbing_time이 저장되어 있습니다.
- 또한 이들은 하나의 gym에서 두 명의 유저가 기록했다는 사실을 알 수 있습니다.

### [완등] 베스트클라이머
<img width="505" alt="스크린샷 2024-01-26 오후 6 39 24" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/e99e0dd2-15fa-435e-b8d8-731d92d38250">

- 유저별 완등한 횟수와 랭킹을 확인할 수 있습니다.
- 위 스크린샷을 확인하면 알 수 있듯이 총 완등한 횟수가 더해져서 랭킹이 매겨집니다.

### [고수] 베스트클라이머
<img width="544" alt="스크린샷 2024-01-26 오후 6 41 30" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/7c3fcf5d-50cc-4812-b976-a517e33df4e8">

- 유저별 가장 높은 레벨을 기준으로 랭킹이 매겨진 것을 볼 수 있습니다.

### [시간] 베스트클라이머
<img width="518" alt="스크린샷 2024-01-26 오후 6 37 45" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/e524792d-1ab6-4187-8ca4-57777d3f80d0">

- 유저가 총 운동한 시간과 랭킹을 확인할 수 있습니다.
- 총 운동한 시간이 합쳐진 것을 볼 수 있습니다.

### 한 유저가 만든 climbingRecord의 gymId를 전부 바꾸면?
<img width="424" alt="스크린샷 2024-01-26 오후 6 42 12" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/4a18f793-23df-4d2a-9f71-cfe7090987ea">
<img width="514" alt="스크린샷 2024-01-26 오후 6 42 56" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/d655e73f-f4e6-43b8-b6e1-2d895e004b25">

- 1번 gymId에 속해있는 결과만 나오는 것을 확인할 수 있습니다.

### 한 유저의 만든 특정 climbingRecord의 gymId를 바꾸면?
<img width="472" alt="스크린샷 2024-01-26 오후 6 44 16" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/cd2cc8bd-b3bf-44d9-9d34-4068c3740e17">
<img width="557" alt="스크린샷 2024-01-26 오후 6 45 11" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/e3f7ccfd-cf7b-4b9c-8caf-f43b5d0293d1">

- 해당 기록은 제외된 결과를 볼 수 있습니다.
- "totalTime": "02:52:03" ->  "totalTime": "00:01:16",

## 질문 및 이외 사항

- 역시나 운동기록 시간에 대해 LocalTime을 아직 Long으로 바꾸지 않았습니다. 한번 모여서 다른 분들의 코드도 점검하고 나서 전체적으로 바꾸는 것이 맞을 것 같습니다.
- 지난 주 기록된 결과에 따른 랭킹으로 고정이지만 해당 코드는 API 요청 시마다 랭킹을 계산해서 보여줍니다. 문제는 같은 요청에 대해서는 해당 결과가 늘 같을 것이라는 점입니다.
- 홈화면의 베스트시리즈들처럼 테이블을 따로 빼지 않은 것은 부하테스트 시 어느 정도의 오버헤드가 있는 지 테스트하고 싶어서입니다.
- 높은 확률로 최종적으로는 따로 테이블을 빼서 구현하는 방식으로 리팩토링 진행할 것 같습니다.
