### PR TITLE
[SPR-98] 루트, 섹터 수정  및 루트버전 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -42,6 +42,10 @@ public class ClimbingGym extends BaseTimeEntity {
 
     private String layoutImageUrl;
 
+    public void changeLayoutImageUrl(String layoutImageUrl) {
+        this.layoutImageUrl = layoutImageUrl;
+    }
+
     private Float AverageRating = 0.0F;
 
     private Float sumRating = 0.0F;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,9 +10,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "ClimbingGym", description = "암장 관련 API")
 @RestController
@@ -35,6 +39,14 @@ public class ClimbingGymController {
         @RequestParam("gymname") String gymName, @RequestParam int page, @RequestParam int size
     ) {
         return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName, page, size));
+    }
+
+    @Operation(summary = "암장 도면 이미지 수정")
+    @PostMapping("/layout")
+    public ResponseEntity<LayoutDetailResponse> changeLayoutImage(
+        @RequestPart Long gymId,
+        @RequestPart MultipartFile layoutImage) {
+        return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, gymId));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -2,19 +2,25 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import com.climeet.climeet_backend.global.s3.S3Service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
+    private final S3Service s3Service;
 
     public PageResponseDto<List<ClimbingGymSimpleResponse>> searchClimbingGym(String gymName,
         int page, int size) {
@@ -63,5 +69,17 @@ public class ClimbingGymService {
         return new PageResponseDto<>(pageable.getPageNumber(), climbingGymSlice.hasNext(),
             climbingGymList);
 
+    }
+
+    public LayoutDetailResponse changeLayoutImage(MultipartFile layoutImage, Long gymId) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
+        climbingGym.changeLayoutImageUrl(layoutImageUrl);
+
+        climbingGymRepository.save(climbingGym);
+
+        return LayoutDetailResponse.toDto(layoutImageUrl);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -21,7 +21,7 @@ public class ClimbingGymResponseDto {
 
         public static ClimbingGymSimpleResponse toDTO(ClimbingGym climbingGym) {
             Long managerId = null;
-            if(climbingGym.getManager() != null){
+            if (climbingGym.getManager() != null) {
                 managerId = climbingGym.getManager().getId();
             }
             return ClimbingGymSimpleResponse.builder()
@@ -57,6 +57,21 @@ public class ClimbingGymResponseDto {
                 .build();
         }
 
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LayoutDetailResponse {
+
+        private String layoutImageUrl;
+
+        public static LayoutDetailResponse toDto(String layoutImageUrl) {
+            return LayoutDetailResponse.builder()
+                .layoutImageUrl(layoutImageUrl)
+                .build();
+        }
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -33,9 +33,6 @@ public class Route extends BaseTimeEntity {
     Sector sector;
 
     @NotNull
-    private String name;
-
-    @NotNull
     private int difficulty;
 
     private String routeImageUrl;
@@ -52,7 +49,6 @@ public class Route extends BaseTimeEntity {
         String routeImageUrl) {
         return Route.builder()
             .sector(sector)
-            .name(requestDto.getName())
             .difficulty(requestDto.getDifficulty())
             .routeImageUrl(routeImageUrl)
             .build();

--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -1,7 +1,6 @@
 package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
-import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
@@ -46,7 +45,7 @@ public class Route extends BaseTimeEntity {
     @ColumnDefault("0")
     private int selectionCount;
 
-    public static Route toEntity(CreateRouteRequest requestDto, Sector sector,
+    public static Route toEntity(Sector sector,
         String routeImageUrl, DifficultyMapping difficultyMapping) {
         return Route.builder()
             .sector(sector)

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteIdSimpleResponse;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,12 +27,11 @@ public class RouteController {
 
     @Operation(summary = "클라이밍 루트 생성")
     @PostMapping("/route")
-    public ResponseEntity<String> createRoute(
+    public ResponseEntity<RouteIdSimpleResponse> createRoute(
         @RequestPart(value = "image") MultipartFile routeImage,
         @RequestPart CreateRouteRequest createRouteRequest
     ) {
-        routeService.createRoute(createRouteRequest, routeImage);
-        return ResponseEntity.ok("루트를 추가했습니다.");
+        return ResponseEntity.ok(routeService.createRoute(createRouteRequest, routeImage));
     }
 
     @Operation(summary = "클라이밍 루트 조회")

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -3,6 +3,10 @@ package com.climeet.climeet_backend.domain.route;
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteIdSimpleResponse;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -26,23 +30,28 @@ public class RouteController {
     private final RouteService routeService;
 
     @Operation(summary = "클라이밍 루트 생성")
+    @SwaggerApiError({ErrorStatus._EMPTY_SECTOR})
     @PostMapping("/route")
     public ResponseEntity<RouteIdSimpleResponse> createRoute(
         @RequestPart(value = "image") MultipartFile routeImage,
-        @RequestPart CreateRouteRequest createRouteRequest
+        @RequestPart CreateRouteRequest createRouteRequest, @CurrentUser User user
     ) {
         return ResponseEntity.ok(routeService.createRoute(createRouteRequest, routeImage));
     }
 
     @Operation(summary = "클라이밍 루트 조회")
+    @SwaggerApiError({ErrorStatus._EMPTY_ROUTE})
     @GetMapping("/route/{routeId}")
-    public ResponseEntity<RouteDetailResponse> getRoute(@PathVariable Long routeId) {
+    public ResponseEntity<RouteDetailResponse> getRoute(@PathVariable Long routeId,
+        @CurrentUser User user) {
         return ResponseEntity.ok(routeService.getRoute(routeId));
     }
 
     @Operation(summary = "클라이밍 암장 루트 목록 조회")
+    @SwaggerApiError({ErrorStatus._EMPTY_ROUTE_LIST})
     @GetMapping("/{gymId}/routes")
-    public ResponseEntity<List<RouteDetailResponse>> getRouteList(@PathVariable Long gymId) {
+    public ResponseEntity<List<RouteDetailResponse>> getRouteList(@PathVariable Long gymId,
+        @CurrentUser User user) {
         return ResponseEntity.ok(routeService.getRouteList(gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -36,7 +36,7 @@ public class RouteController {
         @RequestPart(value = "image") MultipartFile routeImage,
         @RequestPart CreateRouteRequest createRouteRequest, @CurrentUser User user
     ) {
-        return ResponseEntity.ok(routeService.createRoute(createRouteRequest, routeImage));
+        return ResponseEntity.ok(routeService.createRoute(createRouteRequest, routeImage, user));
     }
 
     @Operation(summary = "클라이밍 루트 조회")

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -1,8 +1,8 @@
 package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteIdSimpleResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -36,13 +36,13 @@ public class RouteController {
 
     @Operation(summary = "클라이밍 루트 조회")
     @GetMapping("/route/{routeId}")
-    public ResponseEntity<RouteSimpleResponse> getRoute(@PathVariable Long routeId) {
+    public ResponseEntity<RouteDetailResponse> getRoute(@PathVariable Long routeId) {
         return ResponseEntity.ok(routeService.getRoute(routeId));
     }
 
     @Operation(summary = "클라이밍 암장 루트 목록 조회")
     @GetMapping("/{gymId}/routes")
-    public ResponseEntity<List<RouteSimpleResponse>> getRouteList(@PathVariable Long gymId) {
+    public ResponseEntity<List<RouteDetailResponse>> getRouteList(@PathVariable Long gymId) {
         return ResponseEntity.ok(routeService.getRouteList(gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -2,7 +2,7 @@ package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteIdSimpleResponse;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
@@ -32,7 +32,7 @@ public class RouteController {
     @Operation(summary = "클라이밍 루트 생성")
     @SwaggerApiError({ErrorStatus._EMPTY_SECTOR})
     @PostMapping("/route")
-    public ResponseEntity<RouteIdSimpleResponse> createRoute(
+    public ResponseEntity<RouteSimpleResponse> createRoute(
         @RequestPart(value = "image") MultipartFile routeImage,
         @RequestPart CreateRouteRequest createRouteRequest, @CurrentUser User user
     ) {

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -1,13 +1,15 @@
 package com.climeet.climeet_backend.domain.route;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
+
     List<Route> findBySectorClimbingGymId(Long gymId);
 
     List<Route> findBySectorId(Long sectorId);
 
     Route findByRouteImageUrl(String routeImageUrl);
+
+    List<Route> findByIdIn(List<Long> routeIdList);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -8,4 +8,6 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     List<Route> findBySectorClimbingGymId(Long gymId);
 
     List<Route> findBySectorId(Long sectorId);
+
+    Route findByRouteImageUrl(String routeImageUrl);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -1,8 +1,8 @@
 package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteIdSimpleResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -40,20 +40,20 @@ public class RouteService {
         return RouteIdSimpleResponse.toDto(route);
     }
 
-    public RouteSimpleResponse getRoute(Long routeId) {
+    public RouteDetailResponse getRoute(Long routeId) {
         Route route = routeRepository.findById(routeId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_ROUTE));
 
-        return RouteSimpleResponse.toDto(route);
+        return RouteDetailResponse.toDto(route);
     }
 
-    public List<RouteSimpleResponse> getRouteList(Long gymId) {
+    public List<RouteDetailResponse> getRouteList(Long gymId) {
         List<Route> routeList = routeRepository.findBySectorClimbingGymId(gymId);
         if (routeList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
         }
         return routeList.stream()
-            .map(route -> RouteSimpleResponse.toDto(route))
+            .map(route -> RouteDetailResponse.toDto(route))
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -1,10 +1,7 @@
 package com.climeet.climeet_backend.domain.route;
 
-import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
-import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
@@ -35,10 +32,11 @@ public class RouteService {
 
     @Transactional
     public RouteSimpleResponse createRoute(CreateRouteRequest createRouteRequest,
-        MultipartFile routeImage) {
+        MultipartFile routeImage, User user) {
 
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
+
         DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndGymDifficulty(
             manager.getClimbingGym(), createRouteRequest.getDifficulty());
 
@@ -47,7 +45,7 @@ public class RouteService {
 
         String routeImageUrl = s3Service.uploadFile(routeImage).getImgUrl();
 
-        Route route = routeRepository.save(Route.toEntity(createRouteRequest, sector, routeImageUrl));
+        Route route = routeRepository.save(Route.toEntity(sector, routeImageUrl, difficultyMapping));
 
         return RouteSimpleResponse.toDto(route);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -32,10 +32,7 @@ public class RouteService {
 
         String routeImageUrl = s3Service.uploadFile(routeImage).getImgUrl();
 
-        routeRepository.save(Route.toEntity(createRouteRequest, sector, routeImageUrl));
-
-        // Route Id 값을 반환하기 위해 사용
-        Route route = routeRepository.findByRouteImageUrl(routeImageUrl);
+        Route route = routeRepository.save(Route.toEntity(createRouteRequest, sector, routeImageUrl));
 
         return RouteSimpleResponse.toDto(route);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -2,7 +2,7 @@ package com.climeet.climeet_backend.domain.route;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteIdSimpleResponse;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -24,7 +24,7 @@ public class RouteService {
     private final S3Service s3Service;
 
     @Transactional
-    public RouteIdSimpleResponse createRoute(CreateRouteRequest createRouteRequest,
+    public RouteSimpleResponse createRoute(CreateRouteRequest createRouteRequest,
         MultipartFile routeImage) {
 
         Sector sector = sectorRepository.findById(createRouteRequest.getSectorId())
@@ -37,7 +37,7 @@ public class RouteService {
         // Route Id 값을 반환하기 위해 사용
         Route route = routeRepository.findByRouteImageUrl(routeImageUrl);
 
-        return RouteIdSimpleResponse.toDto(route);
+        return RouteSimpleResponse.toDto(route);
     }
 
     public RouteDetailResponse getRoute(Long routeId) {
@@ -53,7 +53,7 @@ public class RouteService {
             throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
         }
         return routeList.stream()
-            .map(route -> RouteDetailResponse.toDto(route))
+            .map(RouteDetailResponse::toDto)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -10,7 +10,6 @@ public class RouteRequestDto {
     public static class CreateRouteRequest {
 
         private Long sectorId;
-        private String name;
         private int difficulty;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -10,7 +10,7 @@ public class RouteResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RouteSimpleResponse {
+    public static class RouteDetailResponse {
 
         private Long routeId;
         private Long sectorId;
@@ -18,8 +18,8 @@ public class RouteResponseDto {
         private int difficulty;
         private String routeImageUrl;
 
-        public static RouteSimpleResponse toDto(Route route) {
-            return RouteSimpleResponse.builder()
+        public static RouteDetailResponse toDto(Route route) {
+            return RouteDetailResponse.builder()
                 .routeId(route.getId())
                 .sectorId(route.getSector().getId())
                 .sectorName(route.getSector().getSectorName())

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -33,12 +33,12 @@ public class RouteResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RouteIdSimpleResponse {
+    public static class RouteSimpleResponse {
 
         private Long routeId;
 
-        public static RouteIdSimpleResponse toDto(Route route) {
-            return RouteIdSimpleResponse.builder()
+        public static RouteSimpleResponse toDto(Route route) {
+            return RouteSimpleResponse.builder()
                 .routeId(route.getId())
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -6,25 +6,41 @@ import lombok.*;
 public class RouteResponseDto {
 
 
+    @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RouteSimpleResponse {
 
+        private Long routeId;
         private Long sectorId;
         private String sectorName;
-        private Long routeId;
-        private String routeName;
         private int difficulty;
         private String routeImageUrl;
 
-        public RouteSimpleResponse(Route route) {
-            this.sectorId = route.getSector().getId();
-            this.sectorName = route.getSector().getSectorName();
-            this.routeId = route.getId();
-            this.routeName = route.getName();
-            this.difficulty = route.getDifficulty();
-            this.routeImageUrl = route.getRouteImageUrl();
+        public static RouteSimpleResponse toDto(Route route) {
+            return RouteSimpleResponse.builder()
+                .routeId(route.getId())
+                .sectorId(route.getSector().getId())
+                .sectorName(route.getSector().getSectorName())
+                .difficulty(route.getDifficulty())
+                .routeImageUrl(route.getRouteImageUrl())
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RouteIdSimpleResponse {
+
+        private Long routeId;
+
+        public static RouteIdSimpleResponse toDto(Route route) {
+            return RouteIdSimpleResponse.builder()
+                .routeId(route.getId())
+                .build();
         }
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -15,7 +15,10 @@ public class RouteResponseDto {
         private Long routeId;
         private Long sectorId;
         private String sectorName;
-        private int difficulty;
+        private String climeetDifficultyName;
+        private int gymDifficulty;
+        private String gymDifficultyName;
+        private String gymDifficultyColor;
         private String routeImageUrl;
 
         public static RouteDetailResponse toDto(Route route) {
@@ -23,7 +26,10 @@ public class RouteResponseDto {
                 .routeId(route.getId())
                 .sectorId(route.getSector().getId())
                 .sectorName(route.getSector().getSectorName())
-                .difficulty(route.getDifficulty())
+                .climeetDifficultyName(route.getDifficultyMapping().getClimeetDifficulty().getStringValue())
+                .gymDifficulty(route.getDifficultyMapping().getGymDifficulty())
+                .gymDifficultyName(route.getDifficultyMapping().getGymDifficultyName())
+                .gymDifficultyColor(route.getDifficultyMapping().getGymDifficultyColor())
                 .routeImageUrl(route.getRouteImageUrl())
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
@@ -2,7 +2,6 @@ package com.climeet.climeet_backend.domain.routeversion;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -10,17 +9,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.joda.time.LocalDate;
 
+@Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class RouteVersion extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,4 +38,16 @@ public class RouteVersion extends BaseTimeEntity {
 
     @NotNull
     private String sectorList;
+
+
+    public static RouteVersion toEntity(ClimbingGym climbingGym, LocalDate timePoint,
+        String routeList,
+        String sectorList) {
+        return RouteVersion.builder()
+            .climbingGym(climbingGym)
+            .timePoint(timePoint)
+            .routeList(routeList)
+            .sectorList(sectorList)
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -2,7 +2,9 @@ package com.climeet.climeet_backend.domain.routeversion;
 
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +32,7 @@ public class RouteVersionController {
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION_LIST})
     @GetMapping("/version/list")
     public ResponseEntity<List<LocalDate>> getRouteVersionList(
-        @RequestParam Long gymId) {
+        @CurrentUser User user, @RequestParam Long gymId) {
         List<LocalDate> routeVersionList = routeVersionService.getRouteVersionList(gymId);
         return ResponseEntity.ok(routeVersionList);
     }
@@ -40,8 +42,7 @@ public class RouteVersionController {
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
     @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
-        @RequestBody CreateRouteVersionRequest createRouteVersionRequest
-    ) {
+        @RequestBody CreateRouteVersionRequest createRouteVersionRequest) {
         routeVersionService.createRouteVersion(createRouteVersionRequest);
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
@@ -52,8 +53,8 @@ public class RouteVersionController {
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
     @GetMapping("/version")
     public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(
-        @RequestParam Long gymId, @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint
-    ) {
+        @CurrentUser User user, @RequestParam Long gymId,
+        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
         return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.routeversion;
 
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
@@ -7,25 +8,27 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "ClimbingRoute", description = "클라이밍 루트 API")
+@Tag(name = "RouteVersion", description = "암장 루트 버전 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/gym/version")
+@RequestMapping("api/gym")
 public class RouteVersionController {
 
     private final RouteVersionService routeVersionService;
 
     @Operation(summary = "암장의 루트 버전 일자 목록")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION_LIST})
-    @GetMapping("/list")
+    @GetMapping("/version/list")
     public ResponseEntity<List<LocalDate>> getRouteVersionList(
         @RequestParam Long gymId) {
         List<LocalDate> routeVersionList = routeVersionService.getRouteVersionList(gymId);
@@ -33,16 +36,23 @@ public class RouteVersionController {
     }
 
     @Operation(summary = "암장의 루트 버전 추가")
-    @PostMapping("")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._DUPLICATE_ROUTE_VERSION,
+        ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
+    @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
+        @RequestBody CreateRouteVersionRequest createRouteVersionRequest
     ) {
+        routeVersionService.createRouteVersion(createRouteVersionRequest);
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 
     @Operation(summary = "암장 특정 루트 버전 데이터 불러오기")
-    @GetMapping("")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
+        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._EMPTY_SECTOR_LIST,
+        ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
+    @GetMapping("/version")
     public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(
-        @RequestParam Long gymId, @RequestParam LocalDate timePoint
+        @RequestParam Long gymId, @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint
     ) {
         return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -42,8 +42,8 @@ public class RouteVersionController {
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
     @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
-        @RequestBody CreateRouteVersionRequest createRouteVersionRequest) {
-        routeVersionService.createRouteVersion(createRouteVersionRequest);
+        @RequestBody CreateRouteVersionRequest createRouteVersionRequest, @CurrentUser User user) {
+        routeVersionService.createRouteVersion(createRouteVersionRequest, user);
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -1,0 +1,49 @@
+package com.climeet.climeet_backend.domain.routeversion;
+
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.joda.time.LocalDate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "ClimbingRoute", description = "클라이밍 루트 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/gym/version")
+public class RouteVersionController {
+
+    private final RouteVersionService routeVersionService;
+
+    @Operation(summary = "암장의 루트 버전 일자 목록")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION_LIST})
+    @GetMapping("/list")
+    public ResponseEntity<List<LocalDate>> getRouteVersionList(
+        @RequestParam Long gymId) {
+        List<LocalDate> routeVersionList = routeVersionService.getRouteVersionList(gymId);
+        return ResponseEntity.ok(routeVersionList);
+    }
+
+    @Operation(summary = "암장의 루트 버전 추가")
+    @PostMapping("")
+    public ResponseEntity<String> createRouteVersion(
+    ) {
+        return ResponseEntity.ok("루트 버전이 추가되었습니다.");
+    }
+
+    @Operation(summary = "암장 특정 루트 버전 데이터 불러오기")
+    @GetMapping("")
+    public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(
+        @RequestParam Long gymId, @RequestParam LocalDate timePoint
+    ) {
+        return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionConverter.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionConverter.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 public class RouteVersionConverter {
 
     // "[1,2,3,4,5]" -> [1, 2, 3, 4, 5]
-    public List<Long> convertStringToList(String stringToConvert) {
+    public static List<Long> convertStringToList(String stringToConvert) {
 
         String[] longList = stringToConvert.substring(1, stringToConvert.length() - 1).split(",");
         return Arrays.stream(longList)
@@ -16,7 +16,7 @@ public class RouteVersionConverter {
     }
 
     // [1, 2, 3, 4, 5] -> "[1,2,3,4,5]"
-    public String convertListToString(List<Long> listToConvert) {
+    public static String convertListToString(List<Long> listToConvert) {
         String result = listToConvert.stream()
             .map(String::valueOf)
             .collect(Collectors.joining(","));

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionConverter.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionConverter.java
@@ -1,0 +1,26 @@
+package com.climeet.climeet_backend.domain.routeversion;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RouteVersionConverter {
+
+    // "[1,2,3,4,5]" -> [1, 2, 3, 4, 5]
+    public List<Long> convertStringToList(String stringToConvert) {
+
+        String[] longList = stringToConvert.substring(1, stringToConvert.length() - 1).split(",");
+        return Arrays.stream(longList)
+            .map(Long::parseLong)
+            .toList();
+    }
+
+    // [1, 2, 3, 4, 5] -> "[1,2,3,4,5]"
+    public String convertListToString(List<Long> listToConvert) {
+        String result = listToConvert.stream()
+            .map(String::valueOf)
+            .collect(Collectors.joining(","));
+        return "[" + result + "]";
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionRepository.java
@@ -1,0 +1,15 @@
+package com.climeet.climeet_backend.domain.routeversion;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import java.util.List;
+import java.util.Optional;
+import org.joda.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RouteVersionRepository extends JpaRepository<RouteVersion, Long> {
+    List<RouteVersion> findByClimbingGymOrderByTimePointDesc(ClimbingGym climbingGym);
+
+    Optional<RouteVersion> findByClimbingGymAndTimePoint(ClimbingGym climbingGym, LocalDate timePoint);
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionRepository.java
@@ -3,7 +3,7 @@ package com.climeet.climeet_backend.domain.routeversion;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import java.util.List;
 import java.util.Optional;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -2,6 +2,8 @@ package com.climeet.climeet_backend.domain.routeversion;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.manager.Manager;
+import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.domain.route.Route;
 import com.climeet.climeet_backend.domain.route.RouteRepository;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
@@ -10,6 +12,7 @@ import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseD
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import java.util.List;
@@ -26,14 +29,14 @@ public class RouteVersionService {
     private final RouteVersionRepository routeVersionRepository;
     private final RouteRepository routeRepository;
     private final SectorRepository sectorRepository;
+    private final ManagerRepository managerRepository;
 
-    public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest) {
-        ClimbingGym climbingGym = climbingGymRepository.findById(
-                createRouteVersionRequest.getGymId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+    public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user) {
+        Manager manager = managerRepository.findById(user.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
         Optional<RouteVersion> routeVersionOptional = routeVersionRepository.findByClimbingGymAndTimePoint(
-            climbingGym, createRouteVersionRequest.getTimePoint());
+            manager.getClimbingGym(), createRouteVersionRequest.getTimePoint());
         if (routeVersionOptional.isPresent()) {
             throw new GeneralException(ErrorStatus._DUPLICATE_ROUTE_VERSION);
         }
@@ -56,7 +59,7 @@ public class RouteVersionService {
             createRouteVersionRequest.getSectorIdList());
 
         routeVersionRepository.save(
-            RouteVersion.toEntity(climbingGym, createRouteVersionRequest.getTimePoint(),
+            RouteVersion.toEntity(manager.getClimbingGym(), createRouteVersionRequest.getTimePoint(),
                 routeIdListString, sectorIdListString));
 
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -31,6 +31,19 @@ public class RouteVersionService {
     private final SectorRepository sectorRepository;
     private final ManagerRepository managerRepository;
 
+    public List<LocalDate> getRouteVersionList(Long gymId) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+        List<RouteVersion> routeVersionList = routeVersionRepository.findByClimbingGymOrderByTimePointDesc(
+            climbingGym);
+        if (routeVersionList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_VERSION_LIST);
+        }
+        return routeVersionList.stream()
+            .map(routeVersion -> routeVersion.getTimePoint())
+            .toList();
+    }
+
     public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user) {
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
@@ -64,18 +77,7 @@ public class RouteVersionService {
 
     }
 
-    public List<LocalDate> getRouteVersionList(Long gymId) {
-        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
-        List<RouteVersion> routeVersionList = routeVersionRepository.findByClimbingGymOrderByTimePointDesc(
-            climbingGym);
-        if (routeVersionList.isEmpty()) {
-            throw new GeneralException(ErrorStatus._EMPTY_VERSION_LIST);
-        }
-        return routeVersionList.stream()
-            .map(routeVersion -> routeVersion.getTimePoint())
-            .toList();
-    }
+
 
     public RouteVersionDetailResponse getRouteVersionDetail(Long gymId, LocalDate timePoint) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -1,0 +1,80 @@
+package com.climeet.climeet_backend.domain.routeversion;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.route.RouteRepository;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
+import com.climeet.climeet_backend.domain.sector.Sector;
+import com.climeet.climeet_backend.domain.sector.SectorRepository;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.joda.time.LocalDate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RouteVersionService {
+
+    private final ClimbingGymRepository climbingGymRepository;
+    private final RouteVersionRepository routeVersionRepository;
+    private final RouteRepository routeRepository;
+    private final SectorRepository sectorRepository;
+
+    public List<LocalDate> getRouteVersionList(Long gymId) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+        List<RouteVersion> routeVersionList = routeVersionRepository.findByClimbingGymOrderByTimePointDesc(
+            climbingGym);
+        if (routeVersionList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_VERSION_LIST);
+        }
+        return routeVersionList.stream()
+            .map(routeVersion -> routeVersion.getTimePoint())
+            .toList();
+    }
+
+    public RouteVersionDetailResponse getRouteVersionDetail(Long gymId, LocalDate timePoint) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
+                climbingGym, timePoint)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
+
+        List<Long> routeIdList = RouteVersionConverter.convertStringToList(
+            routeVersion.getRouteList());
+        if (routeIdList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
+        }
+
+        List<Long> sectorIdList = RouteVersionConverter.convertStringToList(
+            routeVersion.getSectorList());
+        if (sectorIdList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_SECTOR_LIST);
+        }
+
+        List<Route> routeList = routeRepository.findByIdIn(routeIdList);
+        if (routeList.size() != routeIdList.size()) {
+            throw new GeneralException(ErrorStatus._MISMATCH_ROUTE_IDS);
+        }
+
+        List<Sector> sectorList = sectorRepository.findByIdIn(sectorIdList);
+        if (sectorList.size() != sectorIdList.size()) {
+            throw new GeneralException(ErrorStatus._MISMATCH_SECTOR_IDS);
+        }
+
+        List<RouteDetailResponse> routeListResponse = routeList.stream()
+            .map(route -> RouteDetailResponse.toDto(route)).toList();
+        List<SectorDetailResponse> sectorDetailResponses = sectorList.stream()
+            .map(sector -> SectorDetailResponse.toDto(sector)).toList();
+
+        return RouteVersionDetailResponse.toDto(climbingGym, sectorDetailResponses,
+            routeListResponse);
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -1,0 +1,24 @@
+package com.climeet.climeet_backend.domain.routeversion.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+public class RouteVersionRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateRouteVersionRequest {
+
+        private Long gymId;
+        @DateTimeFormat(iso = ISO.DATE)
+        private LocalDate date;
+
+        private List<String> routeList;
+        private List<String> sectorList;
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.format.annotation.DateTimeFormat.ISO;
 
 public class RouteVersionRequestDto {
 
@@ -14,11 +13,10 @@ public class RouteVersionRequestDto {
     public static class CreateRouteVersionRequest {
 
         private Long gymId;
-        @DateTimeFormat(iso = ISO.DATE)
-        private LocalDate date;
-
-        private List<String> routeList;
-        private List<String> sectorList;
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        private LocalDate timePoint;
+        private List<Long> routeIdList;
+        private List<Long> sectorIdList;
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -12,7 +12,6 @@ public class RouteVersionRequestDto {
     @NoArgsConstructor
     public static class CreateRouteVersionRequest {
 
-        private Long gymId;
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         private LocalDate timePoint;
         private List<Long> routeIdList;

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -1,0 +1,36 @@
+package com.climeet.climeet_backend.domain.routeversion.dto;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RouteVersionResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RouteVersionDetailResponse {
+
+        private Long gymId;
+        private String layoutImageUrl;
+        private List<SectorDetailResponse> sectorList;
+        private List<RouteDetailResponse> routeList;
+
+        public static RouteVersionDetailResponse toDto(ClimbingGym climbingGym,
+            List<SectorDetailResponse> sectorList, List<RouteDetailResponse> routeList) {
+            return RouteVersionDetailResponse.builder()
+                .gymId(climbingGym.getId())
+                .layoutImageUrl(climbingGym.getLayoutImageUrl())
+                .sectorList(sectorList)
+                .routeList(routeList)
+                .build();
+        }
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -34,13 +34,17 @@ public class Sector extends BaseTimeEntity {
     @NotNull
     private String sectorName;
 
+    private String sectorImageUrl;
+
     private int floor = 0;
 
-    public static Sector toEntity(CreateSectorRequest requestDto, ClimbingGym climbingGym){
+    public static Sector toEntity(CreateSectorRequest requestDto, ClimbingGym climbingGym,
+        String sectorImageUrl) {
         return Sector.builder()
             .climbingGym(climbingGym)
             .sectorName(requestDto.getName())
             .floor(requestDto.getFloor())
+            .sectorImageUrl(sectorImageUrl)
             .build();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.sector;
 
 import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorIdSimpleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -10,9 +11,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "ClimbingSector", description = "클라이밍 섹터 API")
 @RequiredArgsConstructor
@@ -24,10 +26,11 @@ public class SectorController {
 
     @Operation(summary = "클라이밍 섹터 생성")
     @PostMapping("/sector")
-    public ResponseEntity<String> createSector(
-        @RequestBody CreateSectorRequest createSectorRequest) {
-        sectorService.createSector(createSectorRequest);
-        return ResponseEntity.ok("새로운 Sector를 추가했습니다.");
+    public ResponseEntity<SectorIdSimpleResponse> createSector(
+        @RequestPart(value = "image") MultipartFile sectorImage,
+        @RequestPart CreateSectorRequest createSectorRequest) {
+
+        return ResponseEntity.ok(sectorService.createSector(createSectorRequest, sectorImage));
     }
 
     @Operation(summary = "특정 암장 전체 섹터 조회")

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -2,7 +2,7 @@ package com.climeet.climeet_backend.domain.sector;
 
 import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorIdSimpleResponse;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorSimpleResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
@@ -31,7 +31,7 @@ public class SectorController {
     @Operation(summary = "클라이밍 섹터 생성")
     @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._DUPLICATE_SECTOR_NAME})
     @PostMapping("/sector")
-    public ResponseEntity<SectorIdSimpleResponse> createSector(
+    public ResponseEntity<SectorSimpleResponse> createSector(
         @RequestPart(value = "image") MultipartFile sectorImage,
         @RequestPart CreateSectorRequest createSectorRequest, @CurrentUser User user) {
 

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -3,6 +3,10 @@ package com.climeet.climeet_backend.domain.sector;
 import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorIdSimpleResponse;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -25,18 +29,20 @@ public class SectorController {
     private final SectorService sectorService;
 
     @Operation(summary = "클라이밍 섹터 생성")
+    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._DUPLICATE_SECTOR_NAME})
     @PostMapping("/sector")
     public ResponseEntity<SectorIdSimpleResponse> createSector(
         @RequestPart(value = "image") MultipartFile sectorImage,
-        @RequestPart CreateSectorRequest createSectorRequest) {
+        @RequestPart CreateSectorRequest createSectorRequest, @CurrentUser User user) {
 
-        return ResponseEntity.ok(sectorService.createSector(createSectorRequest, sectorImage));
+        return ResponseEntity.ok(sectorService.createSector(createSectorRequest, sectorImage, user));
     }
 
     @Operation(summary = "특정 암장 전체 섹터 조회")
+    @SwaggerApiError({ErrorStatus._EMPTY_SECTOR_LIST})
     @GetMapping("/{gymId}/sector")
     public ResponseEntity<List<SectorDetailResponse>> getSectorList(
-        @PathVariable Long gymId
+        @PathVariable Long gymId, @CurrentUser User user
     ) {
         List<SectorDetailResponse> sectorList = sectorService.getSectorList(gymId);
         return ResponseEntity.ok(sectorList);

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorRepository.java
@@ -4,5 +4,10 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectorRepository extends JpaRepository<Sector, Long> {
+
     List<Sector> findSectorByClimbingGymId(Long gymId);
+
+    Sector findBySectorImageUrl(String sectorImageUrl);
+
+    List<Sector> findByIdIn(List<Long> sectorIdList);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -4,7 +4,7 @@ import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorIdSimpleResponse;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorSimpleResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
@@ -25,7 +25,7 @@ public class SectorService {
     private final S3Service s3Service;
 
     @Transactional
-    public SectorIdSimpleResponse createSector(CreateSectorRequest createSectorRequest,
+    public SectorSimpleResponse createSector(CreateSectorRequest createSectorRequest,
         MultipartFile sectorImage, User user) {
 
         Manager manager = managerRepository.findById(user.getId())
@@ -48,7 +48,7 @@ public class SectorService {
         // Sector Id 값을 반환하기 위해 사용
         Sector sector = sectorRepository.findBySectorImageUrl(sectorImageUrl);
 
-        return SectorIdSimpleResponse.toDto(sector);
+        return SectorSimpleResponse.toDto(sector);
     }
 
     public List<SectorDetailResponse> getSectorList(Long gymId) {
@@ -58,7 +58,7 @@ public class SectorService {
         }
 
         return sectorList.stream()
-            .map(sector -> SectorDetailResponse.toDto(sector))
+            .map(SectorDetailResponse::toDto)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -42,11 +42,8 @@ public class SectorService {
 
         String sectorImageUrl = s3Service.uploadFile(sectorImage).getImgUrl();
 
-        sectorRepository.save(
+        Sector sector = sectorRepository.save(
             Sector.toEntity(createSectorRequest, manager.getClimbingGym(), sectorImageUrl));
-
-        // Sector Id 값을 반환하기 위해 사용
-        Sector sector = sectorRepository.findBySectorImageUrl(sectorImageUrl);
 
         return SectorSimpleResponse.toDto(sector);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
@@ -8,8 +8,6 @@ public class SectorRequestDto {
     @Getter
     @NoArgsConstructor
     public static class CreateSectorRequest {
-
-        private Long gymId;
         private String name;
         private int floor;
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
@@ -34,12 +34,12 @@ public class SectorResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SectorIdSimpleResponse {
+    public static class SectorSimpleResponse {
 
         private Long sectorId;
 
-        public static SectorIdSimpleResponse toDto(Sector sector) {
-            return SectorIdSimpleResponse.builder()
+        public static SectorSimpleResponse toDto(Sector sector) {
+            return SectorSimpleResponse.builder()
                 .sectorId(sector.getId())
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.sector.dto;
 
 import com.climeet.climeet_backend.domain.sector.Sector;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class SectorResponseDto {
 
 
+    @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
@@ -16,10 +18,30 @@ public class SectorResponseDto {
 
         private String name;
         private int floor;
+        private String sectorImageUrl;
 
-        public SectorDetailResponse(Sector sector) {
-            this.name = sector.getSectorName();
-            this.floor = sector.getFloor();
+        public static SectorDetailResponse toDto(Sector sector) {
+            return SectorDetailResponse.builder()
+                .name(sector.getSectorName())
+                .floor(sector.getFloor())
+                .sectorImageUrl(sector.getSectorImageUrl())
+                .build();
+
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SectorIdSimpleResponse {
+
+        private Long sectorId;
+
+        public static SectorIdSimpleResponse toDto(Sector sector) {
+            return SectorIdSimpleResponse.builder()
+                .sectorId(sector.getId())
+                .build();
         }
     }
 

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -26,6 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),
     _EMPTY_MANAGER_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 존재하지 않는 암장입니다"),
     _DUPLICATE_GYM_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_003", "이미 관리자가 등록된 암장입니다."),
+    _EMPTY_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_004", "해당 관리자가 존재하지 않습니다."),
 
     //루트 버전 관련
     _EMPTY_VERSION_LIST(HttpStatus.CONFLICT, "ROUTE_VERSION_001", "암장의 루트 버전이 존재하지 않습니다."),
@@ -52,7 +53,6 @@ public enum ErrorStatus implements BaseErrorCode {
     //회원가입 중복 관련
     _DUPLICATE_SIGN_IN(HttpStatus.CONFLICT, "AUTH_004", "이미 가입 된 유저입니다."),
 
-
     //파일 업로드 관련
     _FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),
 
@@ -78,9 +78,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_USER(HttpStatus.CONFLICT, "USER_001", "존재하지 않는 유저입니다."),
 
     //숏츠 댓글 관련
-    _EMPTY_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001" , "존재하지 않는 쇼츠 댓글입니다.");
+    _EMPTY_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001", "존재하지 않는 쇼츠 댓글입니다.");
 
-    ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -27,9 +27,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_MANAGER_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 존재하지 않는 암장입니다"),
     _DUPLICATE_GYM_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_003", "이미 관리자가 등록된 암장입니다."),
 
+    //루트 버전 관련
+    _EMPTY_VERSION_LIST(HttpStatus.CONFLICT, "ROUTE_VERSION_001", "암장의 루트 버전이 존재하지 않습니다."),
+    _EMPTY_VERSION(HttpStatus.CONFLICT, "ROUTE_VERSION_002", "암장의 해당 날짜의 버전이 존재하지 않습니다."),
+    _MISMATCH_ROUTE_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_003", "등록된 루트 데이터 중 불러오지 못한 값이 있습니다."),
+    _MISMATCH_SECTOR_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_004", "등록된 섹터 데이터 중 불러오지 못한 값이 있습니다."),
+
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),
     _DUPLICATE_SECTOR_NAME(HttpStatus.CONFLICT, "SECTOR_002", "섹터 이름이 중복됩니다."),
+    _EMPTY_SECTOR_LIST(HttpStatus.CONFLICT, "SECTOR_003", "암장의 섹터 정보를 찾을 수 없습니다."),
 
     //루트 관련
     _EMPTY_ROUTE(HttpStatus.CONFLICT, "ROUTE_001", "존재하지 않는 루트입니다."),

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_VERSION(HttpStatus.CONFLICT, "ROUTE_VERSION_002", "암장의 해당 날짜의 버전이 존재하지 않습니다."),
     _MISMATCH_ROUTE_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_003", "등록된 루트 데이터 중 불러오지 못한 값이 있습니다."),
     _MISMATCH_SECTOR_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_004", "등록된 섹터 데이터 중 불러오지 못한 값이 있습니다."),
+    _DUPLICATE_ROUTE_VERSION(HttpStatus.CONFLICT, "ROUTE_VERSION_005", "해당일에 이미 등록된 버전이 있습니다."),
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),


### PR DESCRIPTION
## 요약
> - 조금씩 해서 PR 날리고 싶었지만... 이걸 하다보니 저게 필요하고, 저걸 하다보니 이게 필요해서... 다 붙어버렸습니다 ㅠㅠ
> - 최대한 설명 자세히 하겠습니다!!

1. 암장 프로필의 도면을 추가하거나 수정하는 기능 구현
>  - 프로필 수정시 이전 사진을 삭제하는 기능은 피그마 답변 확인 후 구현 예정입니다.
>  - 질문 내용은 루트 버전에 따라 프로필 사진이 변경되는것도 저장해야 하는지입니다.
2. Route에서는 name이 존재하지 않아서 삭제했습니다.
3. Route와 Sector에서 CurrentUser와 Swagger Error를 추가했습니다.
>  - CurrentUser를 사용하면서, Sector의 암장 추가 부분은 userId로 Manager를 검색하여 암장 데이터를 가져오는 방식으로 변경하였고, gymId를 입력받지 않아도 되어 삭제했습니다.
4. RouteSimpleResponse 라고 명명되어있던 Dto가 Route의 모든 정보를 가져온다는 사실을 깨닫고, RouteDetailResponse로 변경하였습니다.
5. 추가로 RouteSimpleResponse는  routeId만 반환하는 Dto가 되어 새롭게 탄생했습니다.
>  - SectorSimpleResponse도 새로 추가하였는데, 이는 RouteVersion을 추가할 때 Route와 Sector를 추가하는 메서드를 따로 사용하지 않으면 처리방식이 복잡해질 것 같아서 Route와 Sector를 따로 추가하고, 반환되는 Id값으로 RouteVersion을 업데이트하도록 하는게 좋을 것 같다는 생각을 했습니다.
>  - 그리고 save한 루트나 섹터의 Id를 가져오려면, 다시 JPA로 검색하는 방법뿐인것 같아서 검색을 하려고 했는데, Route나 Sector에서 Id를 모르는 상태에서 검색을 하기 위한 고유값이 이미지 Url이 제일 편한 것 같아서 저장된 Url을 통해 해당 데이터를 가져오도록 했습니다.
6. Sector에도 이미지를 추가할 수 있기 때문에 sectorImageUrl 컬럼하였고, 수정하였습니다.
7. 리스트를 반환할 때 빈 리스트면 예외 처리로 에러를 반환하도록 처리하였습니다.
8. Sector Response에 Builder 패턴을 적용하였고, 이미지 추가에 따라 반환 데이터를 추가했습니다.
9. RouteVersion의 기능을 추가했습니다.
>  - 루트 버전 일자 목록을 불러오는 기능을 추가했습니다.
>  - 루트 버전을 추가하는 기능을 추가했습니다.
>  - 특정 루트 버전 데이터를 불러오는 기능을 추가했습니다.
>  - RouteVersionConverter에 List와 String을 변환하는 Converter를 추가했습니다.


- 이상입니다... 열심히 상세내용 적어보겠습니다!

## 상세 내용
### 암장 프로필 관련
1. 암장 프로필의 도면을 추가하거나 수정하는 기능 구현
>  - 프로필 수정시 이전 사진을 삭제하는 기능은 피그마 답변 확인 후 구현 예정입니다.
>  - 질문 내용은 루트 버전에 따라 프로필 사진이 변경되는것도 저장해야 하는지입니다.

ClimbingGym
``` java
    private String layoutImageUrl;

    public void changeLayoutImageUrl(String layoutImageUrl) {
        this.layoutImageUrl = layoutImageUrl;
    }
```

ClimbingGymController
``` java
    @Operation(summary = "암장 도면 이미지 수정")
    @PostMapping("/layout")
    public ResponseEntity<LayoutDetailResponse> changeLayoutImage(
        @RequestPart Long gymId,
        @RequestPart MultipartFile layoutImage) {
        return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, gymId));
    }
```

ClimbingGymService (S3에 저장, 테이블 업데이트, 링크 반환)
``` java
    public LayoutDetailResponse changeLayoutImage(MultipartFile layoutImage, Long gymId) {
        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));

        String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
        climbingGym.changeLayoutImageUrl(layoutImageUrl);

        climbingGymRepository.save(climbingGym);

        return LayoutDetailResponse.toDto(layoutImageUrl);
    }
```

ResponseDto (ImageUrl만 반환)
``` java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class LayoutDetailResponse {

        private String layoutImageUrl;

        public static LayoutDetailResponse toDto(String layoutImageUrl) {
            return LayoutDetailResponse.builder()
                .layoutImageUrl(layoutImageUrl)
                .build();
        }
    }
```

### 루트, 섹터 관련
2. Route에서는 name이 존재하지 않아서 삭제했습니다.

3. Route와 Sector에서 CurrentUser와 Swagger Error를 추가했습니다.
>  - CurrentUser를 사용하면서, Sector의 암장 추가 부분은 userId로 Manager를 검색하여 암장 데이터를 가져오는 방식으로 변경하였고, gymId를 입력받지 않아도 되어 삭제했습니다.

암장 데이터 가져오는 방식

SectorController (User 데이터를 Service로 보냄)
``` java
    @Operation(summary = "클라이밍 섹터 생성")
    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._DUPLICATE_SECTOR_NAME})
    @PostMapping("/sector")
    public ResponseEntity<SectorIdSimpleResponse> createSector(
        @RequestPart(value = "image") MultipartFile sectorImage,
        @RequestPart CreateSectorRequest createSectorRequest, @CurrentUser User user) {

        return ResponseEntity.ok(sectorService.createSector(createSectorRequest, sectorImage, user));
    }
```

SectorService (UserId로 Manager를 가져오고, Manager의 ClimbingGym 활용)
``` java
    @Transactional
    public SectorSimpleResponse createSector(CreateSectorRequest createSectorRequest,
        MultipartFile sectorImage, User user) {

        Manager manager = managerRepository.findById(user.getId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));

        // 루트 이름 중복 체크 (같은 섹터에서 중복일 경우)
        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
            manager.getClimbingGym().getId());
        for (Sector sector : sectorList) {
            if (sector.getSectorName().equals(createSectorRequest.getName())) {
                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
            }
        }

        String sectorImageUrl = s3Service.uploadFile(sectorImage).getImgUrl();

        sectorRepository.save(
            Sector.toEntity(createSectorRequest, manager.getClimbingGym(), sectorImageUrl));

        // Sector Id 값을 반환하기 위해 사용
        Sector sector = sectorRepository.findBySectorImageUrl(sectorImageUrl);

        return SectorSimpleResponse.toDto(sector);
    }
```

4. RouteSimpleResponse 라고 명명되어있던 Dto가 Route의 모든 정보를 가져온다는 사실을 깨닫고, RouteDetailResponse로 변경하였습니다.

``` java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class RouteDetailResponse {

        private Long routeId;
        private Long sectorId;
        private String sectorName;
        private int difficulty;
        private String routeImageUrl;

        public static RouteDetailResponse toDto(Route route) {
            return RouteDetailResponse.builder()
                .routeId(route.getId())
                .sectorId(route.getSector().getId())
                .sectorName(route.getSector().getSectorName())
                .difficulty(route.getDifficulty())
                .routeImageUrl(route.getRouteImageUrl())
                .build();
        }
    }
```

5. 추가로 RouteSimpleResponse는  routeId만 반환하는 Dto가 되어 새롭게 탄생했습니다.
>  - SectorSimpleResponse도 새로 추가하였는데, 이는 RouteVersion을 추가할 때 Route와 Sector를 추가하는 메서드를 따로 사용하지 않으면 처리방식이 복잡해질 것 같아서 Route와 Sector를 따로 추가하고, 반환되는 Id값으로 RouteVersion을 업데이트하도록 하는게 좋을 것 같다는 생각을 했습니다.
>  - 그리고 save한 루트나 섹터의 Id를 가져오려면, 다시 JPA로 검색하는 방법뿐인것 같아서 검색을 하려고 했는데, Route나 Sector에서 Id를 모르는 상태에서 검색을 하기 위한 고유값이 이미지 Url이 제일 편한 것 같아서 저장된 Url을 통해 해당 데이터를 가져오도록 했습니다.

RouteSimpleResponse
``` java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class RouteSimpleResponse {

        private Long routeId;

        public static RouteSimpleResponse toDto(Route route) {
            return RouteSimpleResponse.builder()
                .routeId(route.getId())
                .build();
        }
    }
```

SectorSimpleResponse
``` java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class SectorSimpleResponse {

        private Long sectorId;

        public static SectorSimpleResponse toDto(Sector sector) {
            return SectorSimpleResponse.builder()
                .sectorId(sector.getId())
                .build();
        }
    }
```

사용처: createRoute, createSector(저장 이후 Id값을 반환)


6. Sector에도 이미지를 추가할 수 있기 때문에 sectorImageUrl 컬럼 추가하였고, 수정하였습니다.

7. 리스트를 반환할 때 빈 리스트면 예외 처리로 에러를 반환하도록 처리하였습니다.

SectorService
``` java
    public List<SectorDetailResponse> getSectorList(Long gymId) {
        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(gymId);
        if (sectorList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_SECTOR_LIST);
        }

        return sectorList.stream()
            .map(SectorDetailResponse::toDto)
            .collect(Collectors.toList());
    }
```

8. Sector Response에 Builder 패턴을 적용하였고, 이미지 추가에 따라 반환 데이터를 추가했습니다.

### 루트 버전 관련
9. RouteVersion의 기능을 추가했습니다.
>  - 루트 버전 일자 목록을 불러오는 기능을 추가했습니다.

Controller (암장 Id에 해당하는 루트 버전 일자 목록을 불러옴)
``` java
    @Operation(summary = "암장의 루트 버전 일자 목록")
    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION_LIST})
    @GetMapping("/version/list")
    public ResponseEntity<List<LocalDate>> getRouteVersionList(
        @CurrentUser User user, @RequestParam Long gymId) {
        List<LocalDate> routeVersionList = routeVersionService.getRouteVersionList(gymId);
        return ResponseEntity.ok(routeVersionList);
    }
```

Service (해당 암장의 버전 리스트를 불러온 뒤, 날짜 데이터를 리스트 형태로 반환)
``` java
    public List<LocalDate> getRouteVersionList(Long gymId) {
        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
        List<RouteVersion> routeVersionList = routeVersionRepository.findByClimbingGymOrderByTimePointDesc(
            climbingGym);
        if (routeVersionList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_VERSION_LIST);
        }
        return routeVersionList.stream()
            .map(routeVersion -> routeVersion.getTimePoint())
            .toList();
    }
```

Repository (날짜 데이터를 최신순으로 정렬한 뒤 리스트 반환)
``` java
List<RouteVersion> findByClimbingGymOrderByTimePointDesc(ClimbingGym climbingGym);
```

>  - 루트 버전을 추가하는 기능을 추가했습니다.

RequestDto
``` java
    @Getter
    @NoArgsConstructor
    public static class CreateRouteVersionRequest {

        @DateTimeFormat(pattern = "yyyy-MM-dd")
        private LocalDate timePoint;
        private List<Long> routeIdList;
        private List<Long> sectorIdList;
    }
```

Controller
``` java
    @Operation(summary = "암장의 루트 버전 추가")
    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._DUPLICATE_ROUTE_VERSION,
        ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
    @PostMapping("/version")
    public ResponseEntity<String> createRouteVersion(
        @RequestBody CreateRouteVersionRequest createRouteVersionRequest, @CurrentUser User user) {
        routeVersionService.createRouteVersion(createRouteVersionRequest, user);
        return ResponseEntity.ok("루트 버전이 추가되었습니다.");
    }
```

Service
- Sector와 마찬가지로 userId로 manager를 찾습니다.
- 입력된 일자에 해당하는 루트 버전이 이미 존재하는지 확인합니다. (존재하면 예외처리)
- 입력된 루트 리스트가 존재하는 루트의 집합인지 확인합니다. (하나라도 없으면 예외처리)
- 입력된 섹터 리스트가 존재하는 섹터의 집합인지 확인합니다. (하나라도 없으면 예외처리)
- List<Long>의 형태를 String의 형태로 변환합니다.
- 테이블에 저장합니다.
``` java
    public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user) {
        Manager manager = managerRepository.findById(user.getId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));

        Optional<RouteVersion> routeVersionOptional = routeVersionRepository.findByClimbingGymAndTimePoint(
            manager.getClimbingGym(), createRouteVersionRequest.getTimePoint());
        if (routeVersionOptional.isPresent()) {
            throw new GeneralException(ErrorStatus._DUPLICATE_ROUTE_VERSION);
        }

        List<Route> routeList = routeRepository.findByIdIn(
            createRouteVersionRequest.getRouteIdList());
        if (routeList.size() != createRouteVersionRequest.getRouteIdList().size()) {
            throw new GeneralException(ErrorStatus._MISMATCH_ROUTE_IDS);
        }

        List<Sector> sectorList = sectorRepository.findByIdIn(
            createRouteVersionRequest.getSectorIdList());
        if (sectorList.size() != createRouteVersionRequest.getSectorIdList().size()) {
            throw new GeneralException(ErrorStatus._MISMATCH_SECTOR_IDS);
        }

        String routeIdListString = RouteVersionConverter.convertListToString(
            createRouteVersionRequest.getRouteIdList());
        String sectorIdListString = RouteVersionConverter.convertListToString(
            createRouteVersionRequest.getSectorIdList());

        routeVersionRepository.save(
            RouteVersion.toEntity(manager.getClimbingGym(), createRouteVersionRequest.getTimePoint(),
                routeIdListString, sectorIdListString));

    }
```

Repository (이미 해당 암장이 해당 일자에 데이터가 존재하는지 검색하기 위함)
``` java
Optional<RouteVersion> findByClimbingGymAndTimePoint(ClimbingGym climbingGym, LocalDate timePoint);
```


>  - 특정 루트 버전 데이터를 불러오는 기능을 추가했습니다. (반환 형식은 변경 예정입니다.)

Controller
``` java
    @Operation(summary = "암장 특정 루트 버전 데이터 불러오기")
    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._EMPTY_SECTOR_LIST,
        ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
    @GetMapping("/version")
    public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(
        @CurrentUser User user, @RequestParam Long gymId,
        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
        return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
    }
```

Service
- 암장 Id로 암장을 검색합니다.
- 해당 일자의 해당 암장의 루트 버전을 검색합니다.
- String으로 되어있는 RouteList와 SectorList를 List<Long>으로 변환합니다.
- 루트 데이터와 섹터 데이터가 제대로 존재하는지 확인합니다.
- 변환된 데이터를 반환합니다.
``` java
    public RouteVersionDetailResponse getRouteVersionDetail(Long gymId, LocalDate timePoint) {
        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));

        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
                climbingGym, timePoint)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));

        List<Long> routeIdList = RouteVersionConverter.convertStringToList(
            routeVersion.getRouteList());
        if (routeIdList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
        }

        List<Long> sectorIdList = RouteVersionConverter.convertStringToList(
            routeVersion.getSectorList());
        if (sectorIdList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_SECTOR_LIST);
        }

        List<Route> routeList = routeRepository.findByIdIn(routeIdList);
        if (routeList.size() != routeIdList.size()) {
            throw new GeneralException(ErrorStatus._MISMATCH_ROUTE_IDS);
        }

        List<Sector> sectorList = sectorRepository.findByIdIn(sectorIdList);
        if (sectorList.size() != sectorIdList.size()) {
            throw new GeneralException(ErrorStatus._MISMATCH_SECTOR_IDS);
        }

        List<RouteDetailResponse> routeListResponse = routeList.stream()
            .map(route -> RouteDetailResponse.toDto(route)).toList();
        List<SectorDetailResponse> sectorDetailResponses = sectorList.stream()
            .map(sector -> SectorDetailResponse.toDto(sector)).toList();

        return RouteVersionDetailResponse.toDto(climbingGym, sectorDetailResponses,
            routeListResponse);
    }
```



>  - RouteVersionConverter에 List와 String을 변환하는 Converter를 추가했습니다.

``` java
public class RouteVersionConverter {

    // "[1,2,3,4,5]" -> [1, 2, 3, 4, 5]
    public static List<Long> convertStringToList(String stringToConvert) {

        String[] longList = stringToConvert.substring(1, stringToConvert.length() - 1).split(",");
        return Arrays.stream(longList)
            .map(Long::parseLong)
            .toList();
    }

    // [1, 2, 3, 4, 5] -> "[1,2,3,4,5]"
    public static String convertListToString(List<Long> listToConvert) {
        String result = listToConvert.stream()
            .map(String::valueOf)
            .collect(Collectors.joining(","));
        return "[" + result + "]";
    }

}
```


## 테스트 확인 내용
### 루트 버전 목록 가져오기
반환값 테스트 결과
<img width="1327" alt="스크린샷 2024-01-29 오후 4 55 10" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/292aadf1-d58d-445f-a82c-4a274bf92d96">


### 루트 버전 추가하기
반환값 테스트 결과
<img width="1324" alt="스크린샷 2024-01-29 오후 4 53 45" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/dc1519e6-9607-42fd-8bca-9d711c13b952">
<img width="1466" alt="스크린샷 2024-01-29 오후 4 54 17" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/f62ac3d7-c362-4372-8e64-8a0a749e4e5b">


### 루트 버전 데이터 가져오기
반환값 테스트 결과 (너무 길어서 배열 내부는 임의로 잘랐습니다!)
``` json
{
  "gymId": 1,
  "layoutImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/cac791ed-ac07-442d-9e44-2d566258cf78.png",
  "sectorList": [
    {
      "name": "Panorama",
      "floor": 2,
      "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/193fa43d-7db9-45d4-8280-50ef512e46a7.jpeg"
    },
    {
      "name": "Jaws",
      "floor": 2,
      "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/e8390ea4-2415-43a8-a382-9c7aeb60229e.jpeg"
    }
  ],
  "routeList": [
    {
      "routeId": 7,
      "sectorId": 2,
      "sectorName": "Panorama",
      "difficulty": 6,
      "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/472f4348-978c-47a1-ae4b-e2201507e247.jpg"
    },
    {
      "routeId": 8,
      "sectorId": 3,
      "sectorName": "Jaws",
      "difficulty": 7,
      "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/5017af95-73f7-482a-9283-83f292edb3d1.jpg"
    },
    {
      "routeId": 9,
      "sectorId": 3,
      "sectorName": "Jaws",
      "difficulty": 8,
      "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/74405d33-988a-49e2-bb56-ea4be2caea2a.jpg"
    },
    {
      "routeId": 10,
      "sectorId": 3,
      "sectorName": "Jaws",
      "difficulty": 9,
      "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/9846a49d-98f4-4d56-8e41-b2a14f2711ba.jpg"
    }
  ]
}
```

## 질문 및 이외 사항

- 내용이 상당히...상당히 많습니다...! 죄송합니다 ㅠㅠ
- 각 변경사항들이 무엇을 의미하는지를 알기 쉽도록 내용을 나열했습니다! 그래도 양이 많아서 힘들겠지만... 감사합니다...
- 이제 암장 난이도 매칭 기능을 진행하고, 끝나고 바로 암장 난이도를 적용할 계획입니다.
- 반환 형식이 지금은 단순하게 되어있는데, 어떻게 반환하는게 좋을지는 생각해보고 의견 물어보겠습니다!
- 이해 안되는 부분 말해주시면 빠르게 답변 하겠습니다..!
