### PR TITLE
[SPR-99] 암장 난이도 매핑 생성기능 변경, 조회기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
@@ -1,8 +1,7 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.difficultymapping.dto.difficultyMappingRequestDto.CreateDifficultyMappingRequest;
-import com.climeet.climeet_backend.domain.difficultymapping.dto.difficultyMappingRequestDto.DifficultyMappingElement;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.DifficultyMappingElement;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Column;

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.difficultymapping;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.difficultyMappingRequestDto.CreateDifficultyMappingRequest;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.difficultyMappingRequestDto.DifficultyMappingElement;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -46,12 +47,12 @@ public class DifficultyMapping extends BaseTimeEntity {
     @Column(length = 7)
     private String gymDifficultyColor;
 
-    public static DifficultyMapping toEntity(CreateDifficultyMappingRequest requestDto,
-        ClimbingGym climbingGym, ClimeetDifficulty climeetDifficulty) {
+    public static DifficultyMapping toEntity(DifficultyMappingElement requestDto,
+        ClimbingGym climbingGym, ClimeetDifficulty climeetDifficulty, int gymDifficulty) {
         return DifficultyMapping.builder()
             .climbingGym(climbingGym)
             .climeetDifficulty(climeetDifficulty)
-            .gymDifficulty(requestDto.getGymDifficulty())
+            .gymDifficulty(gymDifficulty)
             .gymDifficultyName(requestDto.getGymDifficultyName())
             .gymDifficultyColor(requestDto.getGymDifficultyColor())
             .build();

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
@@ -6,6 +6,7 @@ import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,12 +27,13 @@ public class DifficultyMappingController {
 
     @Operation(summary = "클밋, 암장 난이도 매핑")
     @PostMapping("/difficulty")
-    public ResponseEntity<String> createDifficultyMapping(
+    public ResponseEntity<List<Long>> createDifficultyMapping(
         @CurrentUser User user,
         @RequestBody CreateDifficultyMappingRequest createDifficultyMappingRequest
     ) {
-        difficultyMappingService.createDifficultyMapping(user, createDifficultyMappingRequest);
-        return ResponseEntity.ok("난이도 매핑을 완료했습니다.");
+
+        return ResponseEntity.ok(
+            difficultyMappingService.createDifficultyMapping(user, createDifficultyMappingRequest));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
@@ -3,7 +3,9 @@ package com.climeet.climeet_backend.domain.difficultymapping;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -26,9 +28,9 @@ public class DifficultyMappingController {
     private final DifficultyMappingService difficultyMappingService;
 
     @Operation(summary = "클밋, 암장 난이도 매핑 생성")
+    @SwaggerApiError({ErrorStatus._INVALID_DIFFICULTY, ErrorStatus._EMPTY_MANAGER})
     @PostMapping("/difficulty")
-    public ResponseEntity<List<Long>> createDifficultyMapping(
-        @CurrentUser User user,
+    public ResponseEntity<List<Long>> createDifficultyMapping(@CurrentUser User user,
         @RequestBody CreateDifficultyMappingRequest createDifficultyMappingRequest
     ) {
         return ResponseEntity.ok(
@@ -36,11 +38,13 @@ public class DifficultyMappingController {
     }
 
     @Operation(summary = "클밋, 암장 난이도 매핑 조회")
+    @SwaggerApiError({ErrorStatus._INVALID_DIFFICULTY, ErrorStatus._EMPTY_CLIMBING_GYM,
+        ErrorStatus._EMPTY_DIFFICULTY_LIST})
     @GetMapping("/difficulty")
     public ResponseEntity<List<DifficultyMappingDetailResponse>> getDifficultyMappingList(
         @CurrentUser User user, @RequestParam Long gymId
     ) {
-        return ResponseEntity.ok(difficultyMappingService.getDifficultyMapping(user, gymId));
+        return ResponseEntity.ok(difficultyMappingService.getDifficultyMapping(gymId));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
@@ -1,7 +1,7 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
-import com.climeet.climeet_backend.domain.difficultymapping.dto.difficultyMappingRequestDto.CreateDifficultyMappingRequest;
-import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,12 +9,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "DifficultyMapping", description = "암장 난이도 매핑 ")
@@ -25,15 +25,22 @@ public class DifficultyMappingController {
 
     private final DifficultyMappingService difficultyMappingService;
 
-    @Operation(summary = "클밋, 암장 난이도 매핑")
+    @Operation(summary = "클밋, 암장 난이도 매핑 생성")
     @PostMapping("/difficulty")
     public ResponseEntity<List<Long>> createDifficultyMapping(
         @CurrentUser User user,
         @RequestBody CreateDifficultyMappingRequest createDifficultyMappingRequest
     ) {
-
         return ResponseEntity.ok(
             difficultyMappingService.createDifficultyMapping(user, createDifficultyMappingRequest));
+    }
+
+    @Operation(summary = "클밋, 암장 난이도 매핑 조회")
+    @GetMapping("/difficulty")
+    public ResponseEntity<List<DifficultyMappingDetailResponse>> getDifficultyMappingList(
+        @CurrentUser User user, @RequestParam Long gymId
+    ) {
+        return ResponseEntity.ok(difficultyMappingService.getDifficultyMapping(user, gymId));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingRepository.java
@@ -1,10 +1,13 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DifficultyMappingRepository extends JpaRepository<DifficultyMapping, Long> {
 
     DifficultyMapping findByClimbingGymAndGymDifficulty(ClimbingGym climbingGym, int gymDifficulty);
+
+    List<DifficultyMapping> findByClimbingGymOrderByGymDifficultyAsc(ClimbingGym climbingGym);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
-import com.climeet.climeet_backend.domain.difficultymapping.dto.difficultyMappingRequestDto.CreateDifficultyMappingRequest;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
@@ -36,5 +37,20 @@ public class DifficultyMappingService {
                 return difficultyMapping.getId();
             })
             .toList();
+    }
+
+    public List<DifficultyMappingDetailResponse> getDifficultyMapping(User user, Long gymId) {
+
+        Manager manager = managerRepository.findById(user.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
+
+        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByGymDifficultyAsc(
+            manager.getClimbingGym());
+
+        if (difficultyMappingList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);
+        }
+
+        return difficultyMappingList.stream().map(DifficultyMappingDetailResponse::toDto).toList();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DifficultyMappingService {
 
     private final ManagerRepository managerRepository;
+    private final ClimbingGymRepository climbingGymRepository;
     private final DifficultyMappingRepository difficultyMappingRepository;
 
     @Transactional
@@ -39,13 +42,13 @@ public class DifficultyMappingService {
             .toList();
     }
 
-    public List<DifficultyMappingDetailResponse> getDifficultyMapping(User user, Long gymId) {
+    public List<DifficultyMappingDetailResponse> getDifficultyMapping(Long gymId) {
 
-        Manager manager = managerRepository.findById(user.getId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
         List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByGymDifficultyAsc(
-            manager.getClimbingGym());
+            climbingGym);
 
         if (difficultyMappingList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
@@ -7,6 +7,7 @@ import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,14 +20,21 @@ public class DifficultyMappingService {
     private final DifficultyMappingRepository difficultyMappingRepository;
 
     @Transactional
-    public void createDifficultyMapping(User user, CreateDifficultyMappingRequest createDifficultyMappingRequest) {
+    public List<Long> createDifficultyMapping(User user,
+        CreateDifficultyMappingRequest createDifficultyMappingRequest) {
 
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
-        ClimeetDifficulty climeetDifficulty = ClimeetDifficulty.findByString(createDifficultyMappingRequest.getClimeetDifficulty());
-
-        difficultyMappingRepository.save(
-            DifficultyMapping.toEntity(createDifficultyMappingRequest, manager.getClimbingGym(), climeetDifficulty));
+        return createDifficultyMappingRequest.getElements().stream()
+            .map((element) -> {
+                ClimeetDifficulty climeetDifficulty = ClimeetDifficulty.findByString(
+                    element.getClimeetDifficulty());
+                DifficultyMapping difficultyMapping = difficultyMappingRepository.save(
+                    DifficultyMapping.toEntity(element, manager.getClimbingGym(),
+                        climeetDifficulty, climeetDifficulty.getIntValue()));
+                return difficultyMapping.getId();
+            })
+            .toList();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingRequestDto.java
@@ -1,11 +1,10 @@
 package com.climeet.climeet_backend.domain.difficultymapping.dto;
 
-import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-public class difficultyMappingRequestDto {
+public class DifficultyMappingRequestDto {
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingResponseDto.java
@@ -1,11 +1,6 @@
 package com.climeet.climeet_backend.domain.difficultymapping.dto;
 
-import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
-import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingResponseDto.java
@@ -1,0 +1,38 @@
+package com.climeet.climeet_backend.domain.difficultymapping.dto;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto;
+import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class DifficultyMappingResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DifficultyMappingDetailResponse {
+
+        private String climeetDifficultyName;
+        private String gymDifficultyName;
+        private int gymDifficulty;
+        private String gymDifficultyColor;
+
+        public static DifficultyMappingDetailResponse toDto(
+            DifficultyMapping difficultyMapping) {
+            return DifficultyMappingDetailResponse.builder()
+                .climeetDifficultyName(difficultyMapping.getClimeetDifficulty().getStringValue())
+                .gymDifficultyName(difficultyMapping.getGymDifficultyName())
+                .gymDifficulty(difficultyMapping.getGymDifficulty())
+                .gymDifficultyColor(difficultyMapping.getGymDifficultyColor())
+                .build();
+        }
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/difficultyMappingRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/difficultyMappingRequestDto.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.difficultymapping.dto;
 
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,11 +11,19 @@ public class difficultyMappingRequestDto {
     @NoArgsConstructor
     public static class CreateDifficultyMappingRequest {
 
+        private List<DifficultyMappingElement> elements;
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class DifficultyMappingElement {
+
         private String climeetDifficulty;
-        private int gymDifficulty;
         private String gymDifficultyName;
         private String gymDifficultyColor;
 
     }
+
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -14,7 +14,6 @@ import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.s3.S3Service;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,14 +37,15 @@ public class RouteService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
         DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndGymDifficulty(
-            manager.getClimbingGym(), createRouteRequest.getDifficulty());
+            manager.getClimbingGym(), createRouteRequest.getGymDifficulty());
 
         Sector sector = sectorRepository.findById(createRouteRequest.getSectorId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SECTOR));
 
         String routeImageUrl = s3Service.uploadFile(routeImage).getImgUrl();
 
-        Route route = routeRepository.save(Route.toEntity(sector, routeImageUrl, difficultyMapping));
+        Route route = routeRepository.save(
+            Route.toEntity(sector, routeImageUrl, difficultyMapping));
 
         return RouteSimpleResponse.toDto(route);
     }
@@ -64,6 +64,6 @@ public class RouteService {
         }
         return routeList.stream()
             .map(RouteDetailResponse::toDto)
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -10,6 +10,6 @@ public class RouteRequestDto {
     public static class CreateRouteRequest {
 
         private Long sectorId;
-        private int difficulty;
+        private int gymDifficulty;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //난이도 매핑 관련
     _INVALID_DIFFICULTY(HttpStatus.CONFLICT, "DIFFICULTY_MAPPING_001", "해당하는 난이도가 없습니다."),
+    _EMPTY_DIFFICULTY_LIST(HttpStatus.CONFLICT, "DIFFICULTY_MAPPING_002", "암장에 등록된 매핑이 없습니다."),
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),


### PR DESCRIPTION
## 요약
- 암장 난이도 매핑 생성기능을 목적에 맞게 변경했습니다.
- 암장 난이도 조회 기능도 구현했습니다.

## 상세 내용
1.  암장 난이도 매핑 생성기능
암장 난이도 매핑을 배열로 입력받아 모든 난이도를 한번에 입력받게 구현했습니다.
추가로 이후 To-do는 특정 난이도 수정 기능과 이미 존재하는 난이도인지를 확인하는 것입니다.

**중요사항** 은 따로 gymDifficulty int 값을 관리자에게 입력받는것보다는 그냥 초기 설정할 때에는 매핑된 climeetDifficulty의 int 값을 그대로 가져가도록 구현했습니다.
그 이유는 gymDifficulty의 int값까지 프론트에서 어떻게 입력받느냐 하는 의문때문이었고, gymDifficulty의 값을 없애도 문제는 없지만 그대로 둔 이유는, 이후에 각 암장별로 난이도를 사용자들이 클밋 기준에 어울리는지 판단하고 난이도 제안 기능이 추가될 때에 사용되지 않을까 하는 생각과, 더이상 DifficultyMapping 테이블을 바꾸고싶지 않았기 때문입니다...!
다른 분들이 필요 없을 것 같다, 아니면 프론트에서 입력을 받는게 좋지 않을까 하는 의견을 남겨주신다면 해당 내용 공유해서 모두가 함께 고쳐나가는 것으로 하겠습니다!

Service입니다.
``` java
@Transactional
    public List<Long> createDifficultyMapping(User user,
        CreateDifficultyMappingRequest createDifficultyMappingRequest) {

        Manager manager = managerRepository.findById(user.getId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));

        return createDifficultyMappingRequest.getElements().stream()
            .map((element) -> {
                ClimeetDifficulty climeetDifficulty = ClimeetDifficulty.findByString(
                    element.getClimeetDifficulty());
                DifficultyMapping difficultyMapping = difficultyMappingRepository.save(
                    DifficultyMapping.toEntity(element, manager.getClimbingGym(),
                        climeetDifficulty, climeetDifficulty.getIntValue()));
                return difficultyMapping.getId();
            })
            .toList();
    }
```
각 항목마다 save 쿼리를 생성하고, Transaction 어노테이션을 통해 한번에 처리하도록 하였습니다.

2. 암장 난이도 조회 기능
해당 기능을 구현했습니다.
암장에 해당하는 모든 난이도를 조회하고, 난이도가 낮은 순서부터 정렬해서 반환하는 기능입니다.
간단한 조회 기능입니다.


## 테스트 확인 내용

생성 기능 (다음과 같이 배열의 형태로 입력하면 생성이 되고, id값이 반환되게 됩니다.)
<img width="766" alt="스크린샷 2024-01-30 오후 8 09 02" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/6a1bd0c8-269e-4838-bf1a-eb7024f60af6">

조회기능 (같은 값을 예외처리하지 않아서 현재는 같은 값이 들어갈 수 있습니다.)
<img width="747" alt="스크린샷 2024-01-30 오후 8 08 28" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/82a4f9f5-2cba-4aff-b248-3113e9a0639f">

- 

## 질문 및 이외 사항

위의 내용 그대로 가져왔습니다!!
**중요사항** 은 따로 gymDifficulty int 값을 관리자에게 입력받는것보다는 그냥 초기 설정할 때에는 매핑된 climeetDifficulty의 int 값을 그대로 가져가도록 구현했습니다.
그 이유는 gymDifficulty의 int값까지 프론트에서 어떻게 입력받느냐 하는 의문때문이었고, gymDifficulty의 값을 없애도 문제는 없지만 그대로 둔 이유는, 이후에 각 암장별로 난이도를 사용자들이 클밋 기준에 어울리는지 판단하고 난이도 제안 기능이 추가될 때에 사용되지 않을까 하는 생각과, 더이상 DifficultyMapping 테이블을 바꾸고싶지 않았기 때문입니다...!
다른 분들이 필요 없을 것 같다, 아니면 프론트에서 입력을 받는게 좋지 않을까 하는 의견을 남겨주신다면 해당 내용 공유해서 모두가 함께 고쳐나가는 것으로 하겠습니다! 
