### PR TITLE
[SPR-98] 루트 필터링 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.routeversion;
 
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
@@ -14,6 +15,7 @@ import java.time.LocalDate;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,8 +33,8 @@ public class RouteVersionController {
     @Operation(summary = "암장의 루트 버전 일자 목록")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION_LIST})
     @GetMapping("/version/list")
-    public ResponseEntity<List<LocalDate>> getRouteVersionList(
-        @CurrentUser User user, @RequestParam Long gymId) {
+    public ResponseEntity<List<LocalDate>> getRouteVersionList(@CurrentUser User user,
+        @RequestParam Long gymId) {
         List<LocalDate> routeVersionList = routeVersionService.getRouteVersionList(gymId);
         return ResponseEntity.ok(routeVersionList);
     }
@@ -51,10 +53,26 @@ public class RouteVersionController {
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._EMPTY_SECTOR_LIST,
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
-    @GetMapping("/version")
-    public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(
-        @CurrentUser User user, @RequestParam Long gymId,
+    @GetMapping("/{gymId}/version")
+    public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(@CurrentUser User user,
+        @PathVariable Long gymId,
         @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
         return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
+    }
+
+    @Operation(summary = "암장 특정 루트 버전 데이터 필터링해서 루트 불러오기")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
+        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS,
+        ErrorStatus._EMPTY_ROUTE_LIST})
+    @GetMapping("/{gymId}/version/filter")
+    public ResponseEntity<List<RouteDetailResponse>> getRouteVersionFiltering(
+        @CurrentUser User user, @PathVariable Long gymId,
+        @RequestParam(value = "floor", defaultValue = "") int[] floorList,
+        @RequestParam(value = "sector", defaultValue = "") Long[] sectorIdList,
+        @RequestParam(value = "difficulty", defaultValue = "") int[] gymDifficultyList,
+        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
+        return ResponseEntity.ok(
+            routeVersionService.getRouteVersionFiltering(gymId, timePoint, floorList, sectorIdList,
+                gymDifficultyList));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.routeversion;
 
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.GetFilteredRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -64,15 +65,11 @@ public class RouteVersionController {
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS,
         ErrorStatus._EMPTY_ROUTE_LIST})
-    @GetMapping("/{gymId}/version/filter")
+    @PostMapping("/{gymId}/version/filter")
     public ResponseEntity<List<RouteDetailResponse>> getRouteVersionFiltering(
         @CurrentUser User user, @PathVariable Long gymId,
-        @RequestParam(value = "floor", defaultValue = "") int[] floorList,
-        @RequestParam(value = "sector", defaultValue = "") Long[] sectorIdList,
-        @RequestParam(value = "difficulty", defaultValue = "") int[] gymDifficultyList,
-        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
+        @RequestBody GetFilteredRouteVersionRequest getFilteredRouteVersionRequest) {
         return ResponseEntity.ok(
-            routeVersionService.getRouteVersionFiltering(gymId, timePoint, floorList, sectorIdList,
-                gymDifficultyList));
+            routeVersionService.getRouteVersionFiltering(gymId, getFilteredRouteVersionRequest));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -8,6 +8,7 @@ import com.climeet.climeet_backend.domain.route.Route;
 import com.climeet.climeet_backend.domain.route.RouteRepository;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.GetFilteredRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.domain.sector.SectorRepository;
@@ -115,13 +116,13 @@ public class RouteVersionService {
             routeListResponse);
     }
 
-    public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId, LocalDate timePoint,
-        int[] floorList, Long[] sectorIdList, int[] gymDifficultyList) {
+    public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId,
+        GetFilteredRouteVersionRequest requestDto) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
         RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
-                climbingGym, timePoint)
+                climbingGym, requestDto.getTimePoint())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
 
         List<Long> routeIdList = RouteVersionConverter.convertStringToList(
@@ -136,12 +137,15 @@ public class RouteVersionService {
         }
 
         List<Route> filteredRouteList = routeList.stream().filter(route -> {
-            boolean floorFilter = floorList.length == 0 || Arrays.stream(floorList)
-                .anyMatch(floor -> floor == route.getSector().getFloor());
-            boolean sectorFilter = sectorIdList.length == 0 || Arrays.stream(sectorIdList)
+            boolean floorFilter =
+                requestDto.getFloorList().length == 0 || Arrays.stream(requestDto.getFloorList())
+                    .anyMatch(floor -> floor == route.getSector().getFloor());
+            boolean sectorFilter = requestDto.getSectorIdList().length == 0 || Arrays.stream(
+                    requestDto.getSectorIdList())
                 .anyMatch(sectorId -> sectorId == route.getSector().getId());
             boolean gymDifficultyFilter =
-                gymDifficultyList.length == 0 || Arrays.stream(gymDifficultyList).anyMatch(
+                requestDto.getGymDifficultyList().length == 0 || Arrays.stream(
+                    requestDto.getGymDifficultyList()).anyMatch(
                     gymDifficulty -> gymDifficulty == route.getDifficultyMapping()
                         .getGymDifficulty());
             return floorFilter && sectorFilter && gymDifficultyFilter;

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -15,6 +15,7 @@ import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDet
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -39,9 +40,7 @@ public class RouteVersionService {
         if (routeVersionList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_VERSION_LIST);
         }
-        return routeVersionList.stream()
-            .map(routeVersion -> routeVersion.getTimePoint())
-            .toList();
+        return routeVersionList.stream().map(routeVersion -> routeVersion.getTimePoint()).toList();
     }
 
     public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user) {
@@ -71,12 +70,10 @@ public class RouteVersionService {
         String sectorIdListString = RouteVersionConverter.convertListToString(
             createRouteVersionRequest.getSectorIdList());
 
-        routeVersionRepository.save(
-            RouteVersion.toEntity(manager.getClimbingGym(), createRouteVersionRequest.getTimePoint(),
-                routeIdListString, sectorIdListString));
+        routeVersionRepository.save(RouteVersion.toEntity(manager.getClimbingGym(),
+            createRouteVersionRequest.getTimePoint(), routeIdListString, sectorIdListString));
 
     }
-
 
 
     public RouteVersionDetailResponse getRouteVersionDetail(Long gymId, LocalDate timePoint) {
@@ -116,6 +113,44 @@ public class RouteVersionService {
 
         return RouteVersionDetailResponse.toDto(climbingGym, sectorDetailResponses,
             routeListResponse);
+    }
+
+    public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId, LocalDate timePoint,
+        int[] floorList, Long[] sectorIdList, int[] gymDifficultyList) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
+                climbingGym, timePoint)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
+
+        List<Long> routeIdList = RouteVersionConverter.convertStringToList(
+            routeVersion.getRouteList());
+        if (routeIdList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
+        }
+
+        List<Route> routeList = routeRepository.findByIdIn(routeIdList);
+        if (routeList.size() != routeIdList.size()) {
+            throw new GeneralException(ErrorStatus._MISMATCH_ROUTE_IDS);
+        }
+
+        List<Route> filteredRouteList = routeList.stream().filter(route -> {
+            boolean floorFilter = floorList.length == 0 || Arrays.stream(floorList)
+                .anyMatch(floor -> floor == route.getSector().getFloor());
+            boolean sectorFilter = sectorIdList.length == 0 || Arrays.stream(sectorIdList)
+                .anyMatch(sectorId -> sectorId == route.getSector().getId());
+            boolean gymDifficultyFilter =
+                gymDifficultyList.length == 0 || Arrays.stream(gymDifficultyList).anyMatch(
+                    gymDifficulty -> gymDifficulty == route.getDifficultyMapping()
+                        .getGymDifficulty());
+            return floorFilter && sectorFilter && gymDifficultyFilter;
+        }).toList();
+        if (filteredRouteList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
+        }
+
+        return filteredRouteList.stream().map(RouteDetailResponse::toDto).toList();
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -18,4 +18,21 @@ public class RouteVersionRequestDto {
         private List<Long> sectorIdList;
     }
 
+    @Getter
+    public static class GetFilteredRouteVersionRequest {
+
+        private int[] floorList = null;
+        private Long[] sectorIdList = null;
+        private int[] gymDifficultyList = null;
+
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        private LocalDate timePoint;
+
+        public GetFilteredRouteVersionRequest() {
+            this.floorList = new int[0];
+            this.sectorIdList = new Long[0];
+            this.gymDifficultyList = new int[0];
+        }
+    }
+
 }


### PR DESCRIPTION
## 요약
-루트 필터링 기능을 구현했습니다
-필터링 종류는, floor, sector, difficulty 세 종류입니다.

## 상세 내용
우선 Controller입니다.
``` java
    @Operation(summary = "암장 특정 루트 버전 데이터 필터링해서 루트 불러오기")
    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS,
        ErrorStatus._EMPTY_ROUTE_LIST})
    @GetMapping("/{gymId}/version/filter")
    public ResponseEntity<List<RouteDetailResponse>> getRouteVersionFiltering(
        @CurrentUser User user, @PathVariable Long gymId,
        @RequestParam(value = "floor", defaultValue = "") int[] floorList,
        @RequestParam(value = "sector", defaultValue = "") Long[] sectorIdList,
        @RequestParam(value = "difficulty", defaultValue = "") int[] gymDifficultyList,
        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
        return ResponseEntity.ok(
            routeVersionService.getRouteVersionFiltering(gymId, timePoint, floorList, sectorIdList,
                gymDifficultyList));
    }
```
위와 같이 
PathVariable로 암장 ID를 받고,
RequestParam으로 floorList 배열, sectorIdList 배열, gymDifficultyList 배열을 입력받습니다.
(이름이 길어서 value로 호출시에는 간소화 시켰습니다.)
또한 RequestParam으로 timePoint를 입력받아, 특정 시점의 데이터를 가져올 수 있도록 하였습니다.

반환값은 RouteDetailResponse로 루트의 정보를 담고있는 Dto를 반환합니다.

다음으로 Service입니다.
``` java
public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId, LocalDate timePoint,
        int[] floorList, Long[] sectorIdList, int[] gymDifficultyList) {
        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));

        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
                climbingGym, timePoint)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));

        List<Long> routeIdList = RouteVersionConverter.convertStringToList(
            routeVersion.getRouteList());
        if (routeIdList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
        }

        List<Route> routeList = routeRepository.findByIdIn(routeIdList);
        if (routeList.size() != routeIdList.size()) {
            throw new GeneralException(ErrorStatus._MISMATCH_ROUTE_IDS);
        }

        List<Route> filteredRouteList = routeList.stream().filter(route -> {
            boolean floorFilter = floorList.length == 0 || Arrays.stream(floorList)
                .anyMatch(floor -> floor == route.getSector().getFloor());
            boolean sectorFilter = sectorIdList.length == 0 || Arrays.stream(sectorIdList)
                .anyMatch(sectorId -> sectorId == route.getSector().getId());
            boolean gymDifficultyFilter =
                gymDifficultyList.length == 0 || Arrays.stream(gymDifficultyList).anyMatch(
                    gymDifficulty -> gymDifficulty == route.getDifficultyMapping()
                        .getGymDifficulty());
            return floorFilter && sectorFilter && gymDifficultyFilter;
        }).toList();
        if (filteredRouteList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
        }

        return filteredRouteList.stream().map(RouteDetailResponse::toDto).toList();
    }
```
위와 같이 구현을 진행했고 진행 순서는 다음과 같습니다.
1. gymId로 암장을 가져옵니다.
2. 암장과 timePoint로 timePoint 시점의 암장 세팅을 가져옵니다.
3. 암장 세팅에서 routeList(String)를 List<Long>으로 변환하고, 루트 Id가 하나라도 들어있는 리스트인지 확인합니다.
4. 루트Id 리스트로 루트 리스트를 만들고 모두 실제로 존재하는 루트인지 확인합니다.
5. 모두 존재하는 루트라면 이제부터 필터링을 진행합니다.
5-1. 루트 리스트에서 하나씩 filter를 진행합니다.
5-2. floorFilter boolean을 통해 floorFilter를 사용할 것인지(requestParam에서 가져온 필터링 정보가 있는지 확인) 보고, 있다면 해당 floorList에 있는지 확인합니다.
5-3. sector, gymDifficulty에 대해서도 모두 확인합니다.
5-4. 필터링 요소가 단일로 존재할 경우 (ex. floor 1, 2) 결과를 합집합으로 출력하고, 필터링 요소가 섞여서 존재할 경우 (ex. floor 1, sector 1) 결과를 교집합으로 출력합니다.
6. 필터링된 루트 리스트가 빈 루트 리스트면 예외처리 합니다.
7. Dto에 담아서 반환합니다.

좀 더 자세히 필터링 과정을 설명하면
ex1) floor 1이랑 floor 2로 필터링 해주세요 -> floor가 1이거나, floor가 2인 루트 값을 가져온다.
ex2) floor 1이랑 sector 3으로 필터링 해주세요 -> floor가 1이고 secto가 3인 루트 값을 가져온다.
ex3) floor 1이랑 floor 2랑 sector 3으로 필터링 해주세요 -> floor가 1이거나 2인 루트 값 중에 sector가 3인 루트 값을 가져온다.

가 됩니다.

이상입니다.

## 테스트 확인 내용
테스트를 위해 섹터, 루트, 플로어, 난이도 모두 임의의 더미 데이터를 만들었고, 다양하게 테스트를 진행했습니다.
<img width="757" alt="스크린샷 2024-01-30 오후 9 26 46" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/d547e0c1-6581-48cf-9e03-17ff6a563a69">

<img width="759" alt="스크린샷 2024-01-30 오후 9 25 59" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/5c487fee-639a-4a96-b9f8-b76001e731f7">

정상적으로 모두 출력이 되는 것을 확인했고, 루트 버전에 존재하는 루트만 출력하는 것도 확인하였습니다.

더미 데이터에서 중요 부분만 올리면 다음과 같습니다.

1. 루트
<img width="350" alt="스크린샷 2024-01-30 오후 9 27 44" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/0cd0dc18-401d-4a2d-b373-a918a16421cf">

2. 섹터
<img width="314" alt="스크린샷 2024-01-30 오후 9 28 15" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/2070777a-2e0c-4159-98fc-e652daab183b">

3. 난이도 매핑
<img width="779" alt="스크린샷 2024-01-30 오후 9 28 40" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/4463b24b-6013-4f6d-bf2d-6ad3b68be632">



## 질문 및 이외 사항

- PR을 날리다가 깨달은건데, floor가 sector 내에 들어가있는 데이터라, 둘 다 서버에서 처리할 필요는 없을 것 같긴 합니다. 이 사항은 추후 리팩토링때 고려해서 진행하겠습니다.
