### PR TITLE
[SPR-106] GymName->GymId 변경, Jwt 토큰 발급 로직 수정, 토큰 Refresh api 개발

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -56,4 +56,8 @@ public class Climber extends User {
     public void updateProfileImageUrl(String profileImgUrl) {
         this.profileImageUrl = profileImgUrl;
     }
+
+    public String getPayload(){
+        return this.getId()+"+climber";
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -3,7 +3,6 @@ package com.climeet.climeet_backend.domain.climber;
 
 import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.CreateClimberRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto;
-import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberTokenRefreshResponse;
 import com.climeet.climeet_backend.domain.climber.enums.SocialType;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -21,18 +21,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
-import reactor.core.publisher.Mono;
+
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +72,7 @@ public class ClimberService {
     public Climber login(Climber climber) {
         try {
             String accessToken = jwtTokenProvider.createAccessToken(
-                String.valueOf(climber.getId()));
+                climber.getPayload());
             String refreshToken = jwtTokenProvider.createRefreshToken(climber.getId());
 
             climber.updateToken(accessToken, refreshToken);
@@ -104,7 +99,7 @@ public class ClimberService {
             .profileImageUrl(profileImg).build();
         climberRepository.save(climber);
 
-        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(climber.getId()));
+        String accessToken = jwtTokenProvider.createAccessToken(climber.getPayload());
         String refreshToken = jwtTokenProvider.createRefreshToken(climber.getId());
 
         //추가적으로 사진 url을 입력받으면 입력 받은 url로 변경, null이면 소셜 프로필 사진으로 유지

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
@@ -70,4 +70,8 @@ public class Manager extends User {
     public boolean checkPassword(String plainPassword, PasswordEncoder passwordEncoder){
         return passwordEncoder.matches(plainPassword, this.password);
     }
+
+    public String getPayload(){
+        return this.getId()+"+manager";
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -44,7 +44,7 @@ public class ManagerController {
     }
 
     @Operation(summary = "암장 등록 중복 확인", description = "이미 관리자가 등록된 암장인지 확인하는 API \n\n **이미 관리자 등록 되어있음** : false \n\n **관리자 등록 안되어 있음** : true")
-    @GetMapping("/isRegistered/{gymName}")
+    @GetMapping("/isRegistered/{gymId}")
     public ResponseEntity<Boolean> isRegistered(@PathVariable Long gymId){
         boolean isRegistered = !managerService.checkManagerRegistration(gymId);
         return ResponseEntity.ok(isRegistered);

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
@@ -8,12 +8,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ManagerRepository extends JpaRepository<Manager, Long> {
 
-    //Optional<Manager> findByName(String gymName);
     Optional<Manager> findByLoginId(String loginId);
     Optional<Manager> findByClimbingGym(ClimbingGym climbingGym);
 
     boolean existsByClimbingGym(ClimbingGym gym);
 
-    Optional<Manager> findByLoginIdAndPassword(String loginId, String password);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
@@ -40,7 +40,7 @@ public class ManagerService {
         if(!IdManager.checkPassword(password, passwordEncoder)){
             throw new GeneralException(ErrorStatus._WRONG_LOGINID_PASSWORD);
         }
-        String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(IdManager.getId()));
+        String accessToken = jwtTokenProvider.createAccessToken(IdManager.getPayload());
         String refreshToken = jwtTokenProvider.createRefreshToken(IdManager.getId());
         IdManager.updateToken(accessToken, refreshToken);
 
@@ -65,6 +65,11 @@ public class ManagerService {
         if(managerRepository.findByLoginId(createManagerRequest.getLoginId()).isPresent()){
             throw new GeneralException(ErrorStatus._DUPLICATE_LOGINID);
         }
+
+        if(checkManagerRegistration(createManagerRequest.getGymId())){
+            throw new GeneralException(ErrorStatus._DUPLICATE_GYM_MANAGER);
+        }
+
 
         Manager manager = Manager.toEntity(createManagerRequest, gym);
         manager.hashPassword(passwordEncoder);

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name="User")
@@ -17,13 +19,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     private final UserService userService;
 
-//    @PostMapping("/refresh-token")
-//    @Operation(description = "소셜 Access token, Refresh token 재발급 ")
-//    public ResponseEntity<UserTokenSimpleInfo> refreshToken(String refreshToken){
-//        UserTokenSimpleInfo userTokenSimpleInfo = userService.updateUserToken(refreshToken);
-//        return ResponseEntity.ok(userTokenSimpleInfo);
-//
-//
-//    }
+    @PostMapping("/refresh-token")
+    @Operation(description = "소셜 Access token, Refresh token 재발급 ")
+    public ResponseEntity<UserTokenSimpleInfo> refreshToken(@RequestParam String refreshToken){
+        UserTokenSimpleInfo userTokenSimpleInfo = userService.updateUserToken(refreshToken);
+        return ResponseEntity.ok(userTokenSimpleInfo);
+
+
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -25,7 +25,6 @@ public class UserService {
     }
     public UserTokenSimpleInfo updateUserToken(String refreshToken){
         Long userId = Long.valueOf(jwtTokenProvider.getPayload(refreshToken));
-        System.out.println(userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus._INVALID_JWT));
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.user;
 
+import com.climeet.climeet_backend.domain.climber.ClimberRepository;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ClimberRepository climberRepository;
     public User updateNotification(User user, boolean isAllowFollowNotification, boolean isAllowLikeNotification, boolean isAllowCommentNotification, boolean isAllowAdNotification){
         if(user==null){
             throw new GeneralException(ErrorStatus._EMPTY_MEMBER);

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -23,6 +23,7 @@ public class UserService {
     }
     public UserTokenSimpleInfo updateUserToken(String refreshToken){
         Long userId = Long.valueOf(jwtTokenProvider.getPayload(refreshToken));
+        System.out.println(userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new GeneralException(ErrorStatus._INVALID_JWT));
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
@@ -32,5 +33,5 @@ public class UserService {
         return new UserTokenSimpleInfo(user);
 
     }
-
+//eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxNCIsImlhdCI6MTcwNjY4MDgzMiwiZXhwIjoxNzA2NjgxNDM3fQ.1HFtfxeqiLTinrt0SSrQJaPJt5N5_H8mPwTgxwG4wY8ItrnkaMifOrjz5znqGar1b-jNzXI5sKqp-V0hCcG5KQ
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -12,21 +12,27 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class UserService {
+
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final ClimberRepository climberRepository;
-    public User updateNotification(User user, boolean isAllowFollowNotification, boolean isAllowLikeNotification, boolean isAllowCommentNotification, boolean isAllowAdNotification){
-        if(user==null){
+
+    public User updateNotification(User user, boolean isAllowFollowNotification,
+        boolean isAllowLikeNotification, boolean isAllowCommentNotification,
+        boolean isAllowAdNotification) {
+        if (user == null) {
             throw new GeneralException(ErrorStatus._EMPTY_MEMBER);
         }
-        user.updateNotification(isAllowFollowNotification, isAllowLikeNotification, isAllowCommentNotification, isAllowAdNotification);
+        user.updateNotification(isAllowFollowNotification, isAllowLikeNotification,
+            isAllowCommentNotification, isAllowAdNotification);
         return userRepository.save(user);
 
     }
-    public UserTokenSimpleInfo updateUserToken(String refreshToken){
+
+    public UserTokenSimpleInfo updateUserToken(String refreshToken) {
         Long userId = Long.valueOf(jwtTokenProvider.getPayload(refreshToken));
         User user = userRepository.findById(userId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus._INVALID_JWT));
+            .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_JWT));
         String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
         String newAccesstoken = jwtTokenProvider.refreshAccessToken(refreshToken);
         user.updateToken(newRefreshToken, newAccesstoken);
@@ -34,5 +40,4 @@ public class UserService {
         return new UserTokenSimpleInfo(user);
 
     }
-//eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxNCIsImlhdCI6MTcwNjY4MDgzMiwiZXhwIjoxNzA2NjgxNDM3fQ.1HFtfxeqiLTinrt0SSrQJaPJt5N5_H8mPwTgxwG4wY8ItrnkaMifOrjz5znqGar1b-jNzXI5sKqp-V0hCcG5KQ
 }

--- a/src/main/java/com/climeet/climeet_backend/global/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/CurrentUserArgumentResolver.java
@@ -43,7 +43,12 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
             Claims claims = Jwts.parser().setSigningKey(jwtTokenProvider.getSecretKey())
                 .parseClaimsJws(token).getBody();
 
-            String userId = claims.getSubject();
+            String targetIndex = "+";
+
+            String targetSubject = claims.getSubject();
+
+            int index = targetSubject.indexOf(targetIndex);
+            String userId = targetSubject.substring(0, index);
 
             return userRepository.findById(Long.valueOf(userId))
                 .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));

--- a/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package com.climeet.climeet_backend.global.security;
 
-import static java.lang.Long.parseLong;
 
 import com.climeet.climeet_backend.domain.climber.Climber;
 import com.climeet.climeet_backend.domain.climber.ClimberRepository;
@@ -14,17 +13,8 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.interfaces.ECPrivateKey;
-import java.time.LocalDate;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Optional;
-import java.util.Random;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
@@ -81,7 +81,7 @@ public class JwtTokenProvider {
             .setClaims(claims)
             .setIssuedAt(now)
             .setExpiration(validity)
-            .signWith(SignatureAlgorithm.HS512, getSecretKey())
+            .signWith(SignatureAlgorithm.HS256, getSecretKey())
             .compact();
     }
 

--- a/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
@@ -72,7 +72,9 @@ public class JwtTokenProvider {
 
     public String refreshAccessToken(String refreshToken) {
         if (validateToken(refreshToken)) {
-            return createAccessToken(getPayload(refreshToken));
+            Long climberId = Long.parseLong(getPayload(refreshToken));
+            Climber climber = climberRepository.findById(climberId).orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_MEMBER));
+            return createAccessToken(climber.getPayload());
         } else {
             throw new GeneralException(ErrorStatus._INVALID_JWT);
         }


### PR DESCRIPTION
## 요약
- 암장 등록 중복 확인을 "GymName"에서 "GymId"를 사용하는 방식으로 변경하였습니다
- 기존의 서버 Jwt 토큰 발급 시 access token과 refresh token이 동일한 payload로 생성되고 있어서 변경하였고, 관련된 코드들을 수정하였습니다
- refresh token으로 access token을 재발급 받는 api를 개발하였습니다. 더불어, application-dev.yml을 수정(토큰 유효기간 변경)하였기 때문에 yml파일 pull 받아주세요!

- ## 상세 내용
1. 토큰 발급 로직 수정
```java
public String createAccessToken(String payload){
      return createToken(payload, accessTokenValidityInMilliseconds);
  }

    public String createRefreshToken(Long climberId) {
        return createToken(climberId.toString(), refreshTokenValidityInMillseconds);
    }

```
- 기존 access token과 refresh token을 발급 시 모두 userId를 사용했는데, refresh token은 userId를 사용하는 것을 유지하고, access token은 임의의 payload(userId+"{climber OR manager}")를 사용하도록 변경하였습니다. 
climber, manager 엔티티에 getPayload 함수를 추가하였습니다. 

2. 토큰 refresh api 작동 과정
**토큰 재발급 로직은 모든 유저에게 공통으로 사용되므로, User 도메인에 코드를 작성하였습니다**

- 클라이언트가 refresh token을 입력하면, userId를 파싱해온다
- userId의 유효성을 검증한다
- 문제가 없다면, JwtTokenProvider에서 새로운 access token과 refresh token을 발급 후 DB에 업데이트한다

## 테스트 확인 내용
swagger에서 회원가입 과정부터 새로 수행하면서 정상 작동함을 확인 하였습니다
기존 HS512에서 HS256으로 토큰 생성 알고리즘을 변경하여서, 기존 DB 유저는 사용이 불가능합니다. 유저 DB 한번 정리하도록 하겠습니다!

## 질문 및 이외 사항
