### PR TITLE
[SPR-74] 암장 크롤링 데이터 DB 저장 및 반환 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -4,6 +4,7 @@ import com.climeet.climeet_backend.domain.climbinggymimage.ClimbingGymBackground
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -51,6 +52,20 @@ public class ClimbingGym extends BaseTimeEntity {
     private Float sumRating = 0.0F;
 
     private int reviewCount = 0;
+
+    private String tel;
+
+    private String address;
+
+    @Column(columnDefinition = "json")
+    private String businessHours;
+
+    public void updateGymInfo(String tel, String address, String businessHours) {
+        this.tel = tel;
+        this.address = address;
+        this.businessHours = businessHours;
+    }
+
 
     public void reviewCreate(Float rating) {
         this.sumRating += rating;
@@ -113,4 +128,5 @@ public class ClimbingGym extends BaseTimeEntity {
         this.thisWeekSelectionCount--;
 
     }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -1,6 +1,8 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymRequestDto.UpdateClimbingGymInfoRequest;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
@@ -11,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -47,6 +50,13 @@ public class ClimbingGymController {
         @RequestPart Long gymId,
         @RequestPart MultipartFile layoutImage) {
         return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, gymId));
+    }
+
+    @Operation(summary = "암장 크롤링 정보 입력")
+    @PostMapping("/info")
+    public ResponseEntity<ClimbingGymDetailResponse> updateClimbingGymInfo(
+        @RequestBody UpdateClimbingGymInfoRequest updateClimbingGymInfoRequest) {
+        return ResponseEntity.ok(climbingGymService.updateClimbingGymInfo(updateClimbingGymInfoRequest));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.climbinggym;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymRequestDto.UpdateClimbingGymInfoRequest;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymInfoResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
@@ -67,7 +68,7 @@ public class ClimbingGymController {
 
     @Operation(summary = "암장 크롤링 정보 입력")
     @PostMapping("/info")
-    public ResponseEntity<ClimbingGymDetailResponse> updateClimbingGymInfo(
+    public ResponseEntity<ClimbingGymInfoResponse> updateClimbingGymInfo(
         @RequestBody UpdateClimbingGymInfoRequest updateClimbingGymInfoRequest) {
         return ResponseEntity.ok(climbingGymService.updateClimbingGymInfo(updateClimbingGymInfoRequest));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.climbinggym;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymRequestDto.UpdateClimbingGymInfoRequest;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymInfoResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.domain.manager.Manager;
@@ -108,7 +109,7 @@ public class ClimbingGymService {
     }
 
 
-    public ClimbingGymDetailResponse updateClimbingGymInfo(
+    public ClimbingGymInfoResponse updateClimbingGymInfo(
 
 
         UpdateClimbingGymInfoRequest updateClimbingGymInfoRequest) {
@@ -131,7 +132,7 @@ public class ClimbingGymService {
             String businessHours = jsonNode.get("businessHours").toString();
             climbingGym.updateGymInfo(tel, address, businessHours);
             Map<String, List<String>> businessHoursMap = objectMapper.readValue(businessHours, new TypeReference<Map<String, List<String>>>() {});
-            return ClimbingGymDetailResponse.toDto(climbingGymRepository.save(climbingGym), businessHoursMap);
+            return ClimbingGymInfoResponse.toDto(climbingGymRepository.save(climbingGym), businessHoursMap);
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus._ERROR_JSON_PARSE);
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -28,6 +29,9 @@ public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
     private final S3Service s3Service;
+
+    @Value("${cloud.aws.lambda.crawling-uri}")
+    private String crawlingUri;
 
     public PageResponseDto<List<ClimbingGymSimpleResponse>> searchClimbingGym(String gymName,
         int page, int size) {
@@ -89,6 +93,8 @@ public class ClimbingGymService {
     }
 
     public ClimbingGymDetailResponse updateClimbingGymInfo(
+
+
         UpdateClimbingGymInfoRequest updateClimbingGymInfoRequest) {
         ClimbingGym climbingGym = climbingGymRepository.findById(
                 updateClimbingGymInfoRequest.getGymId())
@@ -96,8 +102,7 @@ public class ClimbingGymService {
 
         RestClient restClient = RestClient.create();
 
-        String callUrl = "https://i9jkabugud.execute-api.ap-northeast-2.amazonaws.com/dev/gym?word="
-            + climbingGym.getName();
+        String callUrl = crawlingUri + "?word="+ climbingGym.getName();
 
         String gymInfoResult = restClient.get().uri(callUrl).retrieve().body(String.class);
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymRequestDto.java
@@ -1,0 +1,14 @@
+package com.climeet.climeet_backend.domain.climbinggym.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ClimbingGymRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateClimbingGymInfoRequest {
+        private Long gymId;
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -1,7 +1,8 @@
 package com.climeet.climeet_backend.domain.climbinggym.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.route.Route;
+import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,6 +71,28 @@ public class ClimbingGymResponseDto {
         public static LayoutDetailResponse toDto(String layoutImageUrl) {
             return LayoutDetailResponse.builder()
                 .layoutImageUrl(layoutImageUrl)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClimbingGymDetailResponse {
+
+        private String name;
+        private String address;
+        private String tel;
+        private Map<String, List<String>> businessHours;
+
+        public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym,
+            Map<String, List<String>> businessHours) {
+            return ClimbingGymDetailResponse.builder()
+                .name(climbingGym.getName())
+                .address(climbingGym.getAddress())
+                .tel(climbingGym.getTel())
+                .businessHours(businessHours)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -106,16 +106,16 @@ public class ClimbingGymResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ClimbingGymDetailResponse {
+    public static class ClimbingGymInfoResponse {
 
         private String name;
         private String address;
         private String tel;
         private Map<String, List<String>> businessHours;
 
-        public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym,
+        public static ClimbingGymInfoResponse toDto(ClimbingGym climbingGym,
             Map<String, List<String>> businessHours) {
-            return ClimbingGymDetailResponse.builder()
+            return ClimbingGymInfoResponse.builder()
                 .name(climbingGym.getName())
                 .address(climbingGym.getAddress())
                 .tel(climbingGym.getTel())

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_MANAGER_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_002", "관리자가 존재하지 않는 암장입니다"),
     _DUPLICATE_GYM_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_003", "이미 관리자가 등록된 암장입니다."),
     _EMPTY_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_004", "해당 관리자가 존재하지 않습니다."),
+    _ERROR_JSON_PARSE(HttpStatus.CONFLICT, "CLIMBING_GYM_005", "JSON 파싱을 할 수 없습니다."),
 
     //루트 버전 관련
     _EMPTY_VERSION_LIST(HttpStatus.CONFLICT, "ROUTE_VERSION_001", "암장의 루트 버전이 존재하지 않습니다."),


### PR DESCRIPTION
## 요약
- 암장 크롤링 데이터를 파싱해서 DB에 저장하고 반환하는 기능 구현입니다.

## 상세 내용
1. Lambda에서 암장 데이터를 가져옵니다.
2. 가져온 데이터는 다음과 같습니다.
``` json
{
    "name": "홍성클라이밍센터",
    "tel": "010-3389-8848",
    "address": "충청남도 홍성군 홍북읍 봉신리 290-13 2층",
    "businessHours": {
        "수": [
            "16:00",
            "22:00"
        ],
        "목": [
            "16:00",
            "22:00"
        ],
        "금": [
            "16:00",
            "22:00"
        ],
        "월": [
            "16:00",
            "22:00"
        ],
        "화": [
            "16:00",
            "22:00"
        ]
    }
}
```
3. 해당 값을 String으로 받아오고, 받아온 데이터를 파싱하여  DB에 넣음과 동시에 파싱한 값을 반환합니다.

## 테스트 확인 내용
<img width="754" alt="스크린샷 2024-01-31 오후 4 16 47" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/02cf55b1-39f7-4ad4-b403-5405155360a0">
<img width="755" alt="스크린샷 2024-01-31 오후 4 17 04" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/9d2b4ad0-5266-4430-a878-1a3ff6714f0b">
<img width="746" alt="스크린샷 2024-01-31 오후 4 17 19" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/cd545a83-08c0-423a-b88f-dbda9cda0347">

다음과 같습니다!

DB에 저장되는 값은 다음과 같습니다!
<img width="767" alt="스크린샷 2024-01-31 오후 4 18 17" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/8cb17c1b-741c-4830-b9d8-6293b7179188">

값이 없을 때에는 빈 문자열 값을 저장할 것이며, businessHours는 빈 배열을 반환할 것입니다.
또한 정기휴일과 같이 운영시간이 없는 경우에는 해당 일자가 입력되지 않습니다.
- 빈 문자열 반환
<img width="743" alt="스크린샷 2024-01-31 오후 4 20 39" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/30215612-c61e-49ab-966c-6ff1e3cb5519">
- 영업일자 없을 때
<img width="512" alt="스크린샷 2024-01-31 오후 4 21 00" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/83d46199-7bd4-4ce3-9d04-1f84ac0477b0">
이상입니다.

## 질문 및 이외 사항

