### PR TITLE
[SPR-98] RouteVersion 기능 변경 (루트 파인딩 화면에 맞춰 수정)

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -50,7 +50,7 @@ public class RouteVersionController {
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 
-    @Operation(summary = "암장 특정 루트 버전 데이터 불러오기")
+    @Operation(summary = "암장 특정 루트버전 데이터 불러오기")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._EMPTY_SECTOR_LIST,
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -2,6 +2,9 @@ package com.climeet.climeet_backend.domain.routeversion;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.domain.route.Route;
@@ -32,6 +35,7 @@ public class RouteVersionService {
     private final RouteRepository routeRepository;
     private final SectorRepository sectorRepository;
     private final ManagerRepository managerRepository;
+    private final DifficultyMappingRepository difficultyMappingRepository;
 
     public List<LocalDate> getRouteVersionList(Long gymId) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
@@ -107,13 +111,21 @@ public class RouteVersionService {
             throw new GeneralException(ErrorStatus._MISMATCH_SECTOR_IDS);
         }
 
+        List<DifficultyMapping> difficultyList = difficultyMappingRepository.findByClimbingGymOrderByGymDifficultyAsc(
+            climbingGym);
+        if (difficultyList.isEmpty()) {
+            throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);
+        }
+
         List<RouteDetailResponse> routeListResponse = routeList.stream()
-            .map(route -> RouteDetailResponse.toDto(route)).toList();
+            .map(RouteDetailResponse::toDto).toList();
         List<SectorDetailResponse> sectorDetailResponses = sectorList.stream()
-            .map(sector -> SectorDetailResponse.toDto(sector)).toList();
+            .map(SectorDetailResponse::toDto).toList();
+        List<DifficultyMappingDetailResponse> difficultyMappingDetailResponses = difficultyList.stream()
+            .map(DifficultyMappingDetailResponse::toDto).toList();
 
         return RouteVersionDetailResponse.toDto(climbingGym, sectorDetailResponses,
-            routeListResponse);
+            routeListResponse, difficultyMappingDetailResponses);
     }
 
     public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId,

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -96,8 +96,7 @@ public class RouteVersionService {
         if (routeIdList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
         }
-        System.out.println(routeIdList);
-
+        
         routeIdList = routeIdList.stream().sorted(Collections.reverseOrder()).toList();
         routeIdList = routeIdList.subList(0, Math.min(routeIdList.size(), 10));
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -20,6 +20,8 @@ import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -94,6 +96,10 @@ public class RouteVersionService {
         if (routeIdList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
         }
+        System.out.println(routeIdList);
+
+        routeIdList = routeIdList.stream().sorted(Collections.reverseOrder()).toList();
+        routeIdList = routeIdList.subList(0, Math.min(routeIdList.size(), 10));
 
         List<Long> sectorIdList = RouteVersionConverter.convertStringToList(
             routeVersion.getSectorList());
@@ -162,6 +168,7 @@ public class RouteVersionService {
                         .getGymDifficulty());
             return floorFilter && sectorFilter && gymDifficultyFilter;
         }).toList();
+
         if (filteredRouteList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.routeversion.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
 import java.util.List;
@@ -21,14 +22,17 @@ public class RouteVersionResponseDto {
         private String layoutImageUrl;
         private List<SectorDetailResponse> sectorList;
         private List<RouteDetailResponse> routeList;
+        private List<DifficultyMappingDetailResponse> difficultyList;
 
         public static RouteVersionDetailResponse toDto(ClimbingGym climbingGym,
-            List<SectorDetailResponse> sectorList, List<RouteDetailResponse> routeList) {
+            List<SectorDetailResponse> sectorList, List<RouteDetailResponse> routeList,
+            List<DifficultyMappingDetailResponse> difficultyList) {
             return RouteVersionDetailResponse.builder()
                 .gymId(climbingGym.getId())
                 .layoutImageUrl(climbingGym.getLayoutImageUrl())
                 .sectorList(sectorList)
                 .routeList(routeList)
+                .difficultyList(difficultyList)
                 .build();
         }
     }


### PR DESCRIPTION
## 요약
- RouteVersion 기능 변경 (루트 파인딩 화면에 맞춰 수정)

## 상세 내용
1. 루트 파인딩 화면에서 difficultyMapping 데이터를 안보내는 오류를 해결했습니다.

아래 Service의 한 부분을 통해 DifficultyMapping 데이터를 불러오며, Dto로 변환하여 함께 보내게 됩니다.
``` java
List<DifficultyMapping> difficultyList = difficultyMappingRepository.findByClimbingGymOrderByGymDifficultyAsc(
            climbingGym);
        if (difficultyList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);
        }
```

2. 루트 파인딩 화면에서 필터링 되지 않았을 때 모든 루트를 보내는 방식에서 최신 10개의 루트만 보내는 방식으로 변경했습니다.


아래 Service 단의 코드를 통해서, id 리스트를 정렬하고, 최대 10개까지만 출력하도록 변경하였습니다.
``` java
routeIdList = routeIdList.stream().sorted(Collections.reverseOrder()).toList();
        routeIdList = routeIdList.subList(0, Math.min(routeIdList.size(), 10));
```


## 테스트 확인 내용
- 10개 이상인 루트에서 불러오고, 10개 이하인 루트에서도 불러왔는데 모두 정상적으로 동작합니다.
- 테스트 결과는 너무 길어서 패...패스...합니다.

## 질문 및 이외 사항

- reverse를 하고 그대로 10개를 자른 뒤 Dto에 담아서 출력했으면, 21 20 19 18 순서의 id로 가져오는게 맞는거같은데, 이상하게 12 13 14...20 21 순으로 10개를 가져옵니다... 뭔가 이상하지만 잘 돌아가는 그런 느낌...입니다...!
