### PR TITLE
[SPR-109] feat: banner 리스트 조회

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class BannerController {
     private final BannerService bannerService;
 
-    @GetMapping("api/banner")
+    @GetMapping("api/banners")
     public ResponseEntity<List<BannerDetailInfo>> getBannerListBetweenDates(
         @CurrentUser User user
     ){

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerController.java
@@ -1,10 +1,23 @@
 package com.climeet.climeet_backend.domain.banner;
 
+import com.climeet.climeet_backend.domain.banner.dto.BannerResponseDto.BannerDetailInfo;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class BannerController {
+    private final BannerService bannerService;
 
+    @GetMapping("api/banner")
+    public ResponseEntity<List<BannerDetailInfo>> getBannerListBetweenDates(
+        @CurrentUser User user
+    ){
+        return ResponseEntity.ok(bannerService.getBannerListBetweenDates());
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface BannerRepository extends JpaRepository<Banner, Long> {
     @Query("SELECT b "
         + "FROM Banner b "
-        + "WHERE :currentDate >= b.bannerStartDate AND :curDate <= b.bannerEndDate")
+        + "WHERE :currentDate >= b.bannerStartDate AND :currentDate <= b.bannerEndDate")
     List<Banner> findByBannerStartDateBeforeAndBannerEndDateAfter(LocalDate currentDate);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface BannerRepository extends JpaRepository<Banner, Long> {
     @Query("SELECT b "
         + "FROM Banner b "
-        + "WHERE :curDate >= b.bannerStartDate AND :curDate <= b.bannerEndDate")
-    List<Banner> findByBannerStartDateBeforeAndBannerEndDateAfter(LocalDate curDate);
+        + "WHERE :currentDate >= b.bannerStartDate AND :curDate <= b.bannerEndDate")
+    List<Banner> findByBannerStartDateBeforeAndBannerEndDateAfter(LocalDate currentDate);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerRepository.java
@@ -1,7 +1,14 @@
 package com.climeet.climeet_backend.domain.banner;
 
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BannerRepository extends JpaRepository<Banner, Long> {
+    @Query("SELECT b "
+        + "FROM Banner b "
+        + "WHERE :curDate >= b.bannerStartDate AND :curDate <= b.bannerEndDate")
+    List<Banner> findByBannerStartDateBeforeAndBannerEndDateAfter(LocalDate curDate);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerService.java
@@ -1,10 +1,23 @@
 package com.climeet.climeet_backend.domain.banner;
 
+import com.climeet.climeet_backend.domain.banner.dto.BannerResponseDto.BannerDetailInfo;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class BannerService {
+    private final BannerRepository bannerRepository;
 
+    public List<BannerDetailInfo> getBannerListBetweenDates(){
+        LocalDate curDate = LocalDate.now();
+        List<Banner> bannerList = bannerRepository.findByBannerStartDateBeforeAndBannerEndDateAfter(curDate);
+        return bannerList.stream()
+            .map(BannerDetailInfo::toDTO)
+            .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/BannerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/BannerService.java
@@ -11,11 +11,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class BannerService {
+
     private final BannerRepository bannerRepository;
 
-    public List<BannerDetailInfo> getBannerListBetweenDates(){
-        LocalDate curDate = LocalDate.now();
-        List<Banner> bannerList = bannerRepository.findByBannerStartDateBeforeAndBannerEndDateAfter(curDate);
+    public List<BannerDetailInfo> getBannerListBetweenDates() {
+        LocalDate currentDate = LocalDate.now();
+        List<Banner> bannerList = bannerRepository.findByBannerStartDateBeforeAndBannerEndDateAfter(
+            currentDate);
         return bannerList.stream()
             .map(BannerDetailInfo::toDTO)
             .collect(Collectors.toList());

--- a/src/main/java/com/climeet/climeet_backend/domain/banner/dto/BannerResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/banner/dto/BannerResponseDto.java
@@ -1,0 +1,45 @@
+package com.climeet.climeet_backend.domain.banner.dto;
+
+import com.climeet.climeet_backend.domain.banner.Banner;
+import com.climeet.climeet_backend.domain.bestclimber.clear.BestClearClimber;
+import com.climeet.climeet_backend.domain.bestclimber.clear.dto.BestClearClimberResponseDto;
+import java.time.LocalDate;
+import java.util.PrimitiveIterator;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BannerResponseDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BannerDetailInfo{
+
+        private Long id;
+        private String bannerImageUrl;
+        private String title;
+        private String bannerTargetUrl;
+        private LocalDate bannerStartDate;
+        private LocalDate bannerEndDate;
+        private Boolean isPopup;
+        private String linkUrl;
+
+
+        public static BannerDetailInfo toDTO(
+            Banner banner){
+
+            return BannerDetailInfo.builder()
+                .id(banner.getId())
+                .bannerImageUrl(banner.getBannerImageUrl())
+                .title(banner.getTitle())
+                .bannerTargetUrl(banner.getBannerTargetUrl())
+                .bannerStartDate(banner.getBannerStartDate())
+                .bannerEndDate(banner.getBannerEndDate())
+                .isPopup(banner.getIsPopup())
+                .linkUrl(banner.getLinkUrl())
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 현재 날짜 기준 진행 준인 Banner List 조회

## 상세 내용
### BannerController
```java
@GetMapping("api/banners")
    public ResponseEntity<List<BannerDetailInfo>> getBannerListBetweenDates(
        @CurrentUser User user
    ){
        return ResponseEntity.ok(bannerService.getBannerListBetweenDates());
    }
```
- 해당 API 하나만 만들었습니다.
- BannerDetailInfo에는 Banner의 생성,수정시간을 제외한 모든 값이 담겨있습니다.


### BannerService 
```java
public List<BannerDetailInfo> getBannerListBetweenDates(){
        LocalDate currentDate = LocalDate.now();
        List<Banner> bannerList = bannerRepository.findByBannerStartDateBeforeAndBannerEndDateAfter(currentDate);
        return bannerList.stream()
            .map(BannerDetailInfo::toDTO)
            .collect(Collectors.toList());
    }
```
- 현재 날짜를 리퍼지토리 메서드에 인자로 전달합니다.

### BannerRepository
```java
public interface BannerRepository extends JpaRepository<Banner, Long> {
    @Query("SELECT b "
        + "FROM Banner b "
        + "WHERE :currentDate >= b.bannerStartDate AND :currentDate <= b.bannerEndDate")
    List<Banner> findByBannerStartDateBeforeAndBannerEndDateAfter(LocalDate currentDate);

}
```
- @Query 어노테이션을 통해 DB에 있는 값 중 startDate가 인자로 넘겨진 현재날짜보다 같거나 작고, endDate가 현재날짜보다 같거나 큰 항목들을 받아왔습니다.
- 참고
> 저는 저 부등호를 사용하지 못해서 막혔있었습니다.. 공식문서에서도 안나와있길래(찾지 못하였기에) 몰랐었는데 부등호를 사용할 수 있더군요..
![스크린샷 2024-02-01 오전 12 32 11](https://github.com/TheClimeet/climeet-spring/assets/100510247/7551da99-4765-4d16-b0e4-d7503239e8d8)
형식에 안 맞는 값을 넣었을 때 뜨는 경고문구의 `oprator`라는 단어를 통해 알았습니다..ㅎ
왜 당연히 안된다고 생각하고 있었을까요? 우물 안의 개구리임을 다시 깨달았습니다..
어쨌든 성공..!

## 테스트 확인 내용
<img width="1159" alt="스크린샷 2024-02-01 오전 12 22 58" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/8a0741d3-3214-48f6-b341-37a32b7ef91d">

- 현재 날짜 기준 시작 날짜와 종료 날짜가 요청을 보낸 현재 날짜를 포함하고 있는 항목들을 조회하는 로직을 구현하였습니다.
- 현재 날짜가 아닌 다른 임의의 날짜를 넣어보기도 하고 db의 값을 수정하면서도 테스트해봤습니다.
- 테스트 내용

> ❌ 현재 날짜가 시작 날짜보다 작은 데이터 -> 조회 안 됨.
> ❌ 현재 날짜가 시작 날짜와 종료 날짜 보다 큰 데이터 -> 조회 안 됨.
> ❌ 현재 날짜가 종료 날짜보다 큰 데이터 -> 조회 안 됨.
> ❌ 현재 날짜가 시작날짜보다 작고 종료날짜보다 큰 데이터 -> 잘못 들어간 값. 당연히 조회 안 됨.
> ✅ 현재 날짜가 시작날짜보다 크고 종료날짜보다 작거나 같은 데이터 -> 정상값. 조회 성공

## 질문 및 이외 사항
- 날짜를 기준으로 조회하는 로직만 구현하였습니다.
- 그 이유는 db에 배너를 넣고 제거하는 것은 리툴을 통해 관리자가 작업할 내용이기 때문입니다.
- 헤일에게 질문드려보고 배너의 순서 기준이 적용 되어야 한다고 하면 그 때 수정하겠습니다.
