### PR TITLE
[SPR-59] 암장 프로필 정보(상단) 불러오기

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -1,15 +1,19 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
+import com.climeet.climeet_backend.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,6 +51,13 @@ public class ClimbingGymController {
         @RequestPart Long gymId,
         @RequestPart MultipartFile layoutImage) {
         return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, gymId));
+    }
+
+    @Operation(summary = "암장 프로필 정보 (상단) 불러오기")
+    @GetMapping("/{gymId}")
+    public ResponseEntity<ClimbingGymDetailResponse> getClimbingGymInfo(
+        @PathVariable Long gymId, @CurrentUser User user) {
+        return ResponseEntity.ok(climbingGymService.getClimbingGymInfo(gymId));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -6,7 +6,9 @@ import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -46,14 +48,15 @@ public class ClimbingGymController {
     }
 
     @Operation(summary = "암장 도면 이미지 수정")
+    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER})
     @PostMapping("/layout")
     public ResponseEntity<LayoutDetailResponse> changeLayoutImage(
-        @RequestPart Long gymId,
-        @RequestPart MultipartFile layoutImage) {
-        return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, gymId));
+        @CurrentUser User user, @RequestPart MultipartFile layoutImage) {
+        return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, user));
     }
 
     @Operation(summary = "암장 프로필 정보 (상단) 불러오기")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_MANAGER})
     @GetMapping("/{gymId}")
     public ResponseEntity<ClimbingGymDetailResponse> getClimbingGymInfo(
         @PathVariable Long gymId, @CurrentUser User user) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -6,6 +6,7 @@ import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
@@ -75,14 +76,15 @@ public class ClimbingGymService {
 
     }
 
-    public LayoutDetailResponse changeLayoutImage(MultipartFile layoutImage, Long gymId) {
-        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+    public LayoutDetailResponse changeLayoutImage(MultipartFile layoutImage, User user) {
+
+        Manager manager = managerRepository.findById(user.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
         String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
-        climbingGym.changeLayoutImageUrl(layoutImageUrl);
+        manager.getClimbingGym().changeLayoutImageUrl(layoutImageUrl);
 
-        climbingGymRepository.save(climbingGym);
+        climbingGymRepository.save(manager.getClimbingGym());
 
         return LayoutDetailResponse.toDto(layoutImageUrl);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -1,8 +1,11 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
+import com.climeet.climeet_backend.domain.manager.Manager;
+import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
@@ -20,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
+    private final ManagerRepository managerRepository;
     private final S3Service s3Service;
 
     public PageResponseDto<List<ClimbingGymSimpleResponse>> searchClimbingGym(String gymName,
@@ -82,4 +86,15 @@ public class ClimbingGymService {
 
         return LayoutDetailResponse.toDto(layoutImageUrl);
     }
+
+    public ClimbingGymDetailResponse getClimbingGymInfo(Long gymId) {
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        Manager manager = managerRepository.findByClimbingGym(climbingGym)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
+
+        return ClimbingGymDetailResponse.toDto(climbingGym, manager);
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -1,7 +1,7 @@
 package com.climeet.climeet_backend.domain.climbinggym.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.route.Route;
+import com.climeet.climeet_backend.domain.manager.Manager;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,6 +70,32 @@ public class ClimbingGymResponseDto {
         public static LayoutDetailResponse toDto(String layoutImageUrl) {
             return LayoutDetailResponse.builder()
                 .layoutImageUrl(layoutImageUrl)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClimbingGymDetailResponse {
+        private String gymProfileImageUrl;
+        private String managerProfileImageUrl;
+        private String gymName;
+        private Long followerCount;
+        private Long followingCount;
+        private float averageRating;
+        private int reviewCount;
+
+        public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym, Manager manager){
+            return ClimbingGymDetailResponse.builder()
+                .gymProfileImageUrl(climbingGym.getProfileImageUrl())
+                .managerProfileImageUrl(manager.getProfileImageUrl())
+                .gymName(climbingGym.getName())
+                .followerCount(manager.getFollowerCount())
+                .followingCount(manager.getFollowingCount())
+                .averageRating(climbingGym.getAverageRating())
+                .reviewCount(climbingGym.getReviewCount())
                 .build();
         }
     }


### PR DESCRIPTION
## 요약
- 간단한 암장 프로필 정보 불러오기 기능입니다.

## 상세 내용
- 다음 부분을 만들었습니다.
<img width="495" alt="스크린샷 2024-02-01 오후 3 06 21" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/c7fb32fe-9456-402b-9fc7-7527c265166d">

- Controller
gymId로 검색을 합니다.
``` java
    @Operation(summary = "암장 프로필 정보 (상단) 불러오기")
    @GetMapping("/{gymId}")
    public ResponseEntity<ClimbingGymDetailResponse> getClimbingGymInfo(
        @PathVariable Long gymId, @CurrentUser User user) {
        return ResponseEntity.ok(climbingGymService.getClimbingGymInfo(gymId));
    }
```

- Service
암장을 불러오고, 암장으로 매니저를 불러옵니다.
``` java
    public ClimbingGymDetailResponse getClimbingGymInfo(Long gymId) {
        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));

        Manager manager = managerRepository.findByClimbingGym(climbingGym)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));

        return ClimbingGymDetailResponse.toDto(climbingGym, manager);
    }
```

- Dto
gymProfileImageUrl은 위 부분의 배경사진이고,
managerProfileImageUrl은 암장 로고가 들어가는 부분의 사진입니다.
``` java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class ClimbingGymDetailResponse {
        private String gymProfileImageUrl;
        private String managerProfileImageUrl;
        private String gymName;
        private Long followerCount;
        private Long followingCount;
        private float averageRating;
        private int reviewCount;

        public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym, Manager manager){
            return ClimbingGymDetailResponse.builder()
                .gymProfileImageUrl(climbingGym.getProfileImageUrl())
                .managerProfileImageUrl(manager.getProfileImageUrl())
                .gymName(climbingGym.getName())
                .followerCount(manager.getFollowerCount())
                .followingCount(manager.getFollowingCount())
                .averageRating(climbingGym.getAverageRating())
                .reviewCount(climbingGym.getReviewCount())
                .build();
        }
    }
```

- 추가적으로 위와 별개로 암장 프로필 변경 API에서 변경사항이 있습니다.
CurrentUser를 적용해서 사용자인지 확인 -> 사용자가 manager이어야 변경이 가능하고, manager의 ClimbingGym을 받아와서 해당 암장의 데이터를 변경하도록 하였습니다.
따라서 해당 API에서 gymId를 받아오는 것에서 CurrentUser의 User를 사용하는 것으로 변경했습니다.


## 테스트 확인 내용
- 다음과 같은 결과값이 정상적으로 출력되는것을 확인했습니다.
<img width="755" alt="스크린샷 2024-02-01 오후 3 13 22" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/1754b276-b3f1-41ad-8523-f7c699590bc3">

## 질문 및 이외 사항

- 해당 유저가 팔로우 했는지 여부도 같이 반환을 하는게 좋을까요?
