### PR TITLE
[SPR-111] 토큰 refresh api swagger 명세 수정, 클라이머 회원가입 시 팔로우 count 증가 로직 구현, user엔티티 column default 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -119,6 +119,7 @@ public class ClimberService {
             Manager manager = managerRepository.findByClimbingGym(optionalGym)
                 .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM));
             followRelationshipService.createFollowRelationship(manager, climber);
+            manager.updateFollwerCount();
 
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -85,4 +85,8 @@ public class User {
         this.thisWeekTotalClimbingTime -= sec;
     }
 
+    public void updateFollwerCount(){
+        this.followerCount++;
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -41,14 +42,19 @@ public class User {
 
     private Boolean isAllowAdNotification;
 
+    @ColumnDefault("0L")
     private Long followerCount = 0L;
 
+    @ColumnDefault("0L")
     private Long followingCount = 0L;
 
+    @ColumnDefault("0")
     private int thisWeekCompleteCount = 0;
 
+    @ColumnDefault("0L")
     private Long thisWeekTotalClimbingTime = 0L;
 
+    @ColumnDefault("0")
     private int thisWeekHighDifficulty = 0;
 
     @CreatedDate

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -1,7 +1,10 @@
 package com.climeet.climeet_backend.domain.user;
 
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +23,8 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/refresh-token")
-    @Operation(description = "소셜 Access token, Refresh token 재발급 ")
+    @Operation(summary = "소셜 Access token, Refresh token 재발급 ")
+    @SwaggerApiError({ErrorStatus._INVALID_JWT, ErrorStatus._EXPIRED_JWT, ErrorStatus._INVALID_MEMBER})
     public ResponseEntity<UserTokenSimpleInfo> refreshToken(@RequestParam String refreshToken){
         UserTokenSimpleInfo userTokenSimpleInfo = userService.updateUserToken(refreshToken);
         return ResponseEntity.ok(userTokenSimpleInfo);


### PR DESCRIPTION
## 요약
자잘한 수정을 여러 개 진행하였습니다

1. 토큰 refresh api swagger summary 추가
2. 토큰 refresh api SwaggerApiError 명세 추가
3. 클라이머 회원가입 진행 시 암장 팔로우 경우 암장 follwerCount 수 추가
4. User엔티티 ColumnDefault 추가

## 상세 내용


## 테스트 확인 내용



## 질문 및 이외 사항


