### PR TITLE
[SPR-86] 암장 제공 서비스 등록 내부 로직 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/BitmaskConverter.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/BitmaskConverter.java
@@ -1,0 +1,30 @@
+package com.climeet.climeet_backend.domain.climbinggym;
+
+import com.climeet.climeet_backend.domain.climbinggym.enums.ServiceBitmask;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BitmaskConverter {
+
+    // Service List → Bitmask
+    public int convertServiceListToBitmask(List<ServiceBitmask> serviceList) {
+        int bitmask = 0;
+        for (ServiceBitmask serviceBitMask : serviceList) {
+            bitmask |= serviceBitMask.getValue();
+        }
+        return bitmask;
+    }
+
+    // Bitmask → Service List
+    public List<ServiceBitmask> convertBitmaskToServiceList(int bitmask) {
+        List<ServiceBitmask> serviceList = new ArrayList<>();
+        for (ServiceBitmask service : ServiceBitmask.values()) {
+            if ((bitmask & service.getValue()) != 0) {
+                serviceList.add(service);
+            }
+        }
+        return serviceList;
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -81,6 +81,10 @@ public class ClimbingGym extends BaseTimeEntity {
 
     private int serviceBitMask = 0;
 
+    public void updateServiceBitMask(int value){
+        this.serviceBitMask = value;
+    }
+
     public void setManager(Manager manager) {
         // 기존 Manager와의 관계를 해제
         if (this.manager != null) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ServiceBitMask.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ServiceBitMask.java
@@ -1,4 +1,0 @@
-package com.climeet.climeet_backend.domain.climbinggym;
-
-public enum ServiceBitMask {
-}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/enums/ServiceBitmask.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/enums/ServiceBitmask.java
@@ -1,0 +1,13 @@
+package com.climeet.climeet_backend.domain.climbinggym.enums;
+
+public enum ServiceBitmask {
+        샤워_시설,
+        샤워_용품,
+        수건_제공,
+        간이_세면대,
+        초크_대여,
+        암벽화_대여,
+        삼각대_대여,
+        운동복_대여;
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/enums/ServiceBitmask.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/enums/ServiceBitmask.java
@@ -1,13 +1,23 @@
 package com.climeet.climeet_backend.domain.climbinggym.enums;
 
 public enum ServiceBitmask {
-        샤워_시설,
-        샤워_용품,
-        수건_제공,
-        간이_세면대,
-        초크_대여,
-        암벽화_대여,
-        삼각대_대여,
-        운동복_대여;
+    샤워_시설(1),
+    샤워_용품(2),
+    수건_제공(4),
+    간이_세면대(8),
+    초크_대여(16),
+    암벽화_대여(32),
+    삼각대_대여(64),
+    운동복_대여(128);
+
+    private int value;
+
+    ServiceBitmask(int value){
+        this.value = value;
+    }
+
+    public int getValue(){
+        return value;
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -35,7 +35,7 @@ public class ManagerController {
     }
 
     @PostMapping("/signup")
-    @Operation(summary = "관리자 회원가입", description = "**Enum 설명**\n\n**ServiceBitmask** :  샤워_시설,샤워_용품,수건_제공,간이_세면대,초크_대여,암벽화_대여,삼각대_대여,운동복_대여")
+    @Operation(summary = "관리자 회원가입", description = "**Enum 설명**\n\n**ServiceBitmask** :  샤워\\_시설,  샤워\\_용품,  수건\\_제공,  간이\\_세면대,  초크\\_대여,  암벽화\\_대여,  삼각대\\_대여,  운동복\\_대여")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._DUPLICATE_LOGINID})
     public ResponseEntity<ManagerSimpleInfo> signUp(@RequestBody
         CreateManagerRequest createManagerRequest){

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -35,7 +35,7 @@ public class ManagerController {
     }
 
     @PostMapping("/signup")
-    @Operation(summary = "관리자 회원가입", description = "관리자 회원가입 API")
+    @Operation(summary = "관리자 회원가입", description = "**Enum 설명**\n\n**ServiceBitmask** :  샤워_시설,샤워_용품,수건_제공,간이_세면대,초크_대여,암벽화_대여,삼각대_대여,운동복_대여")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._DUPLICATE_LOGINID})
     public ResponseEntity<ManagerSimpleInfo> signUp(@RequestBody
         CreateManagerRequest createManagerRequest){

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
@@ -1,8 +1,10 @@
 package com.climeet.climeet_backend.domain.manager;
 
 
+import com.climeet.climeet_backend.domain.climbinggym.BitmaskConverter;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
+import com.climeet.climeet_backend.domain.climbinggym.enums.ServiceBitmask;
 import com.climeet.climeet_backend.domain.climbinggymimage.ClimbingGymBackgroundImage;
 import com.climeet.climeet_backend.domain.climbinggymimage.ClimbingGymBackgroundImageRepository;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateAccessTokenRequest;
@@ -13,6 +15,7 @@ import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,6 +32,7 @@ public class ManagerService {
     private final ClimbingGymBackgroundImageRepository climbingGymBackgroundImageRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final BitmaskConverter bitmaskConverter;
 
     @Transactional
     public ManagerSimpleInfo login(@RequestBody CreateAccessTokenRequest createAccessTokenRequest){
@@ -86,6 +90,10 @@ public class ManagerService {
         String accessToken = jwtTokenProvider.createAccessToken(manager.getPayload());
         String refreshToken = jwtTokenProvider.createRefreshToken(manager.getId());
         manager.updateToken(accessToken, refreshToken);
+
+        //서비스 리스트 등록
+        List<ServiceBitmask> gymServiceList = createManagerRequest.getProvideServiceList();
+        gym.updateServiceBitMask(bitmaskConverter.convertServiceListToBitmask(gymServiceList));
 
         return new ManagerSimpleInfo(manager);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/dto/ManagerRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/dto/ManagerRequestDto.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.manager.dto;
 
+import com.climeet.climeet_backend.domain.climbinggym.enums.ServiceBitmask;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ public class ManagerRequestDto {
         private String phoneNumber;
         private String email;
         private String backGroundImageUri;
-        private List<String> provideServiceList; //구현 후 처리 예정
+        private List<ServiceBitmask> provideServiceList;
         private String businessRegistrationImageUrl;
         private Boolean isAllowFollowNotification;
         private Boolean isAllowLikeNotification;


### PR DESCRIPTION
## 요약
-BitMask 로직을 이용하여 암장 제공 서비스를 등록하는 로직을 구현하였습니다
-swagger description에 ServiceBitmask Enum값 명시를 추가하였습니다

## 상세 내용
**Thanks to Moveat!**
- ServiceBitmask Enum코드는 다음과 같습니다
각각의 서비스 스트링 값은 생성자로 괄호 안의 값을 같습니다. 
```java
public enum ServiceBitmask {
    샤워_시설(1),
    샤워_용품(2),
    수건_제공(4),
    간이_세면대(8),
    초크_대여(16),
    암벽화_대여(32),
    삼각대_대여(64),
    운동복_대여(128);

    private int value;

    ServiceBitmask(int value){
        this.value = value;
    }
```

- 관리자 회원가입 manager service SignUp 함수에서 Climbing 도메인에 있는 BitmaskConverter 서비스의 함수를 호출하여 처리합니다. convertServiceListToBitmask 함수를 통해 enum 리스트 값들을 int로 변환하여 climbinggym의 serviceBitMask 컬럼 값을 업데이트 합니다.
```java
 List<ServiceBitmask> gymServiceList = createManagerRequest.getProvideServiceList();
        gym.updateServiceBitMask(bitmaskConverter.convertServiceListToBitmask(gymServiceList));
```

-converServiceListToBitmask함수**(무빗이 작성)** : 생성 시 부여받은 값들을 bit OR연산을 통해 정수 값으로 변환합니다
```java
public int convertServiceListToBitmask(List<ServiceBitmask> serviceList) {
        int bitmask = 0;
        for (ServiceBitmask serviceBitMask : serviceList) {
            bitmask |= serviceBitMask.getValue();
        }
        return bitmask;
    }

```


## 테스트 확인 내용
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/0c5f39a1-dac6-46bf-a17b-e224820bf35d)
관리자 회원가입 과정을 수행하면서 정상적으로 DB에 값이 저장되는 것을 확인하였습니다. 
1. 모든 값을 넣었을 때 -> 255
2. 그 외의 경우 -> "1"에 해당하는 "샤워_시설"을 제외하고 넣음 => 254


## 질문 및 이외 사항

