### PR TITLE
[SPR-112] 루트버전 테이블 관련 수정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGym.java
@@ -40,12 +40,6 @@ public class ClimbingGym extends BaseTimeEntity {
 
     private String profileImageUrl;
 
-    private String layoutImageUrl;
-
-    public void changeLayoutImageUrl(String layoutImageUrl) {
-        this.layoutImageUrl = layoutImageUrl;
-    }
-
     private Float AverageRating = 0.0F;
 
     private Float sumRating = 0.0F;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -2,7 +2,6 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
-import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,12 +9,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "ClimbingGym", description = "암장 관련 API")
 @RestController
@@ -39,14 +35,6 @@ public class ClimbingGymController {
         @RequestParam("gymname") String gymName, @RequestParam int page, @RequestParam int size
     ) {
         return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName, page, size));
-    }
-
-    @Operation(summary = "암장 도면 이미지 수정")
-    @PostMapping("/layout")
-    public ResponseEntity<LayoutDetailResponse> changeLayoutImage(
-        @RequestPart Long gymId,
-        @RequestPart MultipartFile layoutImage) {
-        return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, gymId));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -5,7 +5,6 @@ import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymInfoResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
-import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -46,14 +45,6 @@ public class ClimbingGymController {
         @RequestParam("gymname") String gymName, @RequestParam int page, @RequestParam int size
     ) {
         return ResponseEntity.ok(climbingGymService.searchAcceptedClimbingGym(gymName, page, size));
-    }
-
-    @Operation(summary = "암장 도면 이미지 수정")
-    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER})
-    @PostMapping("/layout")
-    public ResponseEntity<LayoutDetailResponse> changeLayoutImage(
-        @CurrentUser User user, @RequestPart MultipartFile layoutImage) {
-        return ResponseEntity.ok(climbingGymService.changeLayoutImage(layoutImage, user));
     }
 
     @Operation(summary = "암장 프로필 정보 (상단) 불러오기")

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -2,25 +2,19 @@ package com.climeet.climeet_backend.domain.climbinggym;
 
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
-import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
-import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
-import com.climeet.climeet_backend.global.response.exception.GeneralException;
-import com.climeet.climeet_backend.global.s3.S3Service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
-    private final S3Service s3Service;
 
     public PageResponseDto<List<ClimbingGymSimpleResponse>> searchClimbingGym(String gymName,
         int page, int size) {
@@ -69,17 +63,5 @@ public class ClimbingGymService {
         return new PageResponseDto<>(pageable.getPageNumber(), climbingGymSlice.hasNext(),
             climbingGymList);
 
-    }
-
-    public LayoutDetailResponse changeLayoutImage(MultipartFile layoutImage, Long gymId) {
-        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
-
-        String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
-        climbingGym.changeLayoutImageUrl(layoutImageUrl);
-
-        climbingGymRepository.save(climbingGym);
-
-        return LayoutDetailResponse.toDto(layoutImageUrl);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -5,14 +5,11 @@ import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymInfoResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
-import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.LayoutDetailResponse;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
-import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
-import com.climeet.climeet_backend.global.s3.S3Service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,7 +22,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -33,7 +29,6 @@ public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
     private final ManagerRepository managerRepository;
-    private final S3Service s3Service;
 
     @Value("${cloud.aws.lambda.crawling-uri}")
     private String crawlingUri;
@@ -83,19 +78,6 @@ public class ClimbingGymService {
         return new PageResponseDto<>(pageable.getPageNumber(), climbingGymSlice.hasNext(),
             climbingGymList);
 
-    }
-
-    public LayoutDetailResponse changeLayoutImage(MultipartFile layoutImage, User user) {
-
-        Manager manager = managerRepository.findById(user.getId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
-
-        String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
-        manager.getClimbingGym().changeLayoutImageUrl(layoutImageUrl);
-
-        climbingGymRepository.save(manager.getClimbingGym());
-
-        return LayoutDetailResponse.toDto(layoutImageUrl);
     }
 
     public ClimbingGymDetailResponse getClimbingGymInfo(Long gymId) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -1,7 +1,6 @@
 package com.climeet.climeet_backend.domain.climbinggym.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.route.Route;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -57,21 +56,6 @@ public class ClimbingGymResponseDto {
                 .build();
         }
 
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class LayoutDetailResponse {
-
-        private String layoutImageUrl;
-
-        public static LayoutDetailResponse toDto(String layoutImageUrl) {
-            return LayoutDetailResponse.builder()
-                .layoutImageUrl(layoutImageUrl)
-                .build();
-        }
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -65,21 +65,6 @@ public class ClimbingGymResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class LayoutDetailResponse {
-
-        private String layoutImageUrl;
-
-        public static LayoutDetailResponse toDto(String layoutImageUrl) {
-            return LayoutDetailResponse.builder()
-                .layoutImageUrl(layoutImageUrl)
-                .build();
-        }
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class ClimbingGymDetailResponse {
         private String gymProfileImageUrl;
         private String managerProfileImageUrl;

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
@@ -30,6 +30,8 @@ public class RouteVersion extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ClimbingGym climbingGym;
 
+    private String layoutImageUrl;
+
     @NotNull
     private LocalDate timePoint;
 
@@ -41,10 +43,10 @@ public class RouteVersion extends BaseTimeEntity {
 
 
     public static RouteVersion toEntity(ClimbingGym climbingGym, LocalDate timePoint,
-        String routeList,
-        String sectorList) {
+        String routeList, String sectorList, String layoutImageUrl) {
         return RouteVersion.builder()
             .climbingGym(climbingGym)
+            .layoutImageUrl(layoutImageUrl)
             .timePoint(timePoint)
             .routeList(routeList)
             .sectorList(sectorList)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -21,7 +21,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "RouteVersion", description = "암장 루트 버전 API")
 @RestController
@@ -45,8 +47,9 @@ public class RouteVersionController {
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
     @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
-        @RequestBody CreateRouteVersionRequest createRouteVersionRequest, @CurrentUser User user) {
-        routeVersionService.createRouteVersion(createRouteVersionRequest, user);
+        @RequestPart(value = "request") CreateRouteVersionRequest createRouteVersionRequest,
+        @RequestPart(required = false) MultipartFile layoutImage,@CurrentUser User user) {
+        routeVersionService.createRouteVersion(createRouteVersionRequest, user, layoutImage);
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionRepository.java
@@ -11,5 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface RouteVersionRepository extends JpaRepository<RouteVersion, Long> {
     List<RouteVersion> findByClimbingGymOrderByTimePointDesc(ClimbingGym climbingGym);
 
+    Optional<RouteVersion> findFirstByClimbingGymAndTimePointLessThanEqualOrderByTimePointDesc(ClimbingGym climbingGym, LocalDate timePoint);
+
     Optional<RouteVersion> findByClimbingGymAndTimePoint(ClimbingGym climbingGym, LocalDate timePoint);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -105,7 +105,7 @@ public class RouteVersionService {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
-        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
+        RouteVersion routeVersion = routeVersionRepository.findFirstByClimbingGymAndTimePointLessThanEqualOrderByTimePointDesc(
                 climbingGym, timePoint)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
 
@@ -148,7 +148,7 @@ public class RouteVersionService {
             .map(DifficultyMappingDetailResponse::toDto).toList();
 
         return RouteVersionDetailResponse.toDto(climbingGym, sectorDetailResponses,
-            routeListResponse, difficultyMappingDetailResponses, routeVersion.getLayoutImageUrl());
+            routeListResponse, difficultyMappingDetailResponses, routeVersion);
     }
 
     public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId,
@@ -156,7 +156,7 @@ public class RouteVersionService {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
-        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
+        RouteVersion routeVersion = routeVersionRepository.findFirstByClimbingGymAndTimePointLessThanEqualOrderByTimePointDesc(
                 climbingGym, requestDto.getTimePoint())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -19,14 +19,15 @@ import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDet
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import com.climeet.climeet_backend.global.s3.S3Service;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +39,7 @@ public class RouteVersionService {
     private final SectorRepository sectorRepository;
     private final ManagerRepository managerRepository;
     private final DifficultyMappingRepository difficultyMappingRepository;
+    private final S3Service s3Service;
 
     public List<LocalDate> getRouteVersionList(Long gymId) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
@@ -50,7 +52,8 @@ public class RouteVersionService {
         return routeVersionList.stream().map(routeVersion -> routeVersion.getTimePoint()).toList();
     }
 
-    public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user) {
+    public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user,
+        MultipartFile layoutImage) {
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
@@ -77,11 +80,26 @@ public class RouteVersionService {
         String sectorIdListString = RouteVersionConverter.convertListToString(
             createRouteVersionRequest.getSectorIdList());
 
+        // 이미지 url이나 이미지 파일이 들어오지 않았을 때 예외처리
+        if (layoutImage == null && createRouteVersionRequest.getLayoutImageUrl() == null) {
+            throw new GeneralException(ErrorStatus._EMPTY_LAYOUT_IMAGE);
+        }
+
+        String layoutImageUrl;
+        // 이미지 파일이 들어왔으면 s3에 업로드 후 사용
+        if (layoutImage != null) {
+            layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
+        }
+        // 이미지 파일이 안들어왔으면 기존 url 그대로 사용
+        else {
+            layoutImageUrl = createRouteVersionRequest.getLayoutImageUrl();
+        }
+
         routeVersionRepository.save(RouteVersion.toEntity(manager.getClimbingGym(),
-            createRouteVersionRequest.getTimePoint(), routeIdListString, sectorIdListString));
+            createRouteVersionRequest.getTimePoint(), routeIdListString, sectorIdListString,
+            layoutImageUrl));
 
     }
-
 
     public RouteVersionDetailResponse getRouteVersionDetail(Long gymId, LocalDate timePoint) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
@@ -96,7 +114,7 @@ public class RouteVersionService {
         if (routeIdList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_ROUTE_LIST);
         }
-        
+
         routeIdList = routeIdList.stream().sorted(Collections.reverseOrder()).toList();
         routeIdList = routeIdList.subList(0, Math.min(routeIdList.size(), 10));
 
@@ -130,7 +148,7 @@ public class RouteVersionService {
             .map(DifficultyMappingDetailResponse::toDto).toList();
 
         return RouteVersionDetailResponse.toDto(climbingGym, sectorDetailResponses,
-            routeListResponse, difficultyMappingDetailResponses);
+            routeListResponse, difficultyMappingDetailResponses, routeVersion.getLayoutImageUrl());
     }
 
     public List<RouteDetailResponse> getRouteVersionFiltering(Long gymId,

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -16,6 +16,7 @@ public class RouteVersionRequestDto {
         private LocalDate timePoint;
         private List<Long> routeIdList;
         private List<Long> sectorIdList;
+        private String layoutImageUrl;
     }
 
     @Getter

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -26,10 +26,10 @@ public class RouteVersionResponseDto {
 
         public static RouteVersionDetailResponse toDto(ClimbingGym climbingGym,
             List<SectorDetailResponse> sectorList, List<RouteDetailResponse> routeList,
-            List<DifficultyMappingDetailResponse> difficultyList) {
+            List<DifficultyMappingDetailResponse> difficultyList, String layoutImageUrl) {
             return RouteVersionDetailResponse.builder()
                 .gymId(climbingGym.getId())
-                .layoutImageUrl(climbingGym.getLayoutImageUrl())
+                .layoutImageUrl(layoutImageUrl)
                 .sectorList(sectorList)
                 .routeList(routeList)
                 .difficultyList(difficultyList)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -3,7 +3,9 @@ package com.climeet.climeet_backend.domain.routeversion.dto;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
+import com.climeet.climeet_backend.domain.routeversion.RouteVersion;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +21,7 @@ public class RouteVersionResponseDto {
     public static class RouteVersionDetailResponse {
 
         private Long gymId;
+        private LocalDate timePoint;
         private String layoutImageUrl;
         private List<SectorDetailResponse> sectorList;
         private List<RouteDetailResponse> routeList;
@@ -26,10 +29,11 @@ public class RouteVersionResponseDto {
 
         public static RouteVersionDetailResponse toDto(ClimbingGym climbingGym,
             List<SectorDetailResponse> sectorList, List<RouteDetailResponse> routeList,
-            List<DifficultyMappingDetailResponse> difficultyList, String layoutImageUrl) {
+            List<DifficultyMappingDetailResponse> difficultyList, RouteVersion routeVersion) {
             return RouteVersionDetailResponse.builder()
                 .gymId(climbingGym.getId())
-                .layoutImageUrl(layoutImageUrl)
+                .timePoint(routeVersion.getTimePoint())
+                .layoutImageUrl(routeVersion.getLayoutImageUrl())
                 .sectorList(sectorList)
                 .routeList(routeList)
                 .difficultyList(difficultyList)

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _MISMATCH_ROUTE_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_003", "등록된 루트 데이터 중 불러오지 못한 값이 있습니다."),
     _MISMATCH_SECTOR_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_004", "등록된 섹터 데이터 중 불러오지 못한 값이 있습니다."),
     _DUPLICATE_ROUTE_VERSION(HttpStatus.CONFLICT, "ROUTE_VERSION_005", "해당일에 이미 등록된 버전이 있습니다."),
+    _EMPTY_LAYOUT_IMAGE(HttpStatus.CONFLICT, "ROUTE_VERSION_006", "암장 도면 관련 데이터가 없습니다."),
 
     //난이도 매핑 관련
     _INVALID_DIFFICULTY(HttpStatus.CONFLICT, "DIFFICULTY_MAPPING_001", "해당하는 난이도가 없습니다."),


### PR DESCRIPTION
## 요약
1. 암장 도면 컬럼이 암장 테이블에서 루트 버전 테이블로 이동했습니다.
2. 루트 버전을 추가하는 기능에서 암장 도면 관련해서 추가했습니다.
3. 특정 일자에 해당하는 루트 버전이 없다면, 가장 가까운  이전 일자의 버전을 가져옵니다.

## 상세 내용
1. 암장 도면 컬럼이 암장 테이블에서 루트 버전 테이블로 이동했습니다.
- ClimbingGym 테이블의 layoutProfileImageUrl 컬럼을 삭제하고, 관련된 함수도 모두 없앴습니다.
- 대신 루트 버전에서 해당 이미지를 관리하도록 추가했습니다.


2. 루트 버전을 추가하는 기능에서 암장 도면 관련해서 추가했습니다.
- 1번과 이어져서, 루트 버전 테이블에서 해당 layoutProfileImageUrl을 사용합니다.
- 각 루트 버전마다 해당 컬럼을 관리하게 됩니다.
- 루트 버전이 생성될 때 레이아웃이 변동되지 않는다면, 그대로 Url이 입력되고, 변동된다면 이미지를 받아서 새로운 이미지 url을 저장합니다.
> 분기를 나누어 설명하자면 프론트에서 둘 중 하나를 입력받게 됩니다. (이미지 url, 이미지 파일)
> 1. 둘 다 입력되지 않았을 때 -> 예외처리
> 2. 둘 중 이미지 url만 입력되었을 때 -> 이미지 url을 그대로 사용
> 3. 둘 중 이미지 파일만 입력되었을 때  -> 이미지 파일을 s3에 업로드 후 반환된 url을 사용
> 4. 둘  모두 입력되었을 때 -> 3번과 동일하게 이미지 파일을 s3에 업로드 후 반환된 url을 사용
> 따라서 둘 다 입력되지 않았을 때 예외처리를 먼저 하고, 
> 이후 이미지 파일이 입력되었는지 확인 후 있다면 이미지 파일을 업로드 후 사용
> 그렇지 않은 경우에는 2번의 상황만 남으므로 이미지 url을 그대로 사용
> 이 됩니다.

관련 코드는 Service 단의 아래와 같습니다.
``` java
        // 이미지 url이나 이미지 파일이 들어오지 않았을 때 예외처리
        if (layoutImage == null && createRouteVersionRequest.getLayoutImageUrl() == null) {
            throw new GeneralException(ErrorStatus._EMPTY_LAYOUT_IMAGE);
        }

        String layoutImageUrl;
        // 이미지 파일이 들어왔으면 s3에 업로드 후 사용
        if (layoutImage != null) {
            layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
        }
        // 이미지 파일이 안들어왔으면 기존 url 그대로 사용
        else {
            layoutImageUrl = createRouteVersionRequest.getLayoutImageUrl();
        }
```


3. 특정 일자에 해당하는 루트 버전이 없다면, 가장 가까운  이전 일자의 버전을 가져옵니다.
- 예를 들어 2024-01-13, 2024-01-15, 2024-01-20의 데이터가 있을 때
- 2024-01-13을 검색하면 2024-01-13의 데이터를 반환하고
- 2024-01-14를 검색하면 2024-01-13의 데이터를 반환하고
- 2024-01-18을 검색하면 2024-01-15의 데이터를 반환하고
- 다음과 같이 진행됩니다.

코드는 repository에 추가한 것만 확인하시면 됩니다.
풀어서 설명하자면, 

찾는데, 첫번째것을 찾는데, 암장에 해당하는 데이터와, 입력된 timePoint보다 작거나 같은 가장 가까운 값을 찾는다는 의미입니다.

``` java
Optional<RouteVersion> findFirstByClimbingGymAndTimePointLessThanEqualOrderByTimePointDesc(ClimbingGym climbingGym, LocalDate timePoint);
```


## 테스트 확인 내용
- 2번의 경우 각 분기에 따라서 정상적으로 동작하는 것 확인했습니다.
<img width="587" alt="스크린샷 2024-02-01 오후 9 05 13" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/654782bb-1c39-4d5c-a874-7dce73fe88e7">

- 3번의 경우에도 
<img width="774" alt="스크린샷 2024-02-01 오후 9 01 48" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/beb695f4-34d7-4cd3-9b60-7a5e9898df86">
<img width="760" alt="스크린샷 2024-02-01 오후 9 02 45" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/4618e126-e996-48ad-beb2-dfe2fd9410ff">
<img width="756" alt="스크린샷 2024-02-01 오후 9 03 23" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/8ea46d05-1a34-4101-be2d-be3e03018cda">
다음과 같이 각 상황에 맞게 확인할 수 있습니다.

## 질문 및 이외 사항
- 암장 도면 url이 상당히 중복 데이터가 많이 입력되는 것 같아서, 관련 테이블을 따로 빼고 하려고 했는데, 일단 PR 날리고 추후에 수정 진행하겠습니다...!
