### PR TITLE
[SPR-118] 유저 팔로우/언팔로우 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -119,7 +119,7 @@ public class ClimberService {
             Manager manager = managerRepository.findByClimbingGym(optionalGym)
                 .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM));
             followRelationshipService.createFollowRelationship(manager, climber);
-            manager.updateFollwerCount();
+            manager.increaseFollwerCount();
 
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
@@ -26,11 +26,11 @@ public class FollowRelationship extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "follower_id")
     private User follower;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "following_id")
     private User following;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
@@ -1,0 +1,35 @@
+package com.climeet.climeet_backend.domain.followrelationship;
+
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.domain.user.UserRepository;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="FollowRelationship")
+@RequiredArgsConstructor
+@RestController
+public class FollowRelationshipController {
+    private final FollowRelationshipService followRelationshipService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/follow/{userId}")
+    @Operation(summary = "유저 팔로우 API")
+    @SwaggerApiError({ErrorStatus._EMPTY_USER})
+    public ResponseEntity<String> followUser(@RequestParam Long followerUserID, @CurrentUser User currentUser){
+        User followerUser = userRepository.findById(followerUserID)
+                .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
+        followRelationshipService.createFollowRelationship(currentUser, followerUser);
+        return ResponseEntity.ok("팔로우 완료");
+    }
+
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
@@ -20,8 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class FollowRelationshipController {
     private final FollowRelationshipService followRelationshipService;
-    private final UserRepository userRepository;
-    private final FollowRelationshipRepository followRelationshipRepository;
 
     @PostMapping("/follow-relationship/{userId}")
     @Operation(summary = "유저 팔로우")

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
@@ -23,28 +23,21 @@ public class FollowRelationshipController {
     private final UserRepository userRepository;
     private final FollowRelationshipRepository followRelationshipRepository;
 
-    @PostMapping("/follow/{userId}")
+    @PostMapping("/follow-relationship/{userId}")
     @Operation(summary = "유저 팔로우")
     @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._EXIST_FOLLOW_RELATIONSHIP})
     public ResponseEntity<String> followUser(@RequestParam Long followingUserId, @CurrentUser User currentUser){
-        User followingUser = userRepository.findById(followingUserId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
-        if(followRelationshipRepository.findByFollowerIdAndFollowingId(currentUser.getId(), followingUserId).isPresent()) {
-            throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
-        }
-        followRelationshipService.createFollowRelationship(currentUser, followingUser);
+        User following = followRelationshipService.findByUserId(followingUserId);
+        followRelationshipService.createFollowRelationship(currentUser, following);
         return ResponseEntity.ok("팔로우 완료");
     }
 
-    @DeleteMapping("/unfollow/{userId}")
+    @DeleteMapping("/follow-relationship/{userId}")
     @Operation(summary = "유저 팔로우 취소")
     @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._EXIST_FOLLOW_RELATIONSHIP})
     public ResponseEntity<String> unfollowUser(@RequestParam Long followingUserId, @CurrentUser User currentUser){
-        userRepository.findById(followingUserId)
-            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
-        FollowRelationship followRelationship = followRelationshipRepository.findByFollowerIdAndFollowingId(currentUser.getId(), followingUserId)
-            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_FOLLOW_RELATIONSHIP));
-        followRelationshipService.deleteFollowRelationship(followRelationship);
+        User following = followRelationshipService.findByUserId(followingUserId);
+        followRelationshipService.deleteFollowRelationship(following, currentUser);
         return ResponseEntity.ok("팔로우 취소 완료");
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipRepository.java
@@ -1,9 +1,13 @@
 package com.climeet.climeet_backend.domain.followrelationship;
 
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowRelationshipRepository extends JpaRepository<FollowRelationship, Long> {
 
+    Optional<FollowRelationship> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    void deleteById(Long followRelationshipId);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipRepository.java
@@ -1,12 +1,14 @@
 package com.climeet.climeet_backend.domain.followrelationship;
 
-import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FollowRelationshipRepository extends JpaRepository<FollowRelationship, Long> {
+    List<FollowRelationship> findByFollowerId(Long followerId);
+    List<FollowRelationship> findByFollowingId(Long followingId);
 
     Optional<FollowRelationship> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
     void deleteById(Long followRelationshipId);

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -11,9 +11,13 @@ import org.springframework.stereotype.Service;
 public class FollowRelationshipService {
 
     private final FollowRelationshipRepository followRelationshipRepository;
-    public FollowRelationship createFollowRelationship(User follower, User followee) {
+    public void createFollowRelationship(User follower, User followee) {
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, followee);
-        return followRelationshipRepository.save(followRelationship);
+        followRelationshipRepository.save(followRelationship);
+    }
+
+    public void deleteFollowRelationship(FollowRelationship followRelationship){
+        followRelationshipRepository.deleteById(followRelationship.getId());
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -14,10 +14,12 @@ public class FollowRelationshipService {
     public void createFollowRelationship(User follower, User followee) {
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, followee);
         followRelationshipRepository.save(followRelationship);
+        follower.increaseFollwerCount();
     }
 
     public void deleteFollowRelationship(FollowRelationship followRelationship){
         followRelationshipRepository.deleteById(followRelationship.getId());
+        followRelationship.getFollower().decreaseFollwerCount();
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -2,6 +2,9 @@ package com.climeet.climeet_backend.domain.followrelationship;
 
 
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.domain.user.UserRepository;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,15 +13,26 @@ import org.springframework.stereotype.Service;
 public class FollowRelationshipService {
 
     private final FollowRelationshipRepository followRelationshipRepository;
-    public void createFollowRelationship(User follower, User followee) {
-        FollowRelationship followRelationship = FollowRelationship.toEntity(follower, followee);
+    private final UserRepository userRepository;
+
+    public User findByUserId(Long userId){
+        return userRepository.findById(userId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
+    }
+    public void createFollowRelationship(User follower, User following) {
+        if(followRelationshipRepository.findByFollowerIdAndFollowingId(follower.getId(),
+            following.getId()).isPresent()){
+            throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
+        }
+        FollowRelationship followRelationship = FollowRelationship.toEntity(follower, following);
         followRelationshipRepository.save(followRelationship);
         follower.increaseFollwerCount();
     }
 
-    public void deleteFollowRelationship(FollowRelationship followRelationship){
+    public void deleteFollowRelationship(User following, User follower){
+        FollowRelationship followRelationship = followRelationshipRepository.findByFollowerIdAndFollowingId(follower.getId(), following.getId())
+            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_FOLLOW_RELATIONSHIP));
         followRelationshipRepository.deleteById(followRelationship.getId());
         followRelationship.getFollower().decreaseFollwerCount();
     }
-
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.followrelationship;
 
 import com.climeet.climeet_backend.domain.climber.Climber;
 import com.climeet.climeet_backend.domain.manager.Manager;
+import com.climeet.climeet_backend.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Service;
 public class FollowRelationshipService {
 
     private final FollowRelationshipRepository followRelationshipRepository;
-    public FollowRelationship createFollowRelationship(Manager follower, Climber followee) {
+    public FollowRelationship createFollowRelationship(User follower, User followee) {
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, followee);
         return followRelationshipRepository.save(followRelationship);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -1,7 +1,6 @@
 package com.climeet.climeet_backend.domain.followrelationship;
 
-import com.climeet.climeet_backend.domain.climber.Climber;
-import com.climeet.climeet_backend.domain.manager.Manager;
+
 import com.climeet.climeet_backend.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -91,7 +91,11 @@ public class User {
         this.thisWeekTotalClimbingTime -= sec;
     }
 
-    public void updateFollwerCount(){
+    public void increaseFollwerCount(){
+        this.followerCount++;
+    }
+
+    public void decreaseFollwerCount(){
         this.followerCount++;
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -43,10 +43,11 @@ public class UserController {
 
     }
 
-//    @GetMapping("/get-following")
-//    @Operation(summary = "특정 유저 암장 팔로잉 조회")
-//    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
-//        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser);
-//
-//    }
+    @GetMapping("/get-following")
+    @Operation(summary = "특정 유저 암장 팔로잉 조회")
+    public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
+        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser, userCategory);
+        return ResponseEntity.ok(userFollowDetailResponseList);
+
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -2,17 +2,12 @@ package com.climeet.climeet_backend.domain.user;
 
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
-import com.climeet.climeet_backend.global.security.JwtTokenProvider;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
 
 
     }
-    @GetMapping("/follower")
+    @GetMapping("/followers")
     @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
@@ -44,7 +44,7 @@ public class UserController {
 
     }
 
-    @GetMapping("/following")
+    @GetMapping("/followees")
     @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -36,7 +36,8 @@ public class UserController {
 
     }
     @GetMapping("/get-follower")
-    @Operation(summary = "특정 유저 암장 팔로워 조회")
+    @Operation(summary = "특정 유저 암장 팔로워 조회", description = "**userCategory** : Manager OR Climber")
+    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollower(userId, currentUser, userCategory);
         return ResponseEntity.ok(userFollowDetailResponseList);
@@ -44,7 +45,8 @@ public class UserController {
     }
 
     @GetMapping("/get-following")
-    @Operation(summary = "특정 유저 암장 팔로잉 조회")
+    @Operation(summary = "특정 유저 암장 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
+    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser, userCategory);
         return ResponseEntity.ok(userFollowDetailResponseList);

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -1,13 +1,22 @@
 package com.climeet.climeet_backend.domain.user;
 
+import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.security.JwtTokenProvider;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +35,18 @@ public class UserController {
 
 
     }
+    @GetMapping("/get-follower")
+    @Operation(summary = "특정 유저 암장 팔로워 조회")
+    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
+        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollower(userId, currentUser, userCategory);
+        return ResponseEntity.ok(userFollowDetailResponseList);
 
+    }
+
+//    @GetMapping("/get-following")
+//    @Operation(summary = "특정 유저 암장 팔로잉 조회")
+//    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
+//        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser);
+//
+//    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -35,8 +35,8 @@ public class UserController {
 
 
     }
-    @GetMapping("/get-follower")
-    @Operation(summary = "특정 유저 암장 팔로워 조회", description = "**userCategory** : Manager OR Climber")
+    @GetMapping("/follower")
+    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollower(userId, currentUser, userCategory);
@@ -44,8 +44,8 @@ public class UserController {
 
     }
 
-    @GetMapping("/get-following")
-    @Operation(summary = "특정 유저 암장 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
+    @GetMapping("/following")
+    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser, userCategory);

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -1,9 +1,7 @@
 package com.climeet.climeet_backend.domain.user;
 
-import static java.util.stream.Collectors.toList;
 
 import com.climeet.climeet_backend.domain.climber.Climber;
-import com.climeet.climeet_backend.domain.climber.ClimberRepository;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.manager.Manager;
@@ -13,9 +11,7 @@ import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -50,31 +50,32 @@ public class UserService {
 
     }
 
-    public List<UserFollowDetailInfo> getFollower(Long targetUserId, User currentUser, String userCategory){
+    public List<UserFollowDetailInfo> getFollower(Long targetUserId, User currentUser,
+        String userCategory) {
         userRepository.findById(targetUserId)
-            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
-        List<FollowRelationship> targetUserFollowerList = followRelationshipRepository.findByFollowingId(targetUserId);
-        if(!userCategory.equals("Climber")&& !userCategory.equals("Manager")){
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+        List<FollowRelationship> targetUserFollowerList = followRelationshipRepository.findByFollowingId(
+            targetUserId);
+        if (!userCategory.equals("Climber") && !userCategory.equals("Manager")) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
         List<UserFollowDetailInfo> userFollowDetailResponseList = null;
-        if(userCategory.equals("Climber")) {
-             userFollowDetailResponseList = targetUserFollowerList.stream()
-                 //.filter(followRelationship -> followRelationship.getFollower() instanceof Climber)
+        if (userCategory.equals("Climber")) {
+            userFollowDetailResponseList = targetUserFollowerList.stream()
+                .filter(followRelationship -> followRelationship.getFollower() instanceof Climber)
                 .map(followRelationship -> {
-                    System.out.println("ssㄴㄴ");
-                        Boolean currentUserRelation = false;
-                        if (followRelationshipRepository.findByFollowerIdAndFollowingId(
-                            currentUser.getId(),
-                            followRelationship.getFollower().getId()).isPresent()) {
-                            currentUserRelation = true;
-                        }
+                    Boolean currentUserRelation = false;
+                    if (followRelationshipRepository.findByFollowerIdAndFollowingId(
+                        currentUser.getId(),
+                        followRelationship.getFollower().getId()).isPresent()) {
+                        currentUserRelation = true;
+                    }
                     return UserFollowDetailInfo.toDTO(followRelationship.getFollower(),
                         currentUserRelation);
                 }).toList();
 
         }
-        if(userCategory.equals("Manager")){
+        if (userCategory.equals("Manager")) {
             userFollowDetailResponseList = targetUserFollowerList.stream()
                 .filter(followRelationship -> followRelationship.getFollower() instanceof Manager)
                 .map(followRelationship -> {
@@ -89,18 +90,51 @@ public class UserService {
                 }).toList();
         }
 
-            return userFollowDetailResponseList;
-        }
-    //암장 팔로워 조회
-//    public List<UserFollowDetailInfo> getGymFollower(Long targetUserId, User currentUser){
-//        List<UserFollowDetailInfo> allFollowerList = getFollower(targetUserId, currentUser);
-//        List<UserFollowDetailInfo> gymFollwerDetailInfoList = allFollowerList.stream()
-//            .map(allFollower -> {
-//                if(allFollower.)
-//            })
-//    }
-    //클라이머 팔로워 조회
+        return userFollowDetailResponseList;
+    }
 
-    //암장 팔로잉 조회
-    //클라이머 팔로잉 조회
+    public List<UserFollowDetailInfo> getFollowing(Long targetUserId, User currentUser, String userCategory){
+        userRepository.findById(targetUserId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
+        List<FollowRelationship> targetUserFollowerList = followRelationshipRepository.findByFollowerId(targetUserId);
+        if(!userCategory.equals("Climber")&& !userCategory.equals("Manager")){
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        List<UserFollowDetailInfo> userFollowDetailResponseList = null;
+        if(userCategory.equals("Climber")) {
+            userFollowDetailResponseList = targetUserFollowerList.stream()
+                .filter(followRelationship -> followRelationship.getFollowing() instanceof Climber)
+                .map(followRelationship -> {
+                    Boolean currentUserRelation = false;
+                    if (followRelationshipRepository.findByFollowerIdAndFollowingId(
+                        currentUser.getId(),
+                        followRelationship.getFollowing().getId()).isPresent()) {
+                        currentUserRelation = true;
+                    }
+                    return UserFollowDetailInfo.toDTO(followRelationship.getFollowing(),
+                        currentUserRelation);
+                }).toList();
+
+        }
+        if(userCategory.equals("Manager")){
+            userFollowDetailResponseList = targetUserFollowerList.stream()
+                .filter(followRelationship -> followRelationship.getFollowing() instanceof Manager)
+                .map(followRelationship -> {
+                    Boolean currentUserRelation = false;
+                    if (followRelationshipRepository.findByFollowerIdAndFollowingId(
+                        currentUser.getId(),
+                        followRelationship.getFollowing().getId()).isPresent()) {
+                        currentUserRelation = true;
+                    }
+                    return UserFollowDetailInfo.toDTO(followRelationship.getFollowing(),
+                        currentUserRelation);
+                }).toList();
+        }
+
+        return userFollowDetailResponseList;
+    }
+
+
+
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -1,12 +1,21 @@
 package com.climeet.climeet_backend.domain.user;
 
+import static java.util.stream.Collectors.toList;
+
+import com.climeet.climeet_backend.domain.climber.Climber;
 import com.climeet.climeet_backend.domain.climber.ClimberRepository;
+import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
+import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
+import com.climeet.climeet_backend.domain.manager.Manager;
+import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -15,7 +24,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final ClimberRepository climberRepository;
+    private final FollowRelationshipRepository followRelationshipRepository;
 
     public User updateNotification(User user, boolean isAllowFollowNotification,
         boolean isAllowLikeNotification, boolean isAllowCommentNotification,
@@ -40,4 +49,58 @@ public class UserService {
         return new UserTokenSimpleInfo(user);
 
     }
+
+    public List<UserFollowDetailInfo> getFollower(Long targetUserId, User currentUser, String userCategory){
+        userRepository.findById(targetUserId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
+        List<FollowRelationship> targetUserFollowerList = followRelationshipRepository.findByFollowingId(targetUserId);
+        if(!userCategory.equals("Climber")&& !userCategory.equals("Manager")){
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        List<UserFollowDetailInfo> userFollowDetailResponseList = null;
+        if(userCategory.equals("Climber")) {
+             userFollowDetailResponseList = targetUserFollowerList.stream()
+                 //.filter(followRelationship -> followRelationship.getFollower() instanceof Climber)
+                .map(followRelationship -> {
+                    System.out.println("ssㄴㄴ");
+                        Boolean currentUserRelation = false;
+                        if (followRelationshipRepository.findByFollowerIdAndFollowingId(
+                            currentUser.getId(),
+                            followRelationship.getFollower().getId()).isPresent()) {
+                            currentUserRelation = true;
+                        }
+                    return UserFollowDetailInfo.toDTO(followRelationship.getFollower(),
+                        currentUserRelation);
+                }).toList();
+
+        }
+        if(userCategory.equals("Manager")){
+            userFollowDetailResponseList = targetUserFollowerList.stream()
+                .filter(followRelationship -> followRelationship.getFollower() instanceof Manager)
+                .map(followRelationship -> {
+                    Boolean currentUserRelation = false;
+                    if (followRelationshipRepository.findByFollowerIdAndFollowingId(
+                        currentUser.getId(),
+                        followRelationship.getFollower().getId()).isPresent()) {
+                        currentUserRelation = true;
+                    }
+                    return UserFollowDetailInfo.toDTO(followRelationship.getFollower(),
+                        currentUserRelation);
+                }).toList();
+        }
+
+            return userFollowDetailResponseList;
+        }
+    //암장 팔로워 조회
+//    public List<UserFollowDetailInfo> getGymFollower(Long targetUserId, User currentUser){
+//        List<UserFollowDetailInfo> allFollowerList = getFollower(targetUserId, currentUser);
+//        List<UserFollowDetailInfo> gymFollwerDetailInfoList = allFollowerList.stream()
+//            .map(allFollower -> {
+//                if(allFollower.)
+//            })
+//    }
+    //클라이머 팔로워 조회
+
+    //암장 팔로잉 조회
+    //클라이머 팔로잉 조회
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.user.dto;
 
+import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,5 +38,30 @@ public class UserResponseDto {
                 .userId(user.getId())
                 .build();
         }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class UserFollowDetailInfo{
+        private Long userId;
+        private String userName;
+        private String userProfileUrl;
+        private Long followerCount;
+        private Long followingCount;
+        private Boolean isFollower;
+
+        public static UserFollowDetailInfo toDTO(User follower, Boolean followStatus){
+            return UserFollowDetailInfo.builder()
+                .userId(follower.getId())
+                .userName(follower.getProfileName())
+                .userProfileUrl(follower.getProfileImageUrl())
+                .followerCount(follower.getFollowerCount())
+                .followingCount(follower.getFollowingCount())
+                .isFollower(followStatus)
+                .build();
+        }
+
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -79,11 +79,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMPTY_REVIEW(HttpStatus.CONFLICT, "REVIEW_003", "리뷰 내용이 없습니다."),
 
     //유저 관련
-    _EMPTY_USER(HttpStatus.CONFLICT, "USER_001", "존재하지 않는 유저입니다."),
+    _EMPTY_USER(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 유저입니다."),
 
     //숏츠 댓글 관련
-    _EMPTY_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001", "존재하지 않는 쇼츠 댓글입니다.");
+    _EMPTY_SHORTS_COMMENT(HttpStatus.CONFLICT, "SHORTS_COMMENT_001", "존재하지 않는 쇼츠 댓글입니다."),
 
+    //팔로우 관련
+    _EMPTY_FOLLOW_RELATIONSHIP(HttpStatus.NOT_FOUND, "FOLLOW_RELATION_001", "존재하지 않는 팔로우 관계입니다."),
+    _EXIST_FOLLOW_RELATIONSHIP(HttpStatus.CONFLICT, "FOLLOW_RELATION_002", "이미 존재하는 팔로우 관계입니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 요약
-유저 팔로우, 언팔로우 API를 개발하였습니다


## 상세 내용

- FollowRelationshipController에 두 가지 API가 존재합니다

**1. 유저를 팔로우 하는 API**

  ``` java
  @PostMapping("/follow/{userId}")
    @Operation(summary = "유저 팔로우")
    @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._EXIST_FOLLOW_RELATIONSHIP})
    public ResponseEntity<String> followUser(@RequestParam Long followingUserId, @CurrentUser User currentUser){
        User followingUser = userRepository.findById(followingUserId)
                .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
        if(followRelationshipRepository.findByFollowerIdAndFollowingId(currentUser.getId(), followingUserId).isPresent()) {
            throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
        }
        followRelationshipService.createFollowRelationship(currentUser, followingUser);
        return ResponseEntity.ok("팔로우 완료");
    }

```

**2. 유저 팔로우 취소 API**

   
```java
@DeleteMapping("/unfollow/{userId}")
    @Operation(summary = "유저 팔로우 취소")
    @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._EXIST_FOLLOW_RELATIONSHIP})
    public ResponseEntity<String> unfollowUser(@RequestParam Long followingUserId, @CurrentUser User currentUser){
        userRepository.findById(followingUserId)
            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
        FollowRelationship followRelationship = followRelationshipRepository.findByFollowerIdAndFollowingId(currentUser.getId(), followingUserId)
            .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_FOLLOW_RELATIONSHIP));
        followRelationshipService.deleteFollowRelationship(followRelationship);
        return ResponseEntity.ok("팔로우 취소 완료");
    }
```

서비스 로직은 다음과 같습니다

- createFollowRelationship의 경우 FollowRelationship 객체를 생성합니다

```java
public void createFollowRelationship(User follower, User followee) {
        FollowRelationship followRelationship = FollowRelationship.toEntity(follower, followee);
        followRelationshipRepository.save(followRelationship);
        follower.increaseFollwerCount();
    }
```

- deleteFollowRelationship의 경우 FollowRelationshipRepository의 deleteById를 이용하여 레코드를 삭제합니다.

```java
    public void deleteFollowRelationship(FollowRelationship followRelationship){
        followRelationshipRepository.deleteById(followRelationship.getId());
        followRelationship.getFollower().decreaseFollwerCount();
    }
```

## 테스트 확인 내용
세 가지의 예외 처리를 작성하였습니다.

1. 팔로우 관계 생성 시 -> 이미 팔로우 관계가 존재하는 경우
2. 팔로우 관계 삭제 시 -> 팔로우 관계가 존재하는 경우
3. 공통 : 유저가 존재하지 않는 경우

더미데이터 삽입과 Swagger 시행을 통해 모두 적절히 예외처리가 처리됨을 확인하였습니다. 

## 질문 및 이외 사항

