### PR TITLE
[SPR-134] feat: 로그인 된 유저의 전체 암장 & 암장별 월별 통계

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -8,6 +8,7 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRespo
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordDetailInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfo;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfoByGym;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.user.User;
@@ -113,6 +114,18 @@ public class ClimbingRecordController {
         @RequestParam int month) {
         return ResponseEntity.ok(
             climbingRecordService.getClimbingRecordStatistics(user, year, month));
+    }
+
+    @Operation(summary = "나의 월별 & 암장별 운동기록 통계")
+    @GetMapping("/users/gyms/{gymId}/statistics/months")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_RECORD, ErrorStatus._INVALID_MEMBER})
+    public ResponseEntity<ClimbingRecordStatisticsInfoByGym> getClimbingStatisticsByGymMonthly(
+        @CurrentUser User user,
+        @PathVariable Long gymId,
+        @RequestParam int year,
+        @RequestParam int month) {
+        return ResponseEntity.ok(
+            climbingRecordService.getClimbingRecordStatisticsByGymId(user, gymId, year, month));
     }
 
     @Operation(summary = "암장별 주간 평균 완등률 통계 ")

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
@@ -31,6 +31,20 @@ public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, 
         @Param("endDate") LocalDate endDate);
 
     @Query("SELECT " +
+        "   SUM(HOUR(cr.climbingTime) * 3600 + MINUTE(cr.climbingTime) * 60 + SECOND(cr.climbingTime)) as totalTime, "
+        +
+        "   SUM(cr.totalCompletedCount) as totalCompletedCount, " +
+        "   SUM(cr.attemptRouteCount) as attemptRouteCount " +
+        "FROM ClimbingRecord cr " +
+        "WHERE cr.climbingDate BETWEEN :startDate AND :endDate AND cr.gym = :climbingGym AND cr.user = :user")
+    Tuple getStatisticsInfoBetweenDaysAndUserAndGym(@Param("user") User user,
+        @Param("climbingGym" ) ClimbingGym climbingGym,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate);
+
+
+
+    @Query("SELECT " +
         "   SUM(cr.totalCompletedCount) as totalCompletedCount, " +
         "   SUM(cr.attemptRouteCount) as attemptRouteCount " +
         "FROM ClimbingRecord cr " +

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -10,8 +10,12 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRespo
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordDetailInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfo;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfoByGym;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserStatisticsSimpleInfo;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.GymDifficultyMappingInfo;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecordRepository;
@@ -45,6 +49,7 @@ public class ClimbingRecordService {
     private final RouteRecordService routeRecordService;
     private final RouteRecordRepository routeRecordRepository;
     private final UserRepository userRepository;
+    private final DifficultyMappingRepository difficultyMappingRepository;
 
     public static final int START_DAY_OF_MONTH = 1;
     public static final int MONDAY = 0;
@@ -191,8 +196,7 @@ public class ClimbingRecordService {
     }
 
     /**
-     * 내 월별 통계 return 완등시간 & 완등률(시도한 루트와 성공한 루트의 비율) & 레벨당 완등한 횟수
-     * 클밋 기준임.
+     * 내 월별 통계 return 완등시간 & 완등률(시도한 루트와 성공한 루트의 비율) & 레벨당 완등한 횟수 클밋 기준임.
      */
     public ClimbingRecordStatisticsInfo getClimbingRecordStatistics(User user, int year,
         int month) {
@@ -222,15 +226,74 @@ public class ClimbingRecordService {
                 endDate
             );
 
-
         Map<String, Long> difficultyList;
         difficultyList = difficulties.stream()
             .collect(Collectors.toMap(
-                arr -> ClimeetDifficulty.findByInt(((Number) arr[CLIMEET_LEVEL]).intValue()).getStringValue(),
+                arr -> ClimeetDifficulty.findByInt(((int) arr[CLIMEET_LEVEL]))
+                    .getStringValue(),
                 arr -> (Long) arr[LEVEL_COUNT]
             ));
 
         return ClimbingRecordStatisticsInfo.toDTO(
+            time,
+            totalCompletedCount,
+            attemptRouteCount,
+            difficultyList
+        );
+    }
+
+    /**
+     * 나의 월별 그리고 암장별 통계기록
+     */
+    public ClimbingRecordStatisticsInfoByGym getClimbingRecordStatisticsByGymId(User user,
+        Long gymId,
+        int year,
+        int month) {
+
+        LocalDate startDate = LocalDate.of(year, month, START_DAY_OF_MONTH);
+        LocalDate endDate = YearMonth.of(year, month).atEndOfMonth();
+
+        ClimbingGym gym = gymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+
+        Tuple crTuple = climbingRecordRepository.getStatisticsInfoBetweenDaysAndUserAndGym(user,
+            gym,
+            startDate, endDate
+        );
+
+        if (crTuple.get("totalTime") == null) {
+            throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD);
+        }
+
+        Double totalTime = (Double) crTuple.get("totalTime");
+
+        LocalTime time = convertDoubleToTime(totalTime);
+
+        Long totalCompletedCount = (Long) crTuple.get("totalCompletedCount");
+
+        Long attemptRouteCount = (Long) crTuple.get("attemptRouteCount");
+
+        //유저가 기록한 레벨 리스트를 뽑아 온다.
+        //여기는 기록한 레벨과 그에 매칭되는 횟수가 나온다.
+        List<Object[]> difficulties = routeRecordRepository
+            .getRouteRecordDifficultyBetweenDatesAndGym(
+                user,
+                gym,
+                startDate,
+                endDate
+            );
+
+        List<GymDifficultyMappingInfo> difficultyList = difficulties.stream()
+            .map(arr -> {
+                DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndDifficulty(
+                    gym, ((int) arr[CLIMEET_LEVEL]));
+                Long levelCount = (Long) arr[LEVEL_COUNT];
+
+                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount );
+            })
+            .collect(Collectors.toList());
+
+        return ClimbingRecordStatisticsInfoByGym.toDTO(
             time,
             totalCompletedCount,
             attemptRouteCount,

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -82,10 +82,10 @@ public class ClimbingRecordResponseDto {
         private LocalTime time;
         private Long totalCompletedCount;
         private Long attemptRouteCount;
-        private List<Map<Long, Long>> difficulty;
+        private Map<String, Long> difficulty;
 
         public static ClimbingRecordStatisticsInfo toDTO(LocalTime time, Long totalCompletedCount,
-            Long attemptRouteCount, List<Map<Long, Long>> difficulty) {
+            Long attemptRouteCount, Map<String, Long> difficulty) {
 
             return ClimbingRecordStatisticsInfo.builder()
                 .time(time)

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.climbingrecord.dto;
 
 import com.climeet.climeet_backend.domain.climbingrecord.ClimbingRecord;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
 import com.climeet.climeet_backend.domain.routerecord.dto.RouteRecordResponseDto.RouteRecordSimpleInfo;
 import com.climeet.climeet_backend.domain.user.User;
 import java.time.LocalDate;
@@ -12,6 +13,7 @@ import lombok.Builder;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 public class ClimbingRecordResponseDto {
 
@@ -95,6 +97,53 @@ public class ClimbingRecordResponseDto {
                 .build();
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ClimbingRecordStatisticsInfoByGym {
+
+        private LocalTime time;
+        private Long totalCompletedCount;
+        private Long attemptRouteCount;
+        private List<GymDifficultyMappingInfo> difficulty;
+
+        public static ClimbingRecordStatisticsInfoByGym toDTO(LocalTime time, Long totalCompletedCount,
+            Long attemptRouteCount, List<GymDifficultyMappingInfo> difficulty) {
+
+            return ClimbingRecordStatisticsInfoByGym.builder()
+                .time(time)
+                .totalCompletedCount(totalCompletedCount)
+                .attemptRouteCount(attemptRouteCount)
+                .difficulty(difficulty)
+                .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    @Builder
+    public static class GymDifficultyMappingInfo{
+
+        private String climeetDifficultyName;
+        private String gymDifficultyName;
+        private String gymDifficultyColor;
+        private Long count;
+        public static GymDifficultyMappingInfo toDTO(
+            DifficultyMapping difficultyMapping,
+            Long count
+        ){
+            return GymDifficultyMappingInfo.builder()
+                .climeetDifficultyName(difficultyMapping.getClimeetDifficultyName())
+                .gymDifficultyName(difficultyMapping.getGymDifficultyName())
+                .gymDifficultyColor(difficultyMapping.getGymDifficultyColor())
+                .count(count)
+                .build();
+        }
+    }
+
 
     @Getter
     @NoArgsConstructor

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.difficultymapping.enums;
 
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.Arrays;
 
 public enum ClimeetDifficulty {
     VB("VB", 0),
@@ -39,5 +40,12 @@ public enum ClimeetDifficulty {
             }
         }
         throw new GeneralException(ErrorStatus._INVALID_DIFFICULTY);
+    }
+
+    public static ClimeetDifficulty findByInt(int climeetDifficulty){
+        return Arrays.stream(ClimeetDifficulty.values())
+            .filter(difficulty -> difficulty.getIntValue() == climeetDifficulty)
+            .findFirst()
+            .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_DIFFICULTY));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -29,6 +29,18 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     @Query("SELECT " +
         "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
+        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym AND rr.user = :user " +
+        "GROUP BY rr.route.difficultyMapping.difficulty")
+    List<Object[]> getRouteRecordDifficultyBetweenDatesAndGym(
+        @Param("user") User user,
+        @Param("gym") ClimbingGym gym,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
+
+    @Query("SELECT " +
+        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "FROM RouteRecord rr " +
         "WHERE rr.user = :user " +
         "GROUP BY rr.route.difficultyMapping.difficulty")
     List<Map<Long,Long>> findAllRouteRecordDifficultyAndUser(

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -20,7 +20,7 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
         "FROM RouteRecord rr " +
         "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.user = :user " +
         "GROUP BY rr.route.difficultyMapping.difficulty")
-    List<Map<Long,Long>> getRouteRecordDifficultyBetween(
+    List<Object[]> getRouteRecordDifficultyBetween(
         @Param("user") User user,
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate


### PR DESCRIPTION
## 요약
**로그인 한 유저의 월별 통계 로직 구현**
1. 전체 암장에 대해
2. 특정 암장에 대해

## 상세 내용

<img width="373" alt="스크린샷 2024-02-04 오후 5 09 01" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/1c9d5700-e11b-4eb7-b533-0e29eb36670f">

- 리팩토링 진행
(리팩토링 전) 기존 평균 완등 레벨에 대해 int값인 레벨과 완등한 횟수를 반환
(리팩토링 후) 레벨을 나타내는 문자, 색깔, 횟수 반환

- Object[] 반환에 따른 매직넘버 사용
- GymDifficultyMappingInfo DTO 구현
### 전체 암장에 대해
**difficulty**
```java
//ClimbingRecordService.getClimbingRecordStatistics 의 코드

(생략)

List<Object[]> difficulties = routeRecordRepository
            .getRouteRecordDifficultyBetween(
                user,
                startDate,
                endDate
            );

        Map<String, Long> difficultyList;
        difficultyList = difficulties.stream()
            .collect(Collectors.toMap(
                arr -> ClimeetDifficulty.findByInt(((int) arr[CLIMEET_LEVEL]))
                    .getStringValue(),
                arr -> (Long) arr[LEVEL_COUNT]
            ));

        return ClimbingRecordStatisticsInfo.toDTO(
            time,
            totalCompletedCount,
            attemptRouteCount,
            difficultyList
        );

(생략)
```
- ClimeeteDifficulty에서 int형으로 레벨을 입력받았을 때 해당하는 enum값을 찾는 로직을 구현하였습니다.
- 기존에는 difficultyList를 Map<Long,Long>으로 넘겼다면 aos파트의 요청에 따라 현재는 Map<String,Long)으로 값을 넘겨줍니다.

### 특정 암장에 대해
**difficulty**
```java
//ClimbingRecordService.getClimbingRecordStatisticsByGymId의 코드

List<Object[]> difficulties = routeRecordRepository
            .getRouteRecordDifficultyBetweenDatesAndGym(
                user,
                gym,
                startDate,
                endDate
            );

        List<GymDifficultyMappingInfo> difficultyList = difficulties.stream()
            .map(arr -> {
                DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndDifficulty(
                    gym, ((int) arr[CLIMEET_LEVEL]));
                Long levelCount = (Long) arr[LEVEL_COUNT];

                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount );
            })
            .collect(Collectors.toList());

        return ClimbingRecordStatisticsInfoByGym.toDTO(
            time,
            totalCompletedCount,
            attemptRouteCount,
            difficultyList
        );
```
- 특정 암장의 경우 difficultyList의 타입이 List<GymDifficultyMappingInfo> 입니다.
- 눈치 채셨겠지만 특정 암장으로 조회할 경우 특정암장의 색깔도 추가로 넘겨줘야 합니다.
- 이에 따라 내친 김에 climmet기준 난이도를 나타내는 문자열까지 포함하여 아래와 같은 네가지의 필드를 넘겨줍니다.
```java
private String climeetDifficultyName;
        private String gymDifficultyName;
        private String gymDifficultyColor;
        private Long count;
```
- 이는 테스트 화면에서 보다 직관적으로 이해할 수 있습니다.

## 테스트 확인 내용
### 전체 암장에 대해
<img width="626" alt="스크린샷 2024-02-04 오후 5 00 54" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/312dde9d-c562-4e8f-919e-83c691b47abf">
**difficulty**
- 클밋 기준 난이도 이름
- 해당 난이도 완등한 횟수

### 특정 암장에 대해
<img width="653" alt="스크린샷 2024-02-04 오후 4 59 53" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/e7226366-22cc-4e1f-9c1d-ae5cdc5e0ff9">
**difficulty**
- 특정 암장의 클밋기준 난이도 이름
- 암장의 난이도 이름
- 암장의 난이도 색깔
- 해당 난이도를 진행한 횟수


## 질문 및 이외 사항
### 리팩토링 시 진행해야 할 사항
**코드의 중복성 제거**
- 클밋기준의 전체암장에 대한 통계 조회와 암장별 통계 조회의 서비스 로직이 꽤나 비슷합니다.
- 이에 따라 이후에는 암장의 값이 유효한 지에 따라 조건문을 통해 두 로직을 합칠 지도 염두하고 있습니다.

**쿼리 최적화**
- 특정 암장 통계 로직의 경우 쿼리가 최대 15개 날아갑니다.
- 그 이유는 유저정보쿼리+관리자정보쿼리+클라이밍짐쿼리+클라이밍기록 쿼리 + 루트의 난이도와 해당 난이도에 대한 count 조회 쿼리 + 최대 10 개의 레벨에 대해 암장 고유 레벨 매핑을 하나하나 진행해야 하기 때문입니다.
- 다르게 말하면 적지는 않지만 최대로 날아갈 수 있는 쿼리의 개수가 정해져있기 때문에 문제가 될 지 안될 지는 두고봐야 할 것 같습니다.
