### PR TITLE
[SPR-129] refactor: 금주 레벨순 클라이머 랭킹 조회 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/BestLevelClimber.java
@@ -22,7 +22,9 @@ public class BestLevelClimber {
 
     private int ranking = 0;
 
-    private int thisWeekHighDifficulty = 0;
+    private int difficulty = 0;
+
+    private Long difficultyCount = 0L;
 
     private String profileImageUrl;
 

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/dto/BestLevelClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/dto/BestLevelClimberResponseDto.java
@@ -22,13 +22,16 @@ public class BestLevelClimberResponseDto {
 
         private int thisWeekHighDifficulty;
 
+        private Long highDifficultyCount;
+
         public static BestLevelClimberDetailInfo toDTO(
             BestLevelClimber bestLevelClimber){
             return BestLevelClimberDetailInfo.builder()
                 .ranking(bestLevelClimber.getRanking())
                 .profileImageUrl(bestLevelClimber.getProfileImageUrl())
-                .thisWeekHighDifficulty(bestLevelClimber.getThisWeekHighDifficulty())
+                .thisWeekHighDifficulty(bestLevelClimber.getDifficulty())
                 .profileName(bestLevelClimber.getProfileName())
+                .highDifficultyCount(bestLevelClimber.getDifficultyCount())
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRoute.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/BestRoute.java
@@ -36,9 +36,11 @@ public class BestRoute extends BaseTimeEntity {
 
     private String sectorName;
 
-    private int level;
+    private String climeetDifficultyName;
 
-    private String levelColor;
+    private String gymDifficultyName;
+
+    private String gymDifficultyColor;
 
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
@@ -20,7 +20,9 @@ public class BestRouteResponseDto {
         private String routeImageUrl;
         private String gymName;
         private String sectorName;
-        private int level;
+        private String climeetDifficultyName;
+        private String gymDifficultyName;
+        private String gymDifficultyColor;
 
         public static BestRouteDetailInfo toDTO(BestRoute bestRoute) {
             return BestRouteDetailInfo.builder()
@@ -29,7 +31,9 @@ public class BestRouteResponseDto {
                 .routeImageUrl(bestRoute.getRouteImageUrl())
                 .gymName(bestRoute.getGymName())
                 .sectorName(bestRoute.getSectorName())
-                .level(bestRoute.getLevel())
+                .climeetDifficultyName(bestRoute.getClimeetDifficultyName())
+                .gymDifficultyName(bestRoute.getGymDifficultyName())
+                .gymDifficultyColor(bestRoute.getGymDifficultyColor())
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -54,9 +54,6 @@ public class User {
     @ColumnDefault("0L")
     private Long thisWeekTotalClimbingTime = 0L;
 
-    @ColumnDefault("0")
-    private int thisWeekHighDifficulty = 0;
-
     @CreatedDate
     private LocalDateTime createdAt;
 


### PR DESCRIPTION
## 요약
- 금주 레벨순 클라이머 랭킹 조회 구현

## 상세 내용
(들어가기 전) 
자바 코드는 적지만 수많은 시간을 쏟았습니다..
- 먼저 User의 thisWeekHighDifficulty를 기록 생성, 삭제, 수정 시마다 업데이트 해줘야 하고, 이는 주간랭킹에만 사용되는 필드이기 때문에 db에 접근하는 오버헤드가 크다고 생각했습니다.
- 더군다나 암장마다 조회를 할 때에도 해당 필드가 사용되지 않는 것을 발견했습니다.
- 이에 따라 thisWeekHighDifficulty 필드를 폐기하고 주마다 랭킹을 업데이트 할 때는 근본있게 가자고 마음먹었습니다.
- 람다함수는 파이썬 코드로 작성되어 있기 때문에 JPA를 사용할 수 없는 저에게 주어진 SQL 요구사항은 다음과 같았습니다.

1. 주어진 기간 동안 전체 기록을 생성한 유저들의 최고값을 가져와야 한다.
2. 해당 최고 레벨을 각 유저가 몇 번을 진행했는지 알아야 한다.
3. 최고 레벨, 레벨이 같다면 많이 완등한 순으로 랭킹을 매겨야 한다.

아래 작성한 쿼리문에 주석으로 설명하겠습니다.
```SQL
cursor.execute("""
            INSERT INTO best_level_climber (user_id, ranking, difficulty, difficulty_count, profile_name, profile_image_url)
            SELECT
                rr.user_id,
                ROW_NUMBER() OVER (ORDER BY difficulty DESC, COUNT(*) DESC) AS ranking,
                dm.difficulty AS difficulty,
                COUNT(*) AS difficulty_count,
                u.profile_name AS profile_name,
                u.profile_image_url AS profile_image_url
                -> 3. 그룹화 한 항목들의 개수와 기타등등 정보 매핑
               
                FROM
                    (
                        SELECT
                            rr.user_id AS user_id,
                            MAX(dm.difficulty) AS difficulty
                        FROM
                            route_record rr
                        INNER JOIN
                            route r on rr.route_id = r.id
                        INNER JOIN
                            difficulty_mapping dm on r.difficulty_mapping_id = dm.id
                        GROUP BY
                            rr.user_id
                    ) AS subquery
                    -> 1. 서브쿼리를 사용하여 user_id로 기록들을 그룹화 하고, 각 유저의 id와 해당 유저가 세운 최고 레벨을 가져온다.
                INNER JOIN
                    route_record rr ON rr.user_id = subquery.user_id
                INNER JOIN
                    route r on rr.route_id = r.id
                INNER JOIN
                    difficulty_mapping dm on dm.id = r.difficulty_mapping_id
                INNER JOIN
                    user u on rr.user_id = u.id
                WHERE rr.user_id = subquery.user_id AND dm.difficulty = subquery.difficulty
                GROUP BY
                    subquery.user_id
             -> 2. 1번에서 뽑아온 user_id로  그룹화 한다.
            ORDER BY 
                difficulty DESC, difficulty_count DESC
            LIMIT 15
        """)
```

## 테스트 확인 내용

- ex) 테스트 코드의 내용을 작성해주세요.
- ex) caculate() 함수의 입력값에 대한 테스트를 작성, 일치하는지 확인했습니다.

## 질문 및 이외 사항
### 의도된 코드 결함
1. 조건절을 주간으로 설정하지 않고 디폴트인 전체 기간으로 둔 것.
2. 완등을 했는 지 체크하지 않고 그냥 기록되어 있으면 계산한 것.
- 위 두가지는 "의도된 사항"입니다.
- 그 이유는 테스트할 때 매우 복잡할 것이 분명하기 때문입니다.
- 새로운 값을 다시 넣어줘야 하고 db에 더미값을 여러 개 넣으며 굉장히 곤혹스러웠습니다...ㅜㅜ
- 참고로 저는 pr에 리팩토링하겠다고 남겨놓고 개인적으로 넘어갔던 수정사항들은 다음과 같이 정리해놓고 있으니 걱정하지 말아주세요!
- (그럼에도 놓친 게 있을 수도..?)
![스크린샷 2024-02-05 오전 12 41 17](https://github.com/TheClimeet/climeet-spring/assets/100510247/b1b902d4-f153-4697-9b78-8d1015cc8ada)

