### PR TITLE
[SPR-136] 루트 버전 API 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -5,6 +5,7 @@ import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDt
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.GetFilteredRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
@@ -69,7 +70,7 @@ public class RouteVersionController {
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS,
         ErrorStatus._EMPTY_ROUTE_LIST})
     @PostMapping("/{gymId}/version/filter")
-    public ResponseEntity<List<RouteDetailResponse>> getRouteVersionFiltering(
+    public ResponseEntity<PageResponseDto<List<RouteDetailResponse>>> getRouteVersionFiltering(
         @CurrentUser User user, @PathVariable Long gymId,
         @RequestBody GetFilteredRouteVersionRequest getFilteredRouteVersionRequest) {
         return ResponseEntity.ok(

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -35,9 +35,9 @@ public class RouteVersionController {
 
     @Operation(summary = "암장의 루트 버전 일자 목록")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION_LIST})
-    @GetMapping("/version/list")
+    @GetMapping("/{gymId}/version/list")
     public ResponseEntity<List<LocalDate>> getRouteVersionList(@CurrentUser User user,
-        @RequestParam Long gymId) {
+        @PathVariable Long gymId) {
         List<LocalDate> routeVersionList = routeVersionService.getRouteVersionList(gymId);
         return ResponseEntity.ok(routeVersionList);
     }
@@ -48,23 +48,23 @@ public class RouteVersionController {
     @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
         @RequestPart(value = "request") CreateRouteVersionRequest createRouteVersionRequest,
-        @RequestPart(required = false) MultipartFile layoutImage,@CurrentUser User user) {
+        @RequestPart(required = false) MultipartFile layoutImage, @CurrentUser User user) {
         routeVersionService.createRouteVersion(createRouteVersionRequest, user, layoutImage);
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 
-    @Operation(summary = "암장 특정 루트버전 데이터 불러오기")
+    @Operation(summary = "암장 특정 루트버전 데이터 불러오기", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다.")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._EMPTY_SECTOR_LIST,
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
     @GetMapping("/{gymId}/version")
     public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(@CurrentUser User user,
         @PathVariable Long gymId,
-        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
         return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
     }
 
-    @Operation(summary = "암장 특정 루트 버전 데이터 필터링해서 루트 불러오기")
+    @Operation(summary = "암장 특정 루트 버전 데이터 필터링해서 루트 불러오기", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다. \n 각 List 필터링 값 또한 비필수이며, 만약 특정 List에 필터링될 값이 없다면 입력하지 않아도 문제 없습니다.")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS,
         ErrorStatus._EMPTY_ROUTE_LIST})

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -67,8 +67,7 @@ public class RouteVersionController {
 
     @Operation(summary = "암장 특정 루트 버전 데이터 필터링해서 루트 불러오기", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다. \n 각 List 필터링 값 또한 비필수이며, 만약 특정 List에 필터링될 값이 없다면 입력하지 않아도 문제 없습니다.")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
-        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS,
-        ErrorStatus._EMPTY_ROUTE_LIST})
+        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS})
     @PostMapping("/{gymId}/version/filter")
     public ResponseEntity<PageResponseDto<List<RouteDetailResponse>>> getRouteVersionFiltering(
         @CurrentUser User user, @PathVariable Long gymId,

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -29,7 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "RouteVersion", description = "암장 루트 버전 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/gym")
+@RequestMapping("api/gyms")
 public class RouteVersionController {
 
     private final RouteVersionService routeVersionService;

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -3,7 +3,7 @@ package com.climeet.climeet_backend.domain.routeversion;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.GetFilteredRouteVersionRequest;
-import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionDetailResponse;
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionFilteringKeyResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -54,25 +54,27 @@ public class RouteVersionController {
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 
-    @Operation(summary = "암장 특정 루트버전 데이터 불러오기", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다.")
+    @Operation(summary = "암장 특정 루트버전 필터링 키 불러오기", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다.")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
-        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._EMPTY_SECTOR_LIST,
-        ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
-    @GetMapping("/{gymId}/version")
-    public ResponseEntity<RouteVersionDetailResponse> getRouteVersionDetail(@CurrentUser User user,
-        @PathVariable Long gymId,
+        ErrorStatus._EMPTY_SECTOR_LIST, ErrorStatus._MISMATCH_SECTOR_IDS,
+        ErrorStatus._EMPTY_DIFFICULTY_LIST})
+    @GetMapping("/{gymId}/version/key")
+    public ResponseEntity<RouteVersionFilteringKeyResponse> getRouteVersionFilteringKey(
+        @CurrentUser User user, @PathVariable Long gymId,
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
-        return ResponseEntity.ok(routeVersionService.getRouteVersionDetail(gymId, timePoint));
+        return ResponseEntity.ok(
+            routeVersionService.getRouteVersionFilteringKey(gymId, timePoint));
     }
 
-    @Operation(summary = "암장 특정 루트 버전 데이터 필터링해서 루트 불러오기", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다. \n 각 List 필터링 값 또한 비필수이며, 만약 특정 List에 필터링될 값이 없다면 입력하지 않아도 문제 없습니다.")
+    @Operation(summary = "암장 특정 루트버전 루트 리스트 불러오기 (필터링 포함)", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다. \n 각 List 필터링 값 또한 비필수이며, 만약 특정 List에 필터링될 값이 없다면 입력하지 않아도 문제 없습니다.")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
         ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS})
-    @PostMapping("/{gymId}/version/filter")
+    @PostMapping("/{gymId}/version/route")
     public ResponseEntity<PageResponseDto<List<RouteDetailResponse>>> getRouteVersionFiltering(
         @CurrentUser User user, @PathVariable Long gymId,
         @RequestBody GetFilteredRouteVersionRequest getFilteredRouteVersionRequest) {
         return ResponseEntity.ok(
-            routeVersionService.getRouteVersionFiltering(gymId, getFilteredRouteVersionRequest));
+            routeVersionService.getRouteVersionFilteringRouteList(gymId,
+                getFilteredRouteVersionRequest));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -49,7 +49,7 @@ public class RouteVersionService {
         if (routeVersionList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_VERSION_LIST);
         }
-        return routeVersionList.stream().map(routeVersion -> routeVersion.getTimePoint()).toList();
+        return routeVersionList.stream().map(RouteVersion::getTimePoint).toList();
     }
 
     public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user,
@@ -102,6 +102,10 @@ public class RouteVersionService {
     }
 
     public RouteVersionDetailResponse getRouteVersionDetail(Long gymId, LocalDate timePoint) {
+        if(timePoint == null){
+            timePoint = LocalDate.now();
+        }
+
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -136,9 +136,11 @@ public class RouteVersionService {
             .map(SectorDetailResponse::toDto).toList();
         List<DifficultyMappingDetailResponse> difficultyMappingDetailResponses = difficultyList.stream()
             .map(DifficultyMappingDetailResponse::toDto).toList();
+        List<Integer> floorList = sectorList.stream()
+            .map(Sector::getFloor).distinct().sorted().toList();
 
         return RouteVersionFilteringKeyResponse.toDto(climbingGym, sectorDetailResponses,
-            difficultyMappingDetailResponses, routeVersion);
+            difficultyMappingDetailResponses, floorList, routeVersion);
     }
 
     public PageResponseDto<List<RouteDetailResponse>> getRouteVersionFilteringRouteList(Long gymId,

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -158,12 +158,12 @@ public class RouteVersionService {
     }
 
     public PageResponseDto<List<RouteDetailResponse>> getRouteVersionFiltering(Long gymId,
-        GetFilteredRouteVersionRequest requestDto) {
+        GetFilteredRouteVersionRequest getFilteredRouteVersionRequest) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
         RouteVersion routeVersion = routeVersionRepository.findFirstByClimbingGymAndTimePointLessThanEqualOrderByTimePointDesc(
-                climbingGym, requestDto.getTimePoint())
+                climbingGym, getFilteredRouteVersionRequest.getTimePoint())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
 
         List<Long> routeIdList = RouteVersionConverter.convertStringToList(
@@ -179,25 +179,25 @@ public class RouteVersionService {
 
         List<Route> filteredRouteList = routeList.stream().filter(route -> {
                 boolean floorFilter =
-                    requestDto.getFloorList().length == 0 || Arrays.stream(requestDto.getFloorList())
+                    getFilteredRouteVersionRequest.getFloorList().length == 0 || Arrays.stream(getFilteredRouteVersionRequest.getFloorList())
                         .anyMatch(floor -> floor == route.getSector().getFloor());
-                boolean sectorFilter = requestDto.getSectorIdList().length == 0 || Arrays.stream(
-                        requestDto.getSectorIdList())
+                boolean sectorFilter = getFilteredRouteVersionRequest.getSectorIdList().length == 0 || Arrays.stream(
+                        getFilteredRouteVersionRequest.getSectorIdList())
                     .anyMatch(sectorId -> sectorId == route.getSector().getId());
                 boolean difficultyFilter =
-                    requestDto.getDifficultyList().length == 0 || Arrays.stream(
-                        requestDto.getDifficultyList()).anyMatch(
+                    getFilteredRouteVersionRequest.getDifficultyList().length == 0 || Arrays.stream(
+                        getFilteredRouteVersionRequest.getDifficultyList()).anyMatch(
                         difficulty -> difficulty == route.getDifficultyMapping()
                             .getDifficulty());
                 return floorFilter && sectorFilter && difficultyFilter;
             }).sorted(Comparator.comparing(Route::getId).reversed())
-            .skip(requestDto.getPage() * requestDto.getSize())
-            .limit(requestDto.getSize())
+            .skip(getFilteredRouteVersionRequest.getPage() * getFilteredRouteVersionRequest.getSize())
+            .limit(getFilteredRouteVersionRequest.getSize())
             .toList();
 
-        boolean hasNextPage = filteredRouteList.size() == requestDto.getSize();
+        boolean hasNextPage = filteredRouteList.size() == getFilteredRouteVersionRequest.getSize();
 
-        return new PageResponseDto<>(requestDto.getPage(), hasNextPage,
+        return new PageResponseDto<>(getFilteredRouteVersionRequest.getPage(), hasNextPage,
             filteredRouteList.stream().map(RouteDetailResponse::toDto).toList());
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -33,6 +33,7 @@ public class RouteVersionRequestDto {
             this.floorList = new int[0];
             this.sectorIdList = new Long[0];
             this.difficultyList = new int[0];
+            this.timePoint = LocalDate.now();
         }
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -22,6 +22,8 @@ public class RouteVersionRequestDto {
     @Getter
     public static class GetFilteredRouteVersionRequest {
 
+        private int page;
+        private int size;
         private int[] floorList = null;
         private Long[] sectorIdList = null;
         private int[] difficultyList = null;

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -5,6 +5,7 @@ import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappin
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.RouteVersion;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
+import com.climeet.climeet_backend.global.common.PageResponseDto;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -18,24 +19,22 @@ public class RouteVersionResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RouteVersionDetailResponse {
+    public static class RouteVersionFilteringKeyResponse {
 
         private Long gymId;
         private LocalDate timePoint;
         private String layoutImageUrl;
         private List<SectorDetailResponse> sectorList;
-        private List<RouteDetailResponse> routeList;
         private List<DifficultyMappingDetailResponse> difficultyList;
 
-        public static RouteVersionDetailResponse toDto(ClimbingGym climbingGym,
-            List<SectorDetailResponse> sectorList, List<RouteDetailResponse> routeList,
+        public static RouteVersionFilteringKeyResponse toDto(ClimbingGym climbingGym,
+            List<SectorDetailResponse> sectorList,
             List<DifficultyMappingDetailResponse> difficultyList, RouteVersion routeVersion) {
-            return RouteVersionDetailResponse.builder()
+            return RouteVersionFilteringKeyResponse.builder()
                 .gymId(climbingGym.getId())
                 .timePoint(routeVersion.getTimePoint())
                 .layoutImageUrl(routeVersion.getLayoutImageUrl())
                 .sectorList(sectorList)
-                .routeList(routeList)
                 .difficultyList(difficultyList)
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -2,10 +2,8 @@ package com.climeet.climeet_backend.domain.routeversion.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.RouteVersion;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import com.climeet.climeet_backend.global.common.PageResponseDto;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -26,16 +24,19 @@ public class RouteVersionResponseDto {
         private String layoutImageUrl;
         private List<SectorDetailResponse> sectorList;
         private List<DifficultyMappingDetailResponse> difficultyList;
+        private List<Integer> floorList;
 
         public static RouteVersionFilteringKeyResponse toDto(ClimbingGym climbingGym,
             List<SectorDetailResponse> sectorList,
-            List<DifficultyMappingDetailResponse> difficultyList, RouteVersion routeVersion) {
+            List<DifficultyMappingDetailResponse> difficultyList, List<Integer> floorList,
+            RouteVersion routeVersion) {
             return RouteVersionFilteringKeyResponse.builder()
                 .gymId(climbingGym.getId())
                 .timePoint(routeVersion.getTimePoint())
                 .layoutImageUrl(routeVersion.getLayoutImageUrl())
                 .sectorList(sectorList)
                 .difficultyList(difficultyList)
+                .floorList(floorList)
                 .build();
         }
     }


### PR DESCRIPTION
## 요약
- 루트 버전 기능 수정(안드 요청): timePoint 값을 비필수 값으로 지정, 기본값은 LocalDate.now()로 사용
- gymId를 PathVariable로 변경
- Swagger Description 추가
- pagenation 추가
- 최신순으로 정렬하여 반환
- 루트 버전 key, route API 분리
- 필터링 리팩토링
- floorList 추가 반환

## 상세 내용
- 루트 버전 기능 수정(안드 요청): timePoint 값을 비필수 값으로 지정, 기본값은 LocalDate.now()로 사용
Service단에서 변경 (getRouteVersionFilteringKey)
``` java
    if (timePoint == null) {
            timePoint = LocalDate.now();
        }
```

RequestDto단에서 변경 (GetFilteredRouteVersionRequest 생성자)
``` java
    public GetFilteredRouteVersionRequest() {
            this.floorList = new int[0];
            this.sectorIdList = new Long[0];
            this.difficultyList = new int[0];
            this.timePoint = LocalDate.now();
        }
```
- gymId를 RequestParam에서 PathVariable로 변경

- Swagger Description 추가

- pagenation 추가 & 최신순으로 정렬하여 반환
Service단에서 변경 (getRouteVersionFilteringRouteList)
``` java
        List<RouteDetailResponse> routeDetailResponseList = routeList.stream()
            .sorted(Comparator.comparing(Route::getId).reversed())
            .skip(
                getFilteredRouteVersionRequest.getPage() * getFilteredRouteVersionRequest.getSize())
            .limit(getFilteredRouteVersionRequest.getSize())
            .map(RouteDetailResponse::toDto)
            .toList();

        boolean hasNextPage = (getFilteredRouteVersionRequest.getPage() + 1)
            * getFilteredRouteVersionRequest.getSize() < routeList.size();

        return new PageResponseDto<>(getFilteredRouteVersionRequest.getPage(), hasNextPage,
            routeDetailResponseList);
```

- 루트 버전 key, route API 분리
Service단에서 

getRouteVersionFilteringKey는 필터링 키, 암장 도면 등 반환  

getRouteVersionFilteringRouteList는 필터링 리스트만 반환


- 필터링 리팩토링
각 필터링에서 배열이 존재하지 않아도 stream에서 모든 route마다 빈 배열인지 확인하는 과정이 존재했었는데 이를 없애고 각 필터 과정에서 처음에 빈 배열인지 확인하는 과정을 추가.

따라서 필터링 키가 존재하는지 여부를 각 루트마다 확인하는 것이 아닌, 필터링 키마다 한번씩만 확인하도록 변경
``` java
        // floor Filter 적용
        if (getFilteredRouteVersionRequest.getFloorList().length != 0) {
            routeList = routeList.stream()
                .filter(route -> Arrays.stream(getFilteredRouteVersionRequest.getFloorList())
                    .anyMatch(floor -> floor == route.getSector().getFloor())
                ).toList();
        }

        // sector Filter 적용
        if (getFilteredRouteVersionRequest.getSectorIdList().length != 0) {
            routeList = routeList.stream()
                .filter(route -> Arrays.stream(getFilteredRouteVersionRequest.getSectorIdList())
                    .anyMatch(sectorId -> sectorId == route.getSector().getId())
                ).toList();
        }

        // difficulty Filter 적용
        if (getFilteredRouteVersionRequest.getDifficultyList().length != 0) {
            routeList = routeList.stream()
                .filter(route -> Arrays.stream(getFilteredRouteVersionRequest.getDifficultyList())
                    .anyMatch(
                        difficulty -> difficulty == route.getDifficultyMapping().getDifficulty())
                ).toList();
        }
```

- floorList 추가반환
Service 단에서 추가(getRouteVersionFilteringKey)
``` java
    List<Integer> floorList = sectorList.stream()
            .map(Sector::getFloor).distinct().sorted().toList();
``` 


## 테스트 확인 내용
- key 반환 APi
출력값 (암장 Id, 시점, 도면, 섹터 리스트, 난이도 리스트, 
``` json
{
    "gymId": 1,
    "timePoint": "2024-02-02",
    "layoutImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/c5bbb0d0-1336-47d9-abb7-be108e949108.png",
    "sectorList": [
        {
            "name": "Mario",
            "floor": 2,
            "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/3ccac787-a467-41d0-bdbf-501b09694b91.jpg"
        },
        {
            "name": "Panorama",
            "floor": 2,
            "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/193fa43d-7db9-45d4-8280-50ef512e46a7.jpeg"
        },
        {
            "name": "Jaws",
            "floor": 2,
            "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/e8390ea4-2415-43a8-a382-9c7aeb60229e.jpeg"
        },
        {
            "name": "Cheesegrater",
            "floor": 2,
            "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/273d7efe-6bfe-495b-88de-add463fcf20f.jpeg"
        },
        {
            "name": "The Wallus",
            "floor": 1,
            "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/87eca97f-0c1b-40bc-8655-b3467ed497a7.jpeg"
        },
        {
            "name": "Bat man",
            "floor": 1,
            "sectorImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/ebc0d58c-e761-4cda-9245-5d27e2731c1e.jpeg"
        }
    ],
    "difficultyList": [
        {
            "climeetDifficultyName": "VB",
            "gymDifficultyName": "난이도0",
            "difficulty": 0,
            "gymDifficultyColor": "#FFFFFF"
        },
        {
            "climeetDifficultyName": "V1",
            "gymDifficultyName": "난이도1",
            "difficulty": 1,
            "gymDifficultyColor": "#E1C8EC"
        },
        {
            "climeetDifficultyName": "V2",
            "gymDifficultyName": "난이도2",
            "difficulty": 2,
            "gymDifficultyColor": "#DD8E2D"
        },
        {
            "climeetDifficultyName": "V3",
            "gymDifficultyName": "난이도3",
            "difficulty": 3,
            "gymDifficultyColor": "#4B803E"
        },
        {
            "climeetDifficultyName": "V4",
            "gymDifficultyName": "난이도4",
            "difficulty": 4,
            "gymDifficultyColor": "#4895D2"
        },
        {
            "climeetDifficultyName": "V5",
            "gymDifficultyName": "난이도5",
            "difficulty": 5,
            "gymDifficultyColor": "#B2394B"
        },
        {
            "climeetDifficultyName": "V6",
            "gymDifficultyName": "난이도6",
            "difficulty": 6,
            "gymDifficultyColor": "#69547F"
        },
        {
            "climeetDifficultyName": "V7",
            "gymDifficultyName": "난이도7",
            "difficulty": 7,
            "gymDifficultyColor": "#A5A5A7"
        },
        {
            "climeetDifficultyName": "V8",
            "gymDifficultyName": "난이도8",
            "difficulty": 8,
            "gymDifficultyColor": "#A08169"
        },
        {
            "climeetDifficultyName": "C",
            "gymDifficultyName": "난이도10",
            "difficulty": 10,
            "gymDifficultyColor": "#000000"
        },
        {
            "climeetDifficultyName": "V9+",
            "gymDifficultyName": "난이도9",
            "difficulty": 15,
            "gymDifficultyColor": "#000000"
        }
    ],
    "floorList": [
        1,
        2
    ]
}
```

- route 반환 API
입력값
``` json
{
    "page": 0,
    "size": 6,
    "timePoint": "2024-01-28",
    "floorList": [2],
    "sectorIdList": []
    
}
```
출력값
``` json
{
    "page": 0,
    "hasNext": true,
    "result": [
        {
            "routeId": 20,
            "sectorId": 4,
            "sectorName": "Cheesegrater",
            "climeetDifficultyName": "V8",
            "difficulty": 8,
            "gymDifficultyName": "난이도8",
            "gymDifficultyColor": "#A08169",
            "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/000fcddb-ecfe-4d95-9195-47e762547f41.jpg"
        },
        {
            "routeId": 19,
            "sectorId": 3,
            "sectorName": "Jaws",
            "climeetDifficultyName": "V7",
            "difficulty": 7,
            "gymDifficultyName": "난이도7",
            "gymDifficultyColor": "#A5A5A7",
            "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/68520a73-9580-46d2-b186-484fddea3ee2.jpg"
        },
        {
            "routeId": 18,
            "sectorId": 2,
            "sectorName": "Panorama",
            "climeetDifficultyName": "V6",
            "difficulty": 6,
            "gymDifficultyName": "난이도6",
            "gymDifficultyColor": "#69547F",
            "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/8ac933c5-f553-4844-8636-47a7cf83455e.jpg"
        },
        {
            "routeId": 17,
            "sectorId": 1,
            "sectorName": "Mario",
            "climeetDifficultyName": "V5",
            "difficulty": 5,
            "gymDifficultyName": "난이도5",
            "gymDifficultyColor": "#B2394B",
            "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/f95fb0db-27b7-44b8-ab96-809bc1f67eee.jpg"
        },
        {
            "routeId": 8,
            "sectorId": 4,
            "sectorName": "Cheesegrater",
            "climeetDifficultyName": "V7",
            "difficulty": 7,
            "gymDifficultyName": "난이도7",
            "gymDifficultyColor": "#A5A5A7",
            "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/5017af95-73f7-482a-9283-83f292edb3d1.jpg"
        },
        {
            "routeId": 7,
            "sectorId": 4,
            "sectorName": "Cheesegrater",
            "climeetDifficultyName": "V6",
            "difficulty": 6,
            "gymDifficultyName": "난이도6",
            "gymDifficultyColor": "#69547F",
            "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/472f4348-978c-47a1-ae4b-e2201507e247.jpg"
        }
    ]
}
```

## 질문 및 이외 사항
- 루트를 모두 돌아서, 암장에 해당하는 루트를 모두 가져오고, 해당 루트를 또 모두 돌면서 필터링 값을 거치다 보니 루트 값이 많을수록 시간이 걸리는 것 같습니다. 이후에 DB 인덱싱 처리를 한다던가 해서 루트를 가져오는데 걸리는 시간을 단축시킨다면 좀 더 빠르게 탐색할 수 있지 않을까 싶습니다.(아니면 Redis로 암장마다 가장 최신의 RouteVersion 데이터를 가지고 있으면 될 것 같기도 합니다.)
