### PR TITLE
[SPR-133] refactor: [레벨순/고수] 암장별 금주 클라이머 랭킹 조회 로직 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
@@ -48,7 +48,7 @@ public class ClimbingRecord extends BaseTimeEntity {
     //도전횟수가 아닌 시도한 루트의 개수
     private int attemptRouteCount = 0;
 
-    private int highDifficulty;
+    private int highDifficulty = 0;
 
     public static ClimbingRecord toEntity(User user, CreateClimbingRecord requestDto,
         ClimbingGym climbingGym) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
@@ -2,11 +2,9 @@ package com.climeet.climeet_backend.domain.climbingrecord;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.user.User;
-import com.climeet.climeet_backend.global.security.CurrentUser;
 import jakarta.persistence.Tuple;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -57,13 +55,20 @@ public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, 
     List<Object[]> findByTimeRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
         LocalDate endDate, ClimbingGym climbingGym);
 
-    @Query("SELECT " +
-        "cr.user, MAX(cr.highDifficulty) as highDifficulty " +
-        "FROM ClimbingRecord cr " +
-        "WHERE cr.climbingDate BETWEEN :startDate AND :endDate " +
-        "AND cr.gym = :climbingGym " +
-        "GROUP BY cr.user " +
-        "ORDER BY highDifficulty DESC")
+    @Query(
+        "SELECT cr.user, MAX(cr.highDifficulty), COUNT(*) as highDifficultyCount " +
+         "FROM " +
+            "(" +
+            "SELECT cr.user as user, MAX(cr.highDifficulty) as highDifficulty " +
+            "FROM ClimbingRecord cr " +
+            "WHERE cr.climbingDate BETWEEN :startDate AND :endDate AND cr.gym = :climbingGym " +
+            "GROUP BY cr.user) as subquery " +
+        "INNER JOIN ClimbingRecord cr ON cr.user.id = subquery.user.id " +
+        "Where subquery.user.id = cr.user.id AND subquery.highDifficulty = cr.highDifficulty " +
+        "AND cr.climbingDate BETWEEN :startDate AND :endDate AND cr.gym = :climbingGym " +
+        "GROUP BY subquery.user.id " +
+        "ORDER BY subquery.highDifficulty DESC, highDifficultyCount DESC"
+    )
     List<Object[]> findByLevelRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
         LocalDate endDate, ClimbingGym climbingGym);
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -12,6 +12,7 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRespo
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserStatisticsSimpleInfo;
+import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecord;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecordRepository;
 import com.climeet.climeet_backend.domain.routerecord.RouteRecordService;
@@ -44,12 +45,14 @@ public class ClimbingRecordService {
     private final RouteRecordService routeRecordService;
     private final RouteRecordRepository routeRecordRepository;
     private final UserRepository userRepository;
+    private final DifficultyMappingRepository difficultyMappingRepository;
 
     public static final int START_DAY_OF_MONTH = 1;
     public static final int MONDAY = 0;
     public static final int SUNDAY = 1;
     public static final int RANKING_USER = 0;
     public static final int RANKING_CONDITION = 1;
+    public static final int RANKING_COUNT = 2;
 
 
     /**
@@ -242,7 +245,8 @@ public class ClimbingRecordService {
         );
     }
 
-    public List<BestClearUserSimpleInfo> getClimberRankingListOrderClearCountByGym(Long climbingGymId) {
+    public List<BestClearUserSimpleInfo> getClimberRankingListOrderClearCountByGym(
+        Long climbingGymId) {
         ClimbingGym climbingGym = gymRepository.findById(climbingGymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
@@ -298,7 +302,11 @@ public class ClimbingRecordService {
             .map(userRankMap -> {
                 User user = (User) userRankMap[RANKING_USER];
                 int highDifficulty = (int) userRankMap[RANKING_CONDITION];
-                return BestLevelUserSimpleInfo.toDTO(user, rank[0]++, highDifficulty);
+                Number count = (Number) userRankMap[RANKING_COUNT];
+                int highDifficultyCount = count.intValue();
+
+                return BestLevelUserSimpleInfo.toDTO(user, rank[0]++, highDifficulty,
+                    highDifficultyCount);
             })
             .collect(Collectors.toList());
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -162,19 +162,24 @@ public class ClimbingRecordResponseDto {
     @Builder
     public static class BestLevelUserSimpleInfo {
 
-        private int highDifficulty;
         private Long userId;
         protected String profileName;
         protected String profileImageUrl;
         private int ranking;
+        private int highDifficulty;
+        private int highDifficultyCount;
 
-        public static BestLevelUserSimpleInfo toDTO(User user, int ranking, int highDifficulty) {
+
+        public static BestLevelUserSimpleInfo toDTO(User user, int ranking,
+            int highDifficulty, int highDifficultyCount
+            ) {
             return BestLevelUserSimpleInfo.builder()
                 .ranking(ranking)
                 .userId(user.getId())
                 .profileImageUrl(user.getProfileImageUrl())
                 .profileName(user.getProfileName())
                 .highDifficulty(highDifficulty)
+                .highDifficultyCount(highDifficultyCount)
                 .build();
         }
     }


### PR DESCRIPTION
## 요약
- 각 암장 금주 레벨순 고수 클라이머 랭킹 리팩토링
- 더미데이터 값 맞추는 쿼리 작성

## 상세 내용
- 암장별 랭킹을 조회할 때 레벨순 + 같은 레벨이라면 더 많은 성공횟수로 랭킹을 매겼습니다.
```java
 @Query(
        "SELECT cr.user, MAX(cr.highDifficulty), COUNT(*) as highDifficultyCount " +
         "FROM " +
            "(" +
            "SELECT cr.user as user, MAX(cr.highDifficulty) as highDifficulty " +
            "FROM ClimbingRecord cr " +
            "WHERE cr.climbingDate BETWEEN :startDate AND :endDate AND cr.gym = :climbingGym " +
            "GROUP BY cr.user) as subquery " +
        "INNER JOIN ClimbingRecord cr ON cr.user.id = subquery.user.id " +
        "Where subquery.user.id = cr.user.id AND subquery.highDifficulty = cr.highDifficulty " +
        "AND cr.climbingDate BETWEEN :startDate AND :endDate AND cr.gym = :climbingGym " +
        "GROUP BY subquery.user.id " +
        "ORDER BY subquery.highDifficulty DESC, highDifficultyCount DESC"
    )
    List<Object[]> findByLevelRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
        LocalDate endDate, ClimbingGym climbingGym);
```
- 먼저 subquery로 각각의 유저가 생성한 기록 중 최대 레벨이 무엇인지 가져왔습니다.
- 그리고 해당 레벨과 유저가 매핑된 항목들을 가져와 개수들을 반환하여 최종적으로 진행한 최고 레벨 & 레벨을 수행한 횟수로 등수를 매겼습니다.

### 더미데이터 값 맞추는 쿼리 작성
- 해당 쿼리들은 정제되지 않은 더미값에 대해 루트기록과 그들을 합산한 클라이밍 기록 테이블의 필드를 맞출 때 사용됩니다.
- 깃허브 상에는 올라가지 않기 때문에 한 번쯤 보시라고 첨부합니다.
```SQL
# 더미데이터들에 대해 연결된 route_record 기록에 attempt_route_count 맞추는 쿼리

우선 0으로 업데이트
UPDATE climbing_record cr
set cr.attempt_route_count = 0
where cr.id is not null;

UPDATE climbing_record cr
JOIN (
    SELECT rr.climbing_record_id, COUNT(*) as attempt_count
    FROM route_record rr
    GROUP BY rr.climbing_record_id
) as subquery ON cr.id = subquery.climbing_record_id
SET cr.attempt_route_count = subquery.attempt_count
WHERE cr.id = subquery.climbing_record_id;
# 더미데이터들에 대해 연결된 route_record 기록의 attempt_route_count 맞추는 쿼리
UPDATE climbing_record cr
JOIN (
    SELECT rr.climbing_record_id, SUM(rr.attempt_count)  as attempt_count
    FROM route_record rr
    GROUP BY rr.climbing_record_id
) as subquery ON cr.id = subquery.climbing_record_id
SET cr.total_attempt_count = subquery.attempt_count
WHERE cr.id = subquery.climbing_record_id;

# 더미데이터들에 대해 연결된 route_record 기록의 completed_count 맞추는 쿼리
UPDATE climbing_record cr
set cr.total_completed_count = 0
where cr.id is not null;

UPDATE climbing_record cr
JOIN (
    SELECT rr.climbing_record_id, COUNT(*)  as completed_count
    FROM route_record rr
    where rr.is_completed = true
    GROUP BY rr.climbing_record_id
) as subquery ON cr.id = subquery.climbing_record_id
SET cr.total_completed_count = subquery.completed_count
WHERE cr.id = subquery.climbing_record_id;
```


## 테스트 확인 내용
<img width="888" alt="스크린샷 2024-02-05 오후 5 50 01" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/81e1b54e-0d63-41e3-ab8d-bcffc53818f9">

- 스크린샷에서 확인할 수 있듯이 한 주 동안(현재 시점 기준 지난 주) 운동기록을 한 유저는 3명입니다.
- 1번 , 27번, 28번 아이디를 갖고 있는 각 유저들의 최고 레벨은 7, 5, 4임을 알 수 있습니다.
- 또한 유저들 각각의 최고 레벨에 대한 완등 횟수로 1번 유저는 7레벨을 2번, 27번은 5레벨을 1번, 28번 유저는 4레벨을 1번 했다는 사실도 알 수 있습니다.


## 질문 및 이외 사항
- 다른 브랜치들과의 코드영역 공유로 충돌이 생길 것을 우려하여 암장에 해당되는 레벨색깔, 문자를 반환하지 않았습니다.
- 이는 현재 pr 진행 중인 코드에 구현되어 있음으로 merge 후 바로 리팩토링 진행하겠습니다.
- 쿼리가 랭킹 횟수만큼 날아가기 때문에 다른 구현방법이 있을 지 고민입니다.
