### PR TITLE
[SPR-138] ClimbingGymLayoutImage 테이블 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImage.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImage.java
@@ -1,0 +1,39 @@
+package com.climeet.climeet_backend.domain.climbinggymlayoutimage;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder
+public class ClimbingGymLayoutImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String imgUrl;
+
+    public static ClimbingGymLayoutImage toEntity(String imgUrl) {
+        return ClimbingGymLayoutImage.builder()
+            .imgUrl(imgUrl)
+            .build();
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImageRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImageRepository.java
@@ -1,0 +1,9 @@
+package com.climeet.climeet_backend.domain.climbinggymlayoutimage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClimbingGymLayoutImageRepository extends JpaRepository<ClimbingGymLayoutImage, Long>{
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.routeversion;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImage;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,7 +31,8 @@ public class RouteVersion extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ClimbingGym climbingGym;
 
-    private String layoutImageUrl;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ClimbingGymLayoutImage climbingGymLayoutImage;
 
     @NotNull
     private LocalDate timePoint;
@@ -43,10 +45,10 @@ public class RouteVersion extends BaseTimeEntity {
 
 
     public static RouteVersion toEntity(ClimbingGym climbingGym, LocalDate timePoint,
-        String routeList, String sectorList, String layoutImageUrl) {
+        String routeList, String sectorList, ClimbingGymLayoutImage climbingGymLayoutImage) {
         return RouteVersion.builder()
             .climbingGym(climbingGym)
-            .layoutImageUrl(layoutImageUrl)
+            .climbingGymLayoutImage(climbingGymLayoutImage)
             .timePoint(timePoint)
             .routeList(routeList)
             .sectorList(sectorList)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -16,7 +16,7 @@ public class RouteVersionRequestDto {
         private LocalDate timePoint;
         private List<Long> routeIdList;
         private List<Long> sectorIdList;
-        private String layoutImageUrl;
+        private Long layoutImageId;
     }
 
     @Getter

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -33,7 +33,7 @@ public class RouteVersionResponseDto {
             return RouteVersionFilteringKeyResponse.builder()
                 .gymId(climbingGym.getId())
                 .timePoint(routeVersion.getTimePoint())
-                .layoutImageUrl(routeVersion.getLayoutImageUrl())
+                .layoutImageUrl(routeVersion.getClimbingGymLayoutImage().getImgUrl())
                 .sectorList(sectorList)
                 .difficultyList(difficultyList)
                 .floorList(floorList)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -21,6 +21,7 @@ public class RouteVersionResponseDto {
 
         private Long gymId;
         private LocalDate timePoint;
+        private Long layoutImageUrlId;
         private String layoutImageUrl;
         private List<SectorDetailResponse> sectorList;
         private List<DifficultyMappingDetailResponse> difficultyList;
@@ -33,6 +34,7 @@ public class RouteVersionResponseDto {
             return RouteVersionFilteringKeyResponse.builder()
                 .gymId(climbingGym.getId())
                 .timePoint(routeVersion.getTimePoint())
+                .layoutImageUrlId(routeVersion.getClimbingGymLayoutImage().getId())
                 .layoutImageUrl(routeVersion.getClimbingGymLayoutImage().getImgUrl())
                 .sectorList(sectorList)
                 .difficultyList(difficultyList)


### PR DESCRIPTION
## 요약
- 테이블 추가 및 저장 방식 수정

## 상세 내용
- ClimbingGymLayoutImage 테이블 추가
id랑 imgUrl로만 구성 (같은 이미지인데, 계속 String으로 RouteVersion에 들어가는게 낭비라고 생각되어 변경)
``` java
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @NotNull
    private String imgUrl;

    public static ClimbingGymLayoutImage toEntity(String imgUrl) {
        return ClimbingGymLayoutImage.builder()
            .imgUrl(imgUrl)
            .build();
    }
```

- 저장 방식 변경
url 부분을 모두 ClimbingGymLayoutImage 테이블의 객체로 변경했습니다.
``` java
ClimbingGymLayoutImage climbingGymLayoutImage = null;
        // 이미지 파일이 들어왔으면 s3에 업로드 후 사용
        if (layoutImage != null) {
            String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
            climbingGymLayoutImage = climbingGymLayoutImageRepository.save(
                ClimbingGymLayoutImage.toEntity(layoutImageUrl));
        }
        // 이미지 파일이 안들어왔으면 기존 URL 그대로 사용
        else {
            climbingGymLayoutImage = climbingGymLayoutImageRepository.findById(
                    createRouteVersionRequest.getLayoutImageId())
                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_LAYOUT_IMAGE));
        }
```

## 테스트 확인 내용

- 이미지 추가시에 레이아웃 테이블 데이터 추가 확인(마지막 데이터 추가)
<img width="307" alt="스크린샷 2024-02-05 오후 7 29 48" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/02557c04-7c96-46d8-a1b4-0c28f054f087">

- 이미지 id와 이미지 파일이 모두 입력되지 않았을 때 확인 (예외처리)
<img width="756" alt="스크린샷 2024-02-05 오후 7 31 33" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/2c712d67-01a1-4829-a697-f2e3a02a2dae">

- 이미 존재하는 이미지 id로 추가 확인 (마지막 데이터 추가)
<img width="338" alt="스크린샷 2024-02-05 오후 7 32 52" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/3218e780-c543-4443-8cb4-cfd77bc1577a">



## 질문 및 이외 사항

- 의견 감사합니다~
