### PR TITLE
[SPR-137] 암장 기능 관련 수정 및 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -5,6 +5,7 @@ import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymDetailResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymInfoResponse;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymSimpleResponse;
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.ClimbingGymTabInfoResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -48,18 +49,28 @@ public class ClimbingGymController {
     }
 
     @Operation(summary = "암장 프로필 정보 (상단) 불러오기")
-    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_MANAGER})
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_MANAGER,
+        ErrorStatus._EMPTY_BACKGROUND_IMAGE_LIST})
     @GetMapping("/{gymId}")
     public ResponseEntity<ClimbingGymDetailResponse> getClimbingGymInfo(
         @PathVariable Long gymId, @CurrentUser User user) {
         return ResponseEntity.ok(climbingGymService.getClimbingGymInfo(gymId));
     }
 
+    @Operation(summary = "암장 프로필 정보 (탭) 불러오기")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._ERROR_JSON_PARSE})
+    @GetMapping("/{gymId}/tab")
+    public ResponseEntity<ClimbingGymTabInfoResponse> getClimbingGymTabInfo(
+        @PathVariable Long gymId, @CurrentUser User user) {
+        return ResponseEntity.ok(climbingGymService.getClimbingGymTabInfo(gymId));
+    }
+
     @Operation(summary = "암장 크롤링 정보 입력")
     @PostMapping("/info")
     public ResponseEntity<ClimbingGymInfoResponse> updateClimbingGymInfo(
         @RequestBody UpdateClimbingGymInfoRequest updateClimbingGymInfoRequest) {
-        return ResponseEntity.ok(climbingGymService.updateClimbingGymInfo(updateClimbingGymInfoRequest));
+        return ResponseEntity.ok(
+            climbingGymService.updateClimbingGymInfo(updateClimbingGymInfoRequest));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -50,7 +50,7 @@ public class ClimbingGymController {
 
     @Operation(summary = "암장 프로필 정보 (상단) 불러오기")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_MANAGER,
-        ErrorStatus._EMPTY_BACKGROUND_IMAGE_LIST})
+        ErrorStatus._EMPTY_BACKGROUND_IMAGE})
     @GetMapping("/{gymId}")
     public ResponseEntity<ClimbingGymDetailResponse> getClimbingGymInfo(
         @PathVariable Long gymId, @CurrentUser User user) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "ClimbingGym", description = "암장 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/gym")
+@RequestMapping("api/gyms")
 public class ClimbingGymController {
 
     private final ClimbingGymService climbingGymService;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -93,15 +93,11 @@ public class ClimbingGymService {
         Manager manager = managerRepository.findByClimbingGym(climbingGym)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
-        List<ClimbingGymBackgroundImage> backgroundImageList = climbingGymBackgroundImageRepository.findByClimbingGym(
-            climbingGym);
-        if (backgroundImageList.isEmpty()) {
-            throw new GeneralException(ErrorStatus._EMPTY_BACKGROUND_IMAGE_LIST);
-        }
-        List<String> backgroundImageUrlList = backgroundImageList.stream()
-            .map(ClimbingGymBackgroundImage::getImgUrl)
-            .toList();
-        return ClimbingGymDetailResponse.toDto(climbingGym, manager, backgroundImageUrlList);
+        ClimbingGymBackgroundImage backgroundImage = climbingGymBackgroundImageRepository.findByClimbingGym(
+                climbingGym)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BACKGROUND_IMAGE));
+
+        return ClimbingGymDetailResponse.toDto(climbingGym, manager, backgroundImage.getImgUrl());
     }
 
     public ClimbingGymTabInfoResponse getClimbingGymTabInfo(Long gymId) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -66,18 +66,20 @@ public class ClimbingGymResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ClimbingGymDetailResponse {
+
         private String gymProfileImageUrl;
-        private String managerProfileImageUrl;
+        private List<String> gymBackGroundImageUrl;
         private String gymName;
         private Long followerCount;
         private Long followingCount;
         private float averageRating;
         private int reviewCount;
 
-        public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym, Manager manager){
+        public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym, Manager manager,
+            List<String> gymBackGroundImageUrl) {
             return ClimbingGymDetailResponse.builder()
                 .gymProfileImageUrl(climbingGym.getProfileImageUrl())
-                .managerProfileImageUrl(manager.getProfileImageUrl())
+                .gymBackGroundImageUrl(gymBackGroundImageUrl)
                 .gymName(climbingGym.getName())
                 .followerCount(manager.getFollowerCount())
                 .followingCount(manager.getFollowingCount())

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -93,6 +93,30 @@ public class ClimbingGymResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class ClimbingGymTabInfoResponse {
+
+        private Long gymId;
+        private String address;
+        private String tel;
+        private Map<String, List<String>> businessHours;
+        private List<String> serviceList;
+
+        public static ClimbingGymTabInfoResponse toDto(ClimbingGym climbingGym,
+            Map<String, List<String>> businessHours, List<String> serviceList) {
+            return ClimbingGymTabInfoResponse.builder()
+                .gymId(climbingGym.getId())
+                .address(climbingGym.getAddress())
+                .tel(climbingGym.getTel())
+                .businessHours(businessHours)
+                .serviceList(serviceList)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ClimbingGymInfoResponse {
 
         private String name;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -68,7 +68,7 @@ public class ClimbingGymResponseDto {
     public static class ClimbingGymDetailResponse {
 
         private String gymProfileImageUrl;
-        private List<String> gymBackGroundImageUrl;
+        private String gymBackGroundImageUrl;
         private String gymName;
         private Long followerCount;
         private Long followingCount;
@@ -76,7 +76,7 @@ public class ClimbingGymResponseDto {
         private int reviewCount;
 
         public static ClimbingGymDetailResponse toDto(ClimbingGym climbingGym, Manager manager,
-            List<String> gymBackGroundImageUrl) {
+            String gymBackGroundImageUrl) {
             return ClimbingGymDetailResponse.builder()
                 .gymProfileImageUrl(climbingGym.getProfileImageUrl())
                 .gymBackGroundImageUrl(gymBackGroundImageUrl)

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymimage/ClimbingGymBackgroundImageRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymimage/ClimbingGymBackgroundImageRepository.java
@@ -1,9 +1,11 @@
 package com.climeet.climeet_backend.domain.climbinggymimage;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClimbingGymBackgroundImageRepository extends JpaRepository<ClimbingGymBackgroundImage, Long>{
-
+    List<ClimbingGymBackgroundImage> findByClimbingGym(ClimbingGym climbingGym);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymimage/ClimbingGymBackgroundImageRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymimage/ClimbingGymBackgroundImageRepository.java
@@ -2,10 +2,11 @@ package com.climeet.climeet_backend.domain.climbinggymimage;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClimbingGymBackgroundImageRepository extends JpaRepository<ClimbingGymBackgroundImage, Long>{
-    List<ClimbingGymBackgroundImage> findByClimbingGym(ClimbingGym climbingGym);
+    Optional<ClimbingGymBackgroundImage> findByClimbingGym(ClimbingGym climbingGym);
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _DUPLICATE_GYM_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_003", "이미 관리자가 등록된 암장입니다."),
     _EMPTY_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_004", "해당 관리자가 존재하지 않습니다."),
     _ERROR_JSON_PARSE(HttpStatus.CONFLICT, "CLIMBING_GYM_005", "JSON 파싱을 할 수 없습니다."),
+    _EMPTY_BACKGROUND_IMAGE_LIST(HttpStatus.CONFLICT, "CLIMBING_GYM_006", "암장 배경 이미지가 없습니다."),
 
     //루트 버전 관련
     _EMPTY_VERSION_LIST(HttpStatus.CONFLICT, "ROUTE_VERSION_001", "암장의 루트 버전이 존재하지 않습니다."),

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -28,7 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _DUPLICATE_GYM_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_003", "이미 관리자가 등록된 암장입니다."),
     _EMPTY_MANAGER(HttpStatus.CONFLICT, "CLIMBING_GYM_004", "해당 관리자가 존재하지 않습니다."),
     _ERROR_JSON_PARSE(HttpStatus.CONFLICT, "CLIMBING_GYM_005", "JSON 파싱을 할 수 없습니다."),
-    _EMPTY_BACKGROUND_IMAGE_LIST(HttpStatus.CONFLICT, "CLIMBING_GYM_006", "암장 배경 이미지가 없습니다."),
+    _EMPTY_BACKGROUND_IMAGE(HttpStatus.CONFLICT, "CLIMBING_GYM_006", "암장 배경 이미지가 없습니다."),
 
     //루트 버전 관련
     _EMPTY_VERSION_LIST(HttpStatus.CONFLICT, "ROUTE_VERSION_001", "암장의 루트 버전이 존재하지 않습니다."),


### PR DESCRIPTION
## 요약
- 암장 배경 이미지 반환 변경
- 암장 정보(탭) 조회 구현
<img width="270" alt="스크린샷 2024-02-05 오후 8 08 13" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/2a17a211-933f-453c-812e-adb53311c221">

## 상세 내용

- 암장 배경 이미지 반환 변경
기존에 이해를 잘못해서 manager의 profileImage를 가져왔었는데, backgroundImage라는 테이블이 있다는 것을 깨달았습니다.
따라서 List<String>을 가져오도록 수정했고, 테이블에서 데이터를 가져오도록 수정했습니다.
Service단에서의 수정사항
``` java
List<ClimbingGymBackgroundImage> backgroundImageList = climbingGymBackgroundImageRepository.findByClimbingGym(
            climbingGym);
        if (backgroundImageList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_BACKGROUND_IMAGE_LIST);
        }
        List<String> backgroundImageUrlList = backgroundImageList.stream()
            .map(ClimbingGymBackgroundImage::getImgUrl)
            .toList();
```

- 암장 정보(탭) 조회 구현
<img width="270" alt="스크린샷 2024-02-05 오후 8 08 13" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/2a17a211-933f-453c-812e-adb53311c221">

위의 화면에서 보이는 Service목록과 크롤링한 정보를 반환하도록 수정했습니다.
간단하니 코드로 바로 이해 가능할 것입니다..!

``` java
    ObjectMapper objectMapper = new ObjectMapper();
        try {
            Map<String, List<String>> businessHoursMap = objectMapper.readValue(
                climbingGym.getBusinessHours(),
                new TypeReference<Map<String, List<String>>>() {
                });
            return ClimbingGymTabInfoResponse.toDto(climbingGymRepository.save(climbingGym),
                businessHoursMap, serviceList);
        } catch (Exception e) {
            throw new GeneralException(ErrorStatus._ERROR_JSON_PARSE);
        }
```
위 코드는 테이블에
``` json
{"금": ["16:00", "22:00"], "목": ["16:00", "22:00"], "수": ["16:00", "22:00"], "월": ["16:00", "22:00"], "화": ["16:00", "22:00"]}
```
위와같이 저장되어있는 json 데이터를 파싱해서 가져오도록 합니다.


## 테스트 확인 내용

- 암장 상단 데이터 불러오기
``` json
{
    "gymProfileImageUrl": "프로필이미지유알엘",
    "gymBackGroundImageUrl": [
        "qwerqwerqwer",
        "asdfasdf"
    ],
    "gymName": "홍성클라이밍센터",
    "followerCount": 50310,
    "followingCount": 30300,
    "averageRating": 1.0,
    "reviewCount": 4
}
```

- 암장 탭 데이터 불러오기
``` json
{
    "gymId": 1,
    "address": "충청남도 홍성군 홍북읍 봉신리 290-13 2층",
    "tel": "010-3389-8848",
    "businessHours": {
        "금": [
            "16:00",
            "22:00"
        ],
        "목": [
            "16:00",
            "22:00"
        ],
        "수": [
            "16:00",
            "22:00"
        ],
        "월": [
            "16:00",
            "22:00"
        ],
        "화": [
            "16:00",
            "22:00"
        ]
    },
    "serviceList": [
        "샤워_시설",
        "샤워_용품",
        "수건_제공",
        "간이_세면대",
        "초크_대여",
        "암벽화_대여",
        "삼각대_대여",
        "운동복_대여"
    ]
}
```
 

## 질문 및 이외 사항

- 의견 감사합니다.
