### PR TITLE
[SPR-131] feat: 유저의 누적통계 리팩토링(유저가 보는 유저화면) & 유저의 암장별 통계 구현(유저가 보는 유저화면) 

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -10,6 +10,7 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRespo
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsInfoByGym;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsSimpleInfo;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserAndGymStatisticsDetailInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -166,12 +167,23 @@ public class ClimbingRecordController {
         return ResponseEntity.ok(climbingRecordService.getClimberRankingListOrderLevelByGym(gymId));
     }
 
-    @Operation(summary = "유저별 누적 통계")
+    @Operation(summary = "유저별 전체 암장에 대한 누적 통계")
     @GetMapping("/users/{userId}/statistics")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
     public ResponseEntity<ClimbingRecordUserStatisticsSimpleInfo> getUserStatistics(
         @CurrentUser User user,
         @PathVariable Long userId) {
         return ResponseEntity.ok(climbingRecordService.getUserStatistics(userId));
+    }
+
+    @Operation(summary = "유저별 특정 암장에 대한 누적 통계")
+    @GetMapping("/users/{userId}/gyms/{gymId}/statistics")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
+    public ResponseEntity<ClimbingRecordUserAndGymStatisticsDetailInfo> getUserStatistics(
+        @CurrentUser User user,
+        @PathVariable Long userId,
+        @PathVariable Long gymId
+    ) {
+        return ResponseEntity.ok(climbingRecordService.getUserStatisticsByGym(userId, gymId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, Long> {
 
@@ -48,6 +49,13 @@ public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, 
         "FROM ClimbingRecord cr " +
         "WHERE cr.user = :user")
     Tuple findAllClearRateAndUser(@Param("user") User user);
+
+    @Query("SELECT " +
+        "   SUM(cr.totalCompletedCount) as totalCompletedCount, " +
+        "   SUM(cr.attemptRouteCount) as attemptRouteCount " +
+        "FROM ClimbingRecord cr " +
+        "WHERE cr.user = :user AND cr.gym = :gym ")
+    Tuple findAllClearRateAndUserAndGym(@Param("user") User user, @Param("gym") ClimbingGym gym);
 
     @Query("SELECT " +
         "cr.user, SUM(cr.totalCompletedCount) as totalCount " +

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -376,6 +376,9 @@ public class ClimbingRecordService {
         List<Object[]> bestUserRanking = climbingRecordRepository.findByLevelRankingClimbingDateBetweenAndClimbingGym(
             (LocalDate) lastWeek[MONDAY], (LocalDate) lastWeek[SUNDAY], climbingGym);
 
+        List<DifficultyMapping> difficultyMappingList
+            = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(climbingGym);
+
         int[] rank = {1};
         List<BestLevelUserSimpleInfo> ranking = bestUserRanking.stream()
             .map(userRankMap -> {
@@ -384,8 +387,17 @@ public class ClimbingRecordService {
                 Number count = (Number) userRankMap[RANKING_COUNT];
                 int highDifficultyCount = count.intValue();
 
+
+                DifficultyMapping difficultyMapping = difficultyMappingList.stream()
+                    .filter(iter -> iter.getDifficulty() == highDifficulty )
+                    .findAny().get();
+
+                String climeetDifficultyName = difficultyMapping.getClimeetDifficultyName();
+                String gymDifficultyName = difficultyMapping.getGymDifficultyName();
+                String gymDifficultyColor = difficultyMapping.getGymDifficultyColor();
+
                 return BestLevelUserSimpleInfo.toDTO(user, rank[0]++, highDifficulty,
-                    highDifficultyCount);
+                    highDifficultyCount, climeetDifficultyName, gymDifficultyName, gymDifficultyColor);
             })
             .collect(Collectors.toList());
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -167,14 +167,39 @@ public class ClimbingRecordResponseDto {
     @Builder
     public static class ClimbingRecordUserStatisticsSimpleInfo {
 
+        private Long userId;
         private Long totalCompletedCount;
         private Long attemptRouteCount;
-        private List<Map<Long, Long>> difficulty;
+        private Map<String, Long> difficulty;
 
-        public static ClimbingRecordUserStatisticsSimpleInfo toDTO(Long totalCompletedCount,
-            Long attemptRouteCount, List<Map<Long, Long>> difficulty) {
+        public static ClimbingRecordUserStatisticsSimpleInfo toDTO(Long userId, Long totalCompletedCount,
+            Long attemptRouteCount, Map<String, Long> difficulty) {
 
             return ClimbingRecordUserStatisticsSimpleInfo.builder()
+                .userId(userId)
+                .totalCompletedCount(totalCompletedCount)
+                .attemptRouteCount(attemptRouteCount)
+                .difficulty(difficulty)
+                .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ClimbingRecordUserAndGymStatisticsDetailInfo {
+
+        private Long userId;
+        private Long totalCompletedCount;
+        private Long attemptRouteCount;
+        private List<GymDifficultyMappingInfo> difficulty;
+
+        public static ClimbingRecordUserAndGymStatisticsDetailInfo toDTO(Long userId, Long totalCompletedCount,
+            Long attemptRouteCount, List<GymDifficultyMappingInfo> difficulty) {
+
+            return ClimbingRecordUserAndGymStatisticsDetailInfo.builder()
+                .userId(userId)
                 .totalCompletedCount(totalCompletedCount)
                 .attemptRouteCount(attemptRouteCount)
                 .difficulty(difficulty)

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -217,10 +217,14 @@ public class ClimbingRecordResponseDto {
         private int ranking;
         private int highDifficulty;
         private int highDifficultyCount;
+        private String climeetDifficultyName;
+        private String gymDifficultyName;
+        private String gymDifficultyColor;
 
 
         public static BestLevelUserSimpleInfo toDTO(User user, int ranking,
-            int highDifficulty, int highDifficultyCount
+            int highDifficulty, int highDifficultyCount,
+            String climeetDifficultyName, String gymDifficultyName, String gymDifficultyColor
             ) {
             return BestLevelUserSimpleInfo.builder()
                 .ranking(ranking)
@@ -229,6 +233,9 @@ public class ClimbingRecordResponseDto {
                 .profileName(user.getProfileName())
                 .highDifficulty(highDifficulty)
                 .highDifficultyCount(highDifficultyCount)
+                .climeetDifficultyName(climeetDifficultyName)
+                .gymDifficultyName(gymDifficultyName)
+                .gymDifficultyColor(gymDifficultyColor)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> {
     List<RouteRecord> findAllByClimbingRecordId(Long ClimbingRecordId);
@@ -41,10 +42,20 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     @Query("SELECT " +
         "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
-        "WHERE rr.user = :user " +
-        "GROUP BY rr.route.difficultyMapping.difficulty")
-    List<Map<Long,Long>> findAllRouteRecordDifficultyAndUser(
+        "WHERE rr.user = :user AND rr.isCompleted = true " +
+        "GROUP BY rr.route.difficultyMapping.difficulty" )
+    List<Object[]> findAllRouteRecordDifficultyAndUser(
         @Param("user") User user
+    );
+
+    @Query("SELECT " +
+        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "FROM RouteRecord rr " +
+        "WHERE rr.user = :user AND rr.isCompleted = true AND rr.gym = :gym " +
+        "GROUP BY rr.route.difficultyMapping.difficulty" )
+    List<Object[]> findAllRouteRecordDifficultyAndUserAndGym(
+        @Param("user") User user,
+        @Param("gym") ClimbingGym gym
     );
 
     @Query("SELECT " +


### PR DESCRIPTION
## 요약
- 유저의 누적통계 리팩토링
- 유저의 암장별 통계 구현

## 상세 내용
- 해당 화면을 구현하였습니다.
<img width="273" alt="스크린샷 2024-02-05 오후 8 53 34" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/ae23aa06-6f47-4e68-934d-7157ac3c695e">


### 유저의 전체암장에 대한 누적통계 리팩토링
- 전체암장의 경우 클밋 단위를 받게 됩니다.
- 따라서 Map으로 반환하였습니다.
<img width="515" alt="스크린샷 2024-02-05 오후 8 54 46" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/3ac1a0fb-528b-4f58-bffb-af6c85783f3e">
 보내면 됩니다.

### 유저의 암장별 통계 구현
- 암장별의 경우 암장에서 사용하는 고유한 레벨체계를 매핑해서 보내게 됩니다.
- 따라서 이 전에 구현한 DefficultyMappingDto로 객체를 담아 보냈습니다.
<img width="544" alt="스크린샷 2024-02-05 오후 8 54 27" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/ffa3af85-27f7-4db4-a462-b814bd0e98b8">


## 테스트 확인 내용
- 더미값에 대해 괜찮은 데이터들로 정제하는 쿼리문을 작성해놨습니다.
- 수정이 조금 필요하나 참고해주시면 감사하겠습니다.
- [클밋 더미데이터 정제 쿼리모음](https://velog.io/@gnstjdqkr/%ED%81%B4%EB%B0%8B-db-%EA%B0%92-%EB%A7%9E%EC%B6%94%EB%8A%94-%EC%BF%BC%EB%A6%AC%EB%AA%A8%EC%9D%8C)
<img width="524" alt="스크린샷 2024-02-05 오후 8 53 20" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/b52ec38f-c85c-42e6-a8e4-949549e867dd">



## 질문 및 이외 사항

- ex) 이 부분에서 쿼리가 너무 많이 날라가는 것 같은데 좋은 방법 있을까요?
