### PR TITLE
[SPR-132] refactor: 클라이밍 암장 평균 완등률 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -309,19 +309,27 @@ public class ClimbingRecordService {
         LocalDate startDate = (LocalDate) lastWeek[MONDAY];
         LocalDate endDate = (LocalDate) lastWeek[SUNDAY];
 
-        ClimbingGym climbingGym = gymRepository.findById(gymId)
+        ClimbingGym gym = gymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
-        List<Map<Long, Long>> difficultyList = routeRecordRepository
+        List<Object[]> difficulties = routeRecordRepository
             .getRouteRecordDifficultyBetweenDaysAndGym(
-                climbingGym,
+                gym,
                 startDate,
                 endDate
             );
 
-        return ClimbingRecordStatisticsSimpleInfo.toDTO(
-            difficultyList
-        );
+        List<GymDifficultyMappingInfo> difficultyList = difficulties.stream()
+            .map(arr -> {
+                DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndDifficulty(
+                    gym, ((int) arr[CLIMEET_LEVEL]));
+                Long levelCount = (Long) arr[LEVEL_COUNT];
+
+                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount );
+            })
+            .collect(Collectors.toList());
+
+        return ClimbingRecordStatisticsSimpleInfo.toDTO(difficultyList);
     }
 
     public List<BestClearUserSimpleInfo> getClimberRankingListOrderClearCountByGym(

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -151,9 +151,9 @@ public class ClimbingRecordResponseDto {
     @Builder
     public static class ClimbingRecordStatisticsSimpleInfo {
 
-        private List<Map<Long, Long>> difficulty;
+        private List<GymDifficultyMappingInfo> difficulty;
 
-        public static ClimbingRecordStatisticsSimpleInfo toDTO(List<Map<Long, Long>> difficulty) {
+        public static ClimbingRecordStatisticsSimpleInfo toDTO(List<GymDifficultyMappingInfo> difficulty) {
 
             return ClimbingRecordStatisticsSimpleInfo.builder()
                 .difficulty(difficulty)

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -50,9 +50,9 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     @Query("SELECT " +
         "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
-        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym " +
+        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym AND rr.isCompleted = true " +
         "GROUP BY rr.route.difficultyMapping.difficulty")
-    List<Map<Long,Long>> getRouteRecordDifficultyBetweenDaysAndGym(
+    List<Object[]> getRouteRecordDifficultyBetweenDaysAndGym(
         @Param("gym") ClimbingGym gym,
         @Param("startDate") LocalDate startDate,
         @Param("endDate") LocalDate endDate


### PR DESCRIPTION
## 요약
- 클라이밍 암장 평균 완등률 리팩토링

## 상세 내용
- 이로써 암장 별 매핑되는 레벨을 반환해야 하는 부분들을 모두 해결했습니다!

## 테스트 확인 내용
<img width="569" alt="스크린샷 2024-02-05 오후 10 07 25" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/8f9e61fd-8346-490e-a804-3cd6ee496382">

- 암장별 평균을 정수가 아닌 난이도 별로 매핑되는 클래스 반환

## 질문 및 이외 사항
- 이제 의식했는데 프론트에서 모든 난이도에 대한 정보도 보내줘야 한다면 한바탕 또 리팩토링을 진행해야할 가능성이 있습니다.(사실 아주 높습니다)
- 현재는 count되지 않은 레벨은 따로 보내주지 않습니다..
- 쿼리의 개수와 처리속도가 매우매우 걱정됩니다.
