### PR TITLE
[SPR-144] 운동기록 시간 리팩토링 & RouteRecord 수정, 삭제에 따른 highDifficulty 업데이트

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/dto/BestTimeClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/dto/BestTimeClimberResponseDto.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.bestclimber.time.dto;
 
+import static com.climeet.climeet_backend.global.utils.DateTimeConverter.convertDoubleToStringTime;
+
 import com.climeet.climeet_backend.domain.bestclimber.time.BestTimeClimber;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,14 +22,14 @@ public class BestTimeClimberResponseDto {
 
         private String profileName;
 
-        private Long thisWeekTotalClimbingTime;
+        private String thisWeekTotalClimbingTime;
 
         public static BestTimeClimberDetailInfo toDTO(
             BestTimeClimber bestTimeClimber){
             return BestTimeClimberDetailInfo.builder()
                 .ranking(bestTimeClimber.getRanking())
                 .profileImageUrl(bestTimeClimber.getProfileImageUrl())
-                .thisWeekTotalClimbingTime(bestTimeClimber.getThisWeekTotalClimbingTime())
+                .thisWeekTotalClimbingTime(convertDoubleToStringTime(bestTimeClimber.getThisWeekTotalClimbingTime()))
                 .profileName(bestTimeClimber.getProfileName())
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -117,7 +117,7 @@ public class ClimbingRecordController {
             climbingRecordService.getClimbingRecordStatistics(user, year, month));
     }
 
-    @Operation(summary = "나의 월별 & 암장별 운동기록 통계")
+    @Operation(summary = "특정 암장에 대한 나의 월 통계")
     @GetMapping("/users/gyms/{gymId}/statistics/months")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_RECORD, ErrorStatus._INVALID_MEMBER})
     public ResponseEntity<ClimbingRecordStatisticsInfoByGym> getClimbingStatisticsByGymMonthly(
@@ -167,7 +167,7 @@ public class ClimbingRecordController {
         return ResponseEntity.ok(climbingRecordService.getClimberRankingListOrderLevelByGym(gymId));
     }
 
-    @Operation(summary = "유저별 전체 암장에 대한 누적 통계")
+    @Operation(summary = "[유저프로필] 유저별 전체 암장에 대한 누적 통계")
     @GetMapping("/users/{userId}/statistics")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM})
     public ResponseEntity<ClimbingRecordUserStatisticsSimpleInfo> getUserStatistics(

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.climbingrecord;
 
+import static com.climeet.climeet_backend.global.utils.DateTimeConverter.convertDoubleToStringTime;
+
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRequestDto.UpdateClimbingRecord;
@@ -213,7 +215,7 @@ public class ClimbingRecordService {
             throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD);
         }
         Double totalTime = (Double) crTuple.get("totalTime");
-        LocalTime time = convertDoubleToTime(totalTime);
+        String time = convertDoubleToStringTime(totalTime);
 
         Long totalCompletedCount = (Long) crTuple.get("totalCompletedCount");
 
@@ -269,7 +271,7 @@ public class ClimbingRecordService {
 
         Double totalTime = (Double) crTuple.get("totalTime");
 
-        LocalTime time = convertDoubleToTime(totalTime);
+        String time = convertDoubleToStringTime(totalTime);
 
         Long totalCompletedCount = (Long) crTuple.get("totalCompletedCount");
 
@@ -368,7 +370,7 @@ public class ClimbingRecordService {
         List<BestTimeUserSimpleInfo> ranking = bestUserRanking.stream()
             .map(userRankMap -> {
                 User user = (User) userRankMap[RANKING_USER];
-                LocalTime totalTime = convertDoubleToTime((Double) userRankMap[RANKING_CONDITION]);
+                String totalTime = convertDoubleToStringTime((Double) userRankMap[RANKING_CONDITION]);
                 return BestTimeUserSimpleInfo.toDTO(user, rank[0]++, totalTime);
             })
             .collect(Collectors.toList());
@@ -411,17 +413,6 @@ public class ClimbingRecordService {
             .collect(Collectors.toList());
 
         return ranking;
-    }
-
-
-    // TODO: 2024/01/21 24시간을 초과했을 때 에러처리
-    public static LocalTime convertDoubleToTime(double totalSeconds) {
-        int seconds = (int) totalSeconds;
-        int hours = (seconds / 3600) % 24;
-        int minutes = (seconds % 3600) / 60;
-        int remainingSeconds = seconds % 60;
-
-        return LocalTime.of(hours, minutes, remainingSeconds);
     }
 
     public static Object[] startDayAndLastDayOfLastWeek() {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -206,10 +206,13 @@ public class ClimbingRecordService {
         int month) {
 
         LocalDate startDate = LocalDate.of(year, month, START_DAY_OF_MONTH);
+        System.out.println("startDate = " + startDate);
         LocalDate endDate = YearMonth.of(year, month).atEndOfMonth();
+        System.out.println("endDate = " + endDate);
 
         Tuple crTuple = climbingRecordRepository.getStatisticsInfoBetweenDaysAndUser(user,
             startDate, endDate);
+        System.out.println("crTuple = " + crTuple);
 
         if (crTuple.get("totalTime") == null) {
             throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD);

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -206,13 +206,10 @@ public class ClimbingRecordService {
         int month) {
 
         LocalDate startDate = LocalDate.of(year, month, START_DAY_OF_MONTH);
-        System.out.println("startDate = " + startDate);
         LocalDate endDate = YearMonth.of(year, month).atEndOfMonth();
-        System.out.println("endDate = " + endDate);
 
         Tuple crTuple = climbingRecordRepository.getStatisticsInfoBetweenDaysAndUser(user,
             startDate, endDate);
-        System.out.println("crTuple = " + crTuple);
 
         if (crTuple.get("totalTime") == null) {
             throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD);

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -81,12 +81,12 @@ public class ClimbingRecordResponseDto {
     @Builder
     public static class ClimbingRecordStatisticsInfo {
 
-        private LocalTime time;
+        private String time;
         private Long totalCompletedCount;
         private Long attemptRouteCount;
         private Map<String, Long> difficulty;
 
-        public static ClimbingRecordStatisticsInfo toDTO(LocalTime time, Long totalCompletedCount,
+        public static ClimbingRecordStatisticsInfo toDTO(String time, Long totalCompletedCount,
             Long attemptRouteCount, Map<String, Long> difficulty) {
 
             return ClimbingRecordStatisticsInfo.builder()
@@ -104,12 +104,12 @@ public class ClimbingRecordResponseDto {
     @Builder
     public static class ClimbingRecordStatisticsInfoByGym {
 
-        private LocalTime time;
+        private String time;
         private Long totalCompletedCount;
         private Long attemptRouteCount;
         private List<GymDifficultyMappingInfo> difficulty;
 
-        public static ClimbingRecordStatisticsInfoByGym toDTO(LocalTime time, Long totalCompletedCount,
+        public static ClimbingRecordStatisticsInfoByGym toDTO(String time, Long totalCompletedCount,
             Long attemptRouteCount, List<GymDifficultyMappingInfo> difficulty) {
 
             return ClimbingRecordStatisticsInfoByGym.builder()
@@ -271,14 +271,14 @@ public class ClimbingRecordResponseDto {
     @Builder
     public static class BestTimeUserSimpleInfo {
 
-        private LocalTime totalTime;
+        private String totalTime;
 
         private Long userId;
         protected String profileName;
         protected String profileImageUrl;
         private int ranking;
 
-        public static BestTimeUserSimpleInfo toDTO(User user, int ranking, LocalTime totalTime) {
+        public static BestTimeUserSimpleInfo toDTO(User user, int ranking, String totalTime) {
 
             return BestTimeUserSimpleInfo.builder()
                 .ranking(ranking)

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
@@ -60,8 +60,7 @@ public class RouteRecord extends BaseTimeEntity {
             .build();
     }
 
-    public void update(int attemptCount, Boolean isCompleted, Route route) {
-        this.route = route;
+    public void update(int attemptCount, Boolean isCompleted) {
         this.attemptCount = attemptCount;
         this.isCompleted = isCompleted;
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
@@ -47,6 +47,8 @@ public class RouteRecord extends BaseTimeEntity {
 
     private Boolean isCompleted = false;
 
+    private int difficulty;
+
     public static RouteRecord toEntity(User user, CreateRouteRecord createRouteRecordReq,
         ClimbingRecord climbingRecord, Route route) {
         return RouteRecord.builder()
@@ -57,6 +59,7 @@ public class RouteRecord extends BaseTimeEntity {
             .attemptCount(createRouteRecordReq.getAttemptCount())
             .isCompleted(createRouteRecordReq.getIsCompleted())
             .routeRecordDate(climbingRecord.getClimbingDate())
+            .difficulty(route.getDifficultyMapping().getDifficulty())
             .build();
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -17,10 +17,10 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     List<RouteRecord> findAllByUser(@Param("user") User user);
 
     @Query("SELECT " +
-        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.user = :user AND rr.isCompleted = true " +
-        "GROUP BY rr.route.difficultyMapping.difficulty")
+        "GROUP BY rr.difficulty")
     List<Object[]> getRouteRecordDifficultyBetween(
         @Param("user") User user,
         @Param("startDate") LocalDate startDate,
@@ -28,10 +28,10 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     );
 
     @Query("SELECT " +
-        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym AND rr.user = :user AND rr.isCompleted = true " +
-        "GROUP BY rr.route.difficultyMapping.difficulty")
+        "GROUP BY rr.difficulty")
     List<Object[]> getRouteRecordDifficultyBetweenDatesAndGym(
         @Param("user") User user,
         @Param("gym") ClimbingGym gym,
@@ -40,29 +40,29 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     );
 
     @Query("SELECT " +
-        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.user = :user AND rr.isCompleted = true " +
-        "GROUP BY rr.route.difficultyMapping.difficulty" )
+        "GROUP BY rr.difficulty" )
     List<Object[]> findAllRouteRecordDifficultyAndUser(
         @Param("user") User user
     );
 
     @Query("SELECT " +
-        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.user = :user AND rr.isCompleted = true AND rr.gym = :gym " +
-        "GROUP BY rr.route.difficultyMapping.difficulty" )
+        "GROUP BY rr.difficulty" )
     List<Object[]> findAllRouteRecordDifficultyAndUserAndGym(
         @Param("user") User user,
         @Param("gym") ClimbingGym gym
     );
 
     @Query("SELECT " +
-        "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
+        "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym AND rr.isCompleted = true " +
-        "GROUP BY rr.route.difficultyMapping.difficulty")
+        "GROUP BY rr.difficulty")
     List<Object[]> getRouteRecordDifficultyBetweenDaysAndGym(
         @Param("gym") ClimbingGym gym,
         @Param("startDate") LocalDate startDate,

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -19,7 +19,7 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     @Query("SELECT " +
         "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
-        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.user = :user " +
+        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.user = :user AND rr.isCompleted = true " +
         "GROUP BY rr.route.difficultyMapping.difficulty")
     List<Object[]> getRouteRecordDifficultyBetween(
         @Param("user") User user,
@@ -30,7 +30,7 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
     @Query("SELECT " +
         "   rr.route.difficultyMapping.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
-        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym AND rr.user = :user " +
+        "WHERE rr.routeRecordDate BETWEEN :startDate AND :endDate AND rr.gym = :gym AND rr.user = :user AND rr.isCompleted = true " +
         "GROUP BY rr.route.difficultyMapping.difficulty")
     List<Object[]> getRouteRecordDifficultyBetweenDatesAndGym(
         @Param("user") User user,

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -45,6 +45,10 @@ public class RouteRecordService {
         if (requestDto.getIsCompleted()) {
             climbingRecord.totalCompletedCountUp();
         }
+
+        climbingRecord.setHighDifficulty(Math.max(route.getDifficultyMapping().getDifficulty(),
+            climbingRecord.getHighDifficulty()));
+
         return ResponseEntity.ok("루트 기록 성공");
 
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -103,17 +103,16 @@ public class RouteRecordService {
         ClimbingRecord climbingRecord = routeRecord.getClimbingRecord();
 
         //각 필드의 기존값들
-        Long routeId = routeRecord.getRoute().getId();
-        int oldAttemptTime = routeRecord.getAttemptCount();
+        int oldAttemptCount = routeRecord.getAttemptCount();
         Boolean oldIsCompleted = routeRecord.getIsCompleted();
 
         //각 필드의 새값들
-        Integer newAttemptTime = updateRouteRecord.getAttemptCount();
+        Integer attemptCount = updateRouteRecord.getAttemptCount();
         Boolean newIsComplete = updateRouteRecord.getIsComplete();
 
-        if (newAttemptTime != null) {
-            climbingRecord.setAttemptCount(newAttemptTime - oldAttemptTime);
-            oldAttemptTime = newAttemptTime;
+        if (attemptCount != null) {
+            climbingRecord.setAttemptCount(attemptCount - oldAttemptCount);
+            oldAttemptCount = attemptCount;
         }
 
         if (newIsComplete != null && newIsComplete != oldIsCompleted) {
@@ -135,7 +134,7 @@ public class RouteRecordService {
 
         climbingRecord.attemptRouteCountUp();
 
-        routeRecord.update(oldAttemptTime, oldIsCompleted);
+        routeRecord.update(oldAttemptCount, oldIsCompleted);
 
         return new RouteRecordSimpleInfo(routeRecord);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -176,6 +176,9 @@ public class RouteRecordService {
             if (!difficulties.isEmpty()) {
                 climbingRecord.setHighDifficulty(difficulties.get(difficulties.size() - 1));
             }
+            else{
+                climbingRecord.setHighDifficulty(0);
+            }
         }
 
         //climbingRecord의 평균 업데이트

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordService.java
@@ -116,7 +116,7 @@ public class RouteRecordService {
         }
 
         if (newIsComplete != null && newIsComplete != oldIsCompleted) {
-            int difficulty = routeRecord.getRoute().getDifficultyMapping().getDifficulty();
+            int difficulty = routeRecord.getDifficulty();
             int oldAvgDifficulty = climbingRecord.getAvgDifficulty();
             int oldCount = climbingRecord.getTotalCompletedCount();
 
@@ -153,7 +153,7 @@ public class RouteRecordService {
 
         ClimbingRecord climbingRecord = routeRecord.getClimbingRecord();
 
-        int difficulty = routeRecord.getRoute().getDifficultyMapping().getDifficulty();
+        int difficulty = routeRecord.getDifficulty();
 
         List<RouteRecord> routeRecordList = routeRecordRepository.findAllByClimbingRecordId(
             climbingRecord.getId());
@@ -162,8 +162,7 @@ public class RouteRecordService {
         List<Integer> difficulties = routeRecordList.stream()
             .filter(record -> !record.getRoute().getId()
                 .equals(routeRecord.getRoute().getId()))
-            .map(record -> record.getRoute()
-                .getDifficultyMapping().getDifficulty())
+            .map(RouteRecord::getDifficulty)
             .toList();
 
         // difficulties 리스트에 difficulty 이상인 값이 있는지 확인

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
@@ -28,7 +28,7 @@ public class RouteRecordRequestDto {
         @Schema(example = "10", description = "해당 루트 도전 횟수")
         private Integer attemptCount;
 
-        @Schema(example = "1", description = "해당 루트 완등 여부")
+        @Schema(example = "true", description = "해당 루트 완등 여부")
         private Boolean isComplete;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/dto/RouteRecordRequestDto.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 
 public class RouteRecordRequestDto {
 
-    // TODO: 2024/01/07 ClimbingRecord의 avgDifficulty 어떻게 구현 할 지 고민
     @Getter
     @NoArgsConstructor
     public static class CreateRouteRecord {
@@ -25,9 +24,6 @@ public class RouteRecordRequestDto {
     @Getter
     @NoArgsConstructor
     public static class UpdateRouteRecord {
-
-        @Schema(example = "1", description = "루트 Id")
-        private Long routeId;
 
         @Schema(example = "10", description = "해당 루트 도전 횟수")
         private Integer attemptCount;

--- a/src/main/java/com/climeet/climeet_backend/global/utils/DateTimeConverter.java
+++ b/src/main/java/com/climeet/climeet_backend/global/utils/DateTimeConverter.java
@@ -18,4 +18,16 @@ public class DateTimeConverter {
         } else
             return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
     }
+
+    public static String convertDoubleToStringTime(double totalSeconds) {
+        int seconds = (int) totalSeconds;
+        int hours = (seconds / 3600);
+        int minutes = (seconds % 3600) / 60;
+        int remainingSeconds = seconds % 60;
+
+        String hoursString = (hours < 100) ? String.format("%02d", hours) : String.format("%03d", hours);
+        String totalTime = String.format("%s:%02d:%02d", hoursString, minutes, remainingSeconds);
+
+        return totalTime;
+    }
 }


### PR DESCRIPTION
## 요약
- climbingTime 반환 타입 수정
- RouteRecord 수정, 삭제에 따른 highDifficulty 업데이트
- RouteRecord에 difficulty 필드 추가
## 상세 내용
### 1. LocalTime 타입 변경
[홈화면]bestTimeClimber
[암장]bestTimeClimber
[캘린더]내 월별 통계 by 암장별
[캘린더]내 월별 통계 by 전체 암장
- 위 네 가지 기능들은 주/월 단위의 운동시간을 합해 24시간을 넘는 시간을 반환할 수 있습니다.
- 기존 LocalTime의 경우 23:59:59를 초과하게 되면 에러를 발생시켜 임시방편으로 hours 필드에 대해 %24 연산을 통해 24시간을 넘게 하지 않았습니다.
- 이에 따라 기존 LocalTime으로 반환하던 time 필드를 String으로 변환하는 로직을 구현하였습니다.

```java
public static String convertDoubleToStringTime(double totalSeconds) {
        int seconds = (int) totalSeconds;
        int hours = (seconds / 3600);
        int minutes = (seconds % 3600) / 60;
        int remainingSeconds = seconds % 60;

        String hoursString = (hours < 100) ? String.format("%02d", hours) : String.format("%03d", hours);
        String totalTime = String.format("%s:%02d:%02d", hoursString, minutes, remainingSeconds);

        return totalTime;
    }
```

### 2. RouteRecord 수정에 따른 ClimbingRecord의 highDifficulty 업데이트
- 수정과 삭제 총 두 가지 메서드를 수정하였습니다.
**먼저 삭제입니다.**
```java
ClimbingRecord climbingRecord = routeRecord.getClimbingRecord();

        int difficulty = routeRecord.getRoute().getDifficultyMapping().getDifficulty();

        List<RouteRecord> routeRecordList = routeRecordRepository.findAllByClimbingRecordId(
            climbingRecord.getId());


        List<Integer> difficulties = routeRecordList.stream()
            .filter(record -> !record.getRoute().getId()
                .equals(routeRecord.getRoute().getId()))
            .map(record -> record.getRoute()
                .getDifficultyMapping().getDifficulty())
            .toList();

        // difficulties 리스트에 difficulty 이상인 값이 있는지 확인
        Optional<Integer> largerOrEqual = difficulties.stream()
            .filter(d -> d >= difficulty)
            .findFirst();

        // difficulty 이상인 값이 없는 경우, 있는 경우라면 climbingRecord를 업데이트 하지 않아도 됨.
        if (largerOrEqual.isEmpty()) {
            // difficulties 리스트가 비어있지 않은 경우라면 climbingRecord에 남은 routeRecord 기록들이 있다는 뜻.
            if (!difficulties.isEmpty()) {
                climbingRecord.setHighDifficulty(difficulties.get(difficulties.size() - 1));
            }
        }
```

- 해당 코드가 추가된 이유는 climbingRecord의 highDifficulty를 업데이트 해주기 위함입니다.
- 먼저 삭제하고자 하는 루트기록의 레벨을 보관합니다.
- 자신이 속해있는 ClimbingRecord와 연결된 또 다른 RouteRecord의 difficulty를 전부 가져옵니다.
- 만약에 자신보다 difficulty가 높거나 같은 값이 따로 존재한다면 삭제를 해도 직접적인 영향을 미치지 않습니다.
- 만약 자신의 difficulty가 ClimbingRecord의 highDifficulty를 정의하는 유일한 값이었다면 바로 가깝게 작은 값으로 업데이트 해야합니다.
- 보다 자세한 내용은 주석을 참고해주시면 감사하겠습니다.

**다음은 수정 로직입니다.**
- 수정은 기존 루트도 변경할 수 있었던 점에 대해 routeId는 변경할 수 없게 수정하였습니다.
- 그 이유는 route와 routeRecord는 일대일이기 때문입니다.

### RouteRecord에 difficulty 필드 추가
-  climberRecord에 연결된 모든 루트 기록 -> 루트 -> difficultyMapping -> difficulty를 방문해야하는 상황이 종종발생했습니다.
- 이는 CRUD 중 가장 많은 수요를 차지하는 R의 경우에 불필요한 쿼리를 많이 생산해냅니다.
- 이에 따라 RouteRecord에 difficulty 필드를 추가하였습니다.
- RouteRecord와 Route는 1대1 관계이기 때문에 큰 문제가 없을 것이라 생각했습니다.
- Route의 값 자체가 바뀌었을 때는 RouteRecord도 수정해야 하는 문제가 있을 것 같기는 합니다만 제가 건드리는 코드영역이 아니기에 우선은 백로그로 남겨놓고 이후 상의하겠습니다.

### 다음은 RouteRecord 삭제 시 쿼리 양의 변화입니다.
(수정 전)
<img width="707" alt="스크린샷 2024-02-08 오후 1 47 20" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/83f85428-7b92-4648-a40a-313a563f6533">

(수정 후)
<img width="699" alt="스크린샷 2024-02-08 오후 1 47 15" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/6c28afdd-61df-403e-ad38-367876d55180">

- 해당 쿼리에 대한 분석은 GPT에게 맡겼습니다!(일일히 분석하고 세기 귀찮았습니다ㅜ)
- 보시다시피 무려 25개의 쿼리가 줄었습니다!


## 테스트 확인 내용
### TotalTime 리팩토링한 결과
[홈화면]bestTimeClimber
<img width="1036" alt="홈 베스트타임클라이머" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/c2a64807-0690-40a0-a6cc-9da83466b9c5">

[암장]bestTimeClimber
<img width="983" alt="암장별 베스트클라이머" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/dc2d3f77-51f8-405e-8f97-943e1e0c1bc3">

[캘린더]내 월별 통계 by 암장별
<img width="1061" alt="내월별통계암장별" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/ae6b577b-992c-469a-9de7-27aa76678fbc">

[캘린더]내 월별 통계 by 전체 암장
<img width="787" alt="내월별통계암장전체" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/7fabb14e-a162-46d6-91ed-6269b09c2244">

### RouteRecord의 difficulty 필드 추가로 인한 시간 최적화
(수정 전)
<img width="658" alt="수정전" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/ae447c1c-e6f7-4803-830e-280547f9d01a">

(수정 후)
<img width="688" alt="수정후" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/1b3d49ed-2347-445b-ae7f-bcd072842b4d">

- 거의 반 정도 시간이 줄었습니다!


## 질문 및 이외 사항

- ~~routeRecord를 하나 삭제하기 위해 climberRecord에 연결된 모든 루트 기록 -> 루트 -> difficultyMapping -> difficulty를 방문해야합니다.~~
- ~~이에 따라 상당한 양의 쿼리가 날아가기 때문에 다음 pr에 routeRecord에 difficulty(int)필드를 넣겠습니다.~~
- ~~route와 routeRecord는 1대1로 규정했기에 문제될 것 없다고 생각합니다.~~
- ~~또한 해당 변경될 사항에 따른 전체 통계&기록 부분들의 쿼리도 최적화 되리라 생각합니다.~~
- 수정완료!

**totalComplete와 실제 complete한 결과가 다릅니다.**
- 이에 따라 해당되는 부분들을 맞추는 쿼리를 로컬에서 작성하였고 람다에 배포할 예정입니다.