### PR TITLE
[SPR-128] 쇼츠 프로필 초록불 관련 작업

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/ClimeetBackendApplication.java
+++ b/src/main/java/com/climeet/climeet_backend/ClimeetBackendApplication.java
@@ -3,9 +3,11 @@ package com.climeet.climeet_backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class ClimeetBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.transaction.Transactional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +44,7 @@ public class FollowRelationship extends BaseTimeEntity {
             .build();
     }
 
+    @Transactional
     public void updateUploadStatus(boolean status){
         this.isUploadShortsRecent = status;
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
@@ -43,4 +43,8 @@ public class FollowRelationship extends BaseTimeEntity {
             .build();
     }
 
+    public void updateUploadStatus(boolean status){
+        this.isUploadShortsRecent = status;
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationship.java
@@ -41,6 +41,7 @@ public class FollowRelationship extends BaseTimeEntity {
         return FollowRelationship.builder()
             .follower(follower)
             .following(following)
+            .isUploadShortsRecent(false)
             .build();
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.shorts;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +16,6 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
     @Query("SELECT s FROM Shorts s WHERE s.ranking <> 0 AND s.isPublic = true ORDER BY s.ranking ASC, s.createdAt DESC")
     Slice<Shorts> findAllByIsPublicTrueANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(Pageable pageable);
 
-    List<Shorts> findByCreatedAtBefore(Date dateTime);
+    List<Shorts> findByCreatedAtBefore(LocalDateTime dateTime);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -1,5 +1,7 @@
 package com.climeet.climeet_backend.domain.shorts;
 
+import java.util.Date;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,5 +13,7 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 
     @Query("SELECT s FROM Shorts s WHERE s.ranking <> 0 AND s.isPublic = true ORDER BY s.ranking ASC, s.createdAt DESC")
     Slice<Shorts> findAllByIsPublicTrueANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(Pageable pageable);
+
+    List<Shorts> findByCreatedAtBefore(Date dateTime);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -74,7 +74,8 @@ public class ShortsService {
         shortsRepository.save(shorts);
 
         //팔로워 관계 isUploadShortsRecent update
-        List<FollowRelationship> followRelationshipList = followRelationshipRepository.findByFollowerId(user.getId());
+        List<FollowRelationship> followRelationshipList = followRelationshipRepository.findByFollowingId(shorts.getUser()
+            .getId());
         for(FollowRelationship f : followRelationshipList){
             f.updateUploadStatus(true);
         }
@@ -172,7 +173,7 @@ public class ShortsService {
         List<Shorts> shortsList = shortsRepository.findByCreatedAtBefore(threeDaysAgo);
         for(Shorts shorts : shortsList) {
             System.out.println(shorts);
-            List<FollowRelationship> followRelationship = followRelationshipRepository.findByFollowerId(
+            List<FollowRelationship> followRelationship = followRelationshipRepository.findByFollowingId(
                 shorts.getUser().getId());
 
             for(FollowRelationship relationship : followRelationship){

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -166,15 +166,18 @@ public class ShortsService {
 
 
     @Transactional
-    @Scheduled(fixedRate = 1000 * 60) //1분마다 실행
+    @Scheduled(fixedRate = 1000 * 60 * 60 * 24) //하루마다 시행
     public void updateVideoStatus(){
 
         LocalDateTime threeDaysAgo = LocalDateTime.now().minusDays(3);
         List<Shorts> shortsList = shortsRepository.findByCreatedAtBefore(threeDaysAgo);
         for(Shorts shorts : shortsList) {
-            System.out.println(shorts);
             List<FollowRelationship> followRelationship = followRelationshipRepository.findByFollowingId(
                 shorts.getUser().getId());
+
+            for(FollowRelationship relationship : followRelationship){
+                relationship.updateUploadStatus(false);
+            }
 
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.List;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -38,6 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class ShortsService {
 
     private final ShortsRepository shortsRepository;
@@ -161,11 +163,15 @@ public class ShortsService {
 
     }
 
-    @Scheduled(fixedRate = 1000 * 60 * 60 * 24) //24시간마다 실행
+
+    @Transactional
+    @Scheduled(fixedRate = 1000 * 60) //1분마다 실행
     public void updateVideoStatus(){
-        Date threeDaysAgo = new Date(System.currentTimeMillis() - 1000 * 60 * 60 * 24 * 3);
+
+        LocalDateTime threeDaysAgo = LocalDateTime.now().minusDays(3);
         List<Shorts> shortsList = shortsRepository.findByCreatedAtBefore(threeDaysAgo);
         for(Shorts shorts : shortsList) {
+            System.out.println(shorts);
             List<FollowRelationship> followRelationship = followRelationshipRepository.findByFollowerId(
                 shorts.getUser().getId());
 

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -176,9 +176,6 @@ public class ShortsService {
             List<FollowRelationship> followRelationship = followRelationshipRepository.findByFollowingId(
                 shorts.getUser().getId());
 
-            for(FollowRelationship relationship : followRelationship){
-                relationship.updateUploadStatus(false);
-            }
         }
 
 


### PR DESCRIPTION
## 요약
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/5a4c2cf1-ca1b-4327-a7a5-c847910e3969)
팔로우 하고 있는 유저의 프로필을 조회하는 화면에서 유저가 최근에 쇼츠를 올렸다면 초록불이 생기고, 
유저가 프로필을 클릭 하거나, 3일이 지나면 초록불이 사라지는 함수를 구현하였습니다. 
(프로필을 조회하는 함수는 이전에 구현 하였습니다)


## 상세 내용
- 스케줄링을 이용하였습니다. 초록불 상태 컬럼은 followRelationship 테이블에 존재하기 때문에, 컬럼의 상태를 바꿔주기 위해서는 followRelationship 테이블의 순회가 필요합니다. 지금은 컬럼이 많지 않지만, 추후에 많아진다면 비효율적일 수도 있을 것 같아서 스케줄링 사용 여부를 고민 하였지만, 결론적으로 스케줄링을 사용하게 되었습니다.
- 대안적으로 고민한 방법은 async + 스케줄링을 이용하는 방법이었습니다. 쇼츠를 업로드 하는 시점에 3일 뒤에 상태를 false로 바꿔주는 스케줄링 함수를 시작하는 방법이었습니다. 다만, async는 서버가 재시작 되거나 종료되는 경우, 상태를 유지하지 못하는 큰 문제점이 있기 때문에 결론적으로 주기적으로 순회하는 스케줄링 방식으로 코드를 작성 하였습니다. 

## 테스트 확인 내용
- 디버거를 통해 스케줄링이 정해진 시간(현재 코드는 1분, 그러나 10분 정도로 바꾸는 것도 괜찮을 것 같다고 생각이 드네요.) 마다 수행되는 것을 확인 하였습니다. (주기적으로 순회하는 스케줄링 기간은 논의 후 확정하면 좋을 것 같습니다)
- 쇼츠 업로드 시간을 불러온 후, 3일 이상이면 상태를 false로 만드는 것을 확인 했습니다. 
- 쇼츠 업로드 시 FollowRelationship 엔티티의 isUploadShortsRecent 컬럼이 true로 변경되는 것을 확인했고, 3일이 지나있다면 false로 바뀌는 것 또한 확인 했습니다. 


## 질문 및 이외 사항

- followRelationship 테이블을 순회하는 함수를 몇 분 간격으로 수행하면 좋을지 함께 논의하면 좋을 것 같습니다. 1분마다 수행하는 것이 가장 정확하겠지만, 부하테스트를 수행해봐도 좋을 것 같습니다!
