### PR TITLE
[SPR-44] 쇼츠 관련 API 수정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipRepository.java
@@ -11,4 +11,6 @@ public interface FollowRelationshipRepository extends JpaRepository<FollowRelati
     List<FollowRelationship> findByFollowingId(Long followingId);
     Optional<FollowRelationship> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
     void deleteById(Long followRelationshipId);
+
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
@@ -7,6 +7,8 @@ import com.climeet.climeet_backend.domain.route.Route;
 import com.climeet.climeet_backend.domain.sector.Sector;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -61,7 +63,8 @@ public class Shorts extends BaseTimeEntity {
 
     private Boolean isSoundEnabled;
 
-    private Boolean isPublic;
+    @Enumerated(EnumType.STRING)
+    private ShortsVisibility shortsVisibility;
 
     public static Shorts toEntity(User user, ClimbingGym climbingGym, Sector sector, Route route,
         String videoUrl, String thumbnailImageUrl, CreateShortsRequest createShortsRequest) {
@@ -73,7 +76,7 @@ public class Shorts extends BaseTimeEntity {
             .thumbnailImageUrl(thumbnailImageUrl)
             .videoUrl(videoUrl)
             .isSoundEnabled(createShortsRequest.isSoundEnabled())
-            .isPublic(createShortsRequest.isPublic())
+            .shortsVisibility(createShortsRequest.getShortsVisibility())
             .description(createShortsRequest.getDescription())
             .build();
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
@@ -67,13 +67,13 @@ public class Shorts extends BaseTimeEntity {
     private ShortsVisibility shortsVisibility = ShortsVisibility.PUBLIC;
 
     public static Shorts toEntity(User user, ClimbingGym climbingGym, Sector sector, Route route,
-        String videoUrl, String thumbnailImageUrl, CreateShortsRequest createShortsRequest) {
+        String videoUrl, CreateShortsRequest createShortsRequest) {
         return Shorts.builder()
             .user(user)
             .climbingGym(climbingGym)
             .sector(sector)
             .route(route)
-            .thumbnailImageUrl(thumbnailImageUrl)
+            .thumbnailImageUrl(createShortsRequest.getThumbnailImageUrl())
             .videoUrl(videoUrl)
             .isSoundEnabled(createShortsRequest.isSoundEnabled())
             .shortsVisibility(createShortsRequest.getShortsVisibility())

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/Shorts.java
@@ -40,7 +40,7 @@ public class Shorts extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Route route;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     private User user;
 
     private String videoUrl;
@@ -64,7 +64,7 @@ public class Shorts extends BaseTimeEntity {
     private Boolean isSoundEnabled;
 
     @Enumerated(EnumType.STRING)
-    private ShortsVisibility shortsVisibility;
+    private ShortsVisibility shortsVisibility = ShortsVisibility.PUBLIC;
 
     public static Shorts toEntity(User user, ClimbingGym climbingGym, Sector sector, Route route,
         String videoUrl, String thumbnailImageUrl, CreateShortsRequest createShortsRequest) {

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -32,12 +32,13 @@ public class ShortsController {
     private final ShortsService shortsService;
 
     @PostMapping("/shorts")
-    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_SECTOR, ErrorStatus._EMPTY_ROUTE})
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_SECTOR,
+        ErrorStatus._EMPTY_ROUTE})
     @Operation(summary = "숏츠 업로드")
-    public ResponseEntity<String> uploadShorts(
-        @CurrentUser User user,
+    public ResponseEntity<String> uploadShorts(@CurrentUser User user,
         @RequestPart(value = "video") MultipartFile video,
-        @RequestPart MultipartFile thumbnailImage, @RequestPart CreateShortsRequest createShortsRequest) {
+        @RequestPart MultipartFile thumbnailImage,
+        @RequestPart CreateShortsRequest createShortsRequest) {
         shortsService.uploadShorts(user, video, thumbnailImage, createShortsRequest);
         return ResponseEntity.ok("업로드 성공");
     }
@@ -46,24 +47,24 @@ public class ShortsController {
     @Operation(summary = "숏츠 최신순 조회")
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findLatestShorts(
         @CurrentUser User user,
-        @RequestParam int page,
-        @RequestParam int size) {
-        return ResponseEntity.ok(shortsService.findShortsLatest(user, page, size));
+        @RequestParam int page, @RequestParam int size,
+        @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,
+        @RequestParam(required = false) List<Long> routeId
+    ) {
+        return ResponseEntity.ok(
+            shortsService.findShortsLatest(user, gymId, sectorId, routeId, page, size));
     }
 
     @GetMapping("/shorts/popular")
     @Operation(summary = "숏츠 인기순 조회")
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findPopularShorts(
-        @CurrentUser User user,
-        @RequestParam int page,
-        @RequestParam int size) {
+        @CurrentUser User user, @RequestParam int page, @RequestParam int size) {
         return ResponseEntity.ok(shortsService.findShortsPopular(user, page, size));
     }
 
     @PatchMapping("/shorts/{shortsId}/viewCount")
     @Operation(summary = "숏츠 조회수 증가")
-    public ResponseEntity<String> updateShortsViewCount(
-        @CurrentUser User user,
+    public ResponseEntity<String> updateShortsViewCount(@CurrentUser User user,
         @PathVariable Long shortsId) {
         shortsService.updateShortsViewCount(user, shortsId);
         return ResponseEntity.ok("조회수 증가에 성공했습니다.");
@@ -71,9 +72,10 @@ public class ShortsController {
 
     @GetMapping("/shorts/profile")
     @Operation(summary = "숏츠 프로필 바 조회", description = "팔로우 하고있는 암장, 프로필 리스트 조회/최근에 영상을 올렸을 시 true")
-    public ResponseEntity<List<ShortsProfileSimpleInfo>> getShortsProfileList(@CurrentUser User user){
-        List<ShortsProfileSimpleInfo> shortsProfileSimpleInfoList = shortsService.getShortsProfileList(user);
+    public ResponseEntity<List<ShortsProfileSimpleInfo>> getShortsProfileList(
+        @CurrentUser User user) {
+        List<ShortsProfileSimpleInfo> shortsProfileSimpleInfoList = shortsService.getShortsProfileList(
+            user);
         return ResponseEntity.ok(shortsProfileSimpleInfoList);
-
     }
- }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -34,7 +34,7 @@ public class ShortsController {
     @PostMapping("/shorts")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_SECTOR,
         ErrorStatus._EMPTY_ROUTE})
-    @Operation(summary = "숏츠 업로드")
+    @Operation(summary = "숏츠 업로드", description = "**shortsVisibility** : PUBLIC OR FOLLOWERS_ONLY OR PRIVATE")
     public ResponseEntity<String> uploadShorts(@CurrentUser User user,
         @RequestPart(value = "video") MultipartFile video,
         @RequestPart MultipartFile thumbnailImage,
@@ -44,7 +44,7 @@ public class ShortsController {
     }
 
     @GetMapping("/shorts/latest")
-    @Operation(summary = "숏츠 최신순 조회")
+    @Operation(summary = "숏츠 최신순 조회", description = "gymId, sectorId, routeIds 미 입력시 전체 조회")
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findLatestShorts(
         @CurrentUser User user, @RequestParam int page, @RequestParam int size,
         @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,
@@ -54,7 +54,7 @@ public class ShortsController {
     }
 
     @GetMapping("/shorts/popular")
-    @Operation(summary = "숏츠 인기순 조회")
+    @Operation(summary = "숏츠 인기순 조회", description = "gymId, sectorId, routeIds 미 입력시 전체 조회")
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findPopularShorts(
         @CurrentUser User user, @RequestParam int page, @RequestParam int size,
         @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -46,20 +46,20 @@ public class ShortsController {
     @GetMapping("/shorts/latest")
     @Operation(summary = "숏츠 최신순 조회")
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findLatestShorts(
-        @CurrentUser User user,
-        @RequestParam int page, @RequestParam int size,
+        @CurrentUser User user, @RequestParam int page, @RequestParam int size,
         @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,
-        @RequestParam(required = false) List<Long> routeId
-    ) {
+        @RequestParam(required = false) List<Long> routeIds) {
         return ResponseEntity.ok(
-            shortsService.findShortsLatest(user, gymId, sectorId, routeId, page, size));
+            shortsService.findShortsLatest(user, gymId, sectorId, routeIds, page, size));
     }
 
     @GetMapping("/shorts/popular")
     @Operation(summary = "숏츠 인기순 조회")
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findPopularShorts(
-        @CurrentUser User user, @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(shortsService.findShortsPopular(user, page, size));
+        @CurrentUser User user, @RequestParam int page, @RequestParam int size,
+        @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,
+        @RequestParam(required = false) List<Long> routeIds) {
+        return ResponseEntity.ok(shortsService.findShortsPopular(user, gymId, sectorId, routeIds, page, size));
     }
 
     @PatchMapping("/shorts/{shortsId}/viewCount")

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -37,9 +37,8 @@ public class ShortsController {
     @Operation(summary = "숏츠 업로드", description = "**shortsVisibility** : PUBLIC OR FOLLOWERS_ONLY OR PRIVATE")
     public ResponseEntity<String> uploadShorts(@CurrentUser User user,
         @RequestPart(value = "video") MultipartFile video,
-        @RequestPart MultipartFile thumbnailImage,
         @RequestPart CreateShortsRequest createShortsRequest) {
-        shortsService.uploadShorts(user, video, thumbnailImage, createShortsRequest);
+        shortsService.uploadShorts(user, video, createShortsRequest);
         return ResponseEntity.ok("업로드 성공");
     }
 
@@ -48,9 +47,9 @@ public class ShortsController {
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findLatestShorts(
         @CurrentUser User user, @RequestParam int page, @RequestParam int size,
         @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,
-        @RequestParam(required = false) List<Long> routeIds) {
+        @RequestParam(required = false) Long routeId) {
         return ResponseEntity.ok(
-            shortsService.findShortsLatest(user, gymId, sectorId, routeIds, page, size));
+            shortsService.findShortsLatest(user, gymId, sectorId, routeId, page, size));
     }
 
     @GetMapping("/shorts/popular")
@@ -58,8 +57,8 @@ public class ShortsController {
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findPopularShorts(
         @CurrentUser User user, @RequestParam int page, @RequestParam int size,
         @RequestParam(required = false) Long gymId, @RequestParam(required = false) Long sectorId,
-        @RequestParam(required = false) List<Long> routeIds) {
-        return ResponseEntity.ok(shortsService.findShortsPopular(user, gymId, sectorId, routeIds, page, size));
+        @RequestParam(required = false) Long routeId) {
+        return ResponseEntity.ok(shortsService.findShortsPopular(user, gymId, sectorId, routeId, page, size));
     }
 
     @PatchMapping("/shorts/{shortsId}/viewCount")

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -37,16 +37,16 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
     @Query("SELECT s "
         + "FROM Shorts s "
         + "WHERE s.ranking <> 0 "
-        + "AND s.route.id IN :routeIds "
+        + "AND s.route.id = :routeId "
         + "AND s.shortsVisibility = 'PUBLIC' "
         + "ORDER BY s.ranking ASC, s.createdAt DESC")
-    Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdInOrderByRankingAscCreatedAtDesc(@Param("routeIds") List<Long> routeIds, Pageable pageable);
+    Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdOrderByRankingAscCreatedAtDesc(@Param("routeId") Long routeId, Pageable pageable);
 
     Slice<Shorts> findAllByShortsVisibilityInAndClimbingGymIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long climbingGymId, Pageable pageable);
 
     Slice<Shorts> findAllByShortsVisibilityInAndSectorIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long gymId, Pageable pageable);
 
-    Slice<Shorts> findAllByShortsVisibilityInAndRouteIdInOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, List<Long> routeIds, Pageable pageable);
+    Slice<Shorts> findAllByShortsVisibilityInAndRouteIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long routeId, Pageable pageable);
 
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 
@@ -17,9 +18,35 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
         + "ORDER BY s.ranking ASC, s.createdAt DESC")
     Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(Pageable pageable);
 
+    @Query("SELECT s "
+        + "FROM Shorts s "
+        + "WHERE s.ranking <> 0 "
+        + "AND s.climbingGym.id = :gymId "
+        + "AND s.shortsVisibility = 'PUBLIC' "
+        + "ORDER BY s.ranking ASC, s.createdAt DESC")
+    Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroAndClimbingGymIdOrderByRankingAscCreatedAtDesc(@Param("gymId") Long gymId, Pageable pageable);
+
+    @Query("SELECT s "
+        + "FROM Shorts s "
+        + "WHERE s.ranking <> 0 "
+        + "AND s.sector.id = :sectorId "
+        + "AND s.shortsVisibility = 'PUBLIC' "
+        + "ORDER BY s.ranking ASC, s.createdAt DESC")
+    Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroAndSectorIdOrderByRankingAscCreatedAtDesc(@Param("sectorId") Long sectorId, Pageable pageable);
+
+    @Query("SELECT s "
+        + "FROM Shorts s "
+        + "WHERE s.ranking <> 0 "
+        + "AND s.route.id IN :routeIds "
+        + "AND s.shortsVisibility = 'PUBLIC' "
+        + "ORDER BY s.ranking ASC, s.createdAt DESC")
+    Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdInOrderByRankingAscCreatedAtDesc(@Param("routeIds") List<Long> routeIds, Pageable pageable);
+
     Slice<Shorts> findAllByShortsVisibilityInAndClimbingGymIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long climbingGymId, Pageable pageable);
 
     Slice<Shorts> findAllByShortsVisibilityInAndSectorIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long gymId, Pageable pageable);
 
     Slice<Shorts> findAllByShortsVisibilityInAndRouteIdInOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, List<Long> routeIds, Pageable pageable);
+
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 
-    Slice<Shorts> findAllByShortsVisibilityInOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibility, Pageable pageable);
+    Slice<Shorts> findAllByShortsVisibilityInOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Pageable pageable);
 
     @Query("SELECT s "
         + "FROM Shorts s "
@@ -17,4 +17,9 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
         + "ORDER BY s.ranking ASC, s.createdAt DESC")
     Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(Pageable pageable);
 
+    Slice<Shorts> findAllByShortsVisibilityInAndClimbingGymIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long climbingGymId, Pageable pageable);
+
+    Slice<Shorts> findAllByShortsVisibilityInAndSectorIdOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, Long gymId, Pageable pageable);
+
+    Slice<Shorts> findAllByShortsVisibilityInAndRouteIdInOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibilities, List<Long> routeIds, Pageable pageable);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.shorts;
 
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,9 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 
-    Slice<Shorts> findAllByIsPublicTrueOrderByCreatedAtDesc(Pageable pageable);
+    Slice<Shorts> findAllByShortsVisibilityInOrderByCreatedAtDesc(List<ShortsVisibility> shortsVisibility, Pageable pageable);
 
-    @Query("SELECT s FROM Shorts s WHERE s.ranking <> 0 AND s.isPublic = true ORDER BY s.ranking ASC, s.createdAt DESC")
-    Slice<Shorts> findAllByIsPublicTrueANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(Pageable pageable);
+    @Query("SELECT s "
+        + "FROM Shorts s "
+        + "WHERE s.ranking <> 0 "
+        + "AND s.shortsVisibility = 'PUBLIC' "
+        + "ORDER BY s.ranking ASC, s.createdAt DESC")
+    Slice<Shorts> findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(Pageable pageable);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -96,12 +96,12 @@ public class ShortsService {
                     shortsVisibilities, sectorId, pageable);
             }
         }
+        //루트 리스트로 필터링
         if (routeIds != null) {
-            //루트 리스트로 필터링
             shortsSlice = shortsRepository.findAllByShortsVisibilityInAndRouteIdInOrderByCreatedAtDesc(
                 shortsVisibilities, routeIds, pageable);
         }
-        if (gymId == null) {
+        if (gymId == null && sectorId == null && routeIds == null) {
             shortsSlice = shortsRepository.findAllByShortsVisibilityInOrderByCreatedAtDesc(
                 ShortsVisibility.getPublicAndFollowersOnlyList(), pageable);
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -6,6 +6,7 @@ import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
+import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.route.Route;
 import com.climeet.climeet_backend.domain.route.RouteRepository;
 import com.climeet.climeet_backend.domain.sector.Sector;
@@ -17,6 +18,7 @@ import com.climeet.climeet_backend.domain.shorts.dto.ShortsResponseDto.ShortsSim
 import com.climeet.climeet_backend.domain.shortsbookmark.ShortsBookmarkRepository;
 import com.climeet.climeet_backend.domain.shortslike.ShortsLikeRepository;
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.domain.user.UserRepository;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
@@ -35,6 +37,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ShortsService {
 
     private final ShortsRepository shortsRepository;
+    private final UserRepository userRepository;
     private final ClimbingGymRepository climbingGymRepository;
     private final SectorRepository sectorRepository;
     private final RouteRepository routeRepository;
@@ -102,7 +105,8 @@ public class ShortsService {
                     shorts.getThumbnailImageUrl(),
                     shorts.getClimbingGym().getName(),
                     findShorts(user, shorts.getId(), difficultyMapping),
-                    difficultyMapping
+                    difficultyMapping,
+                    shorts.getUser() instanceof Manager
                 );
             })
             .toList();
@@ -128,7 +132,8 @@ public class ShortsService {
                     shorts.getThumbnailImageUrl(),
                     shorts.getClimbingGym().getName(),
                     findShorts(user, shorts.getId(), difficultyMapping),
-                    difficultyMapping
+                    difficultyMapping,
+                    shorts.getUser() instanceof Manager
                 );
             })
             .toList();

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -47,7 +47,7 @@ public class ShortsService {
     private final FollowRelationshipRepository followRelationshipRepository;
 
     @Transactional
-    public void uploadShorts(User user, MultipartFile video, MultipartFile thumbnailImage,
+    public void uploadShorts(User user, MultipartFile video,
         CreateShortsRequest createShortsRequest) {
 
         ClimbingGym climbingGym = null;
@@ -69,22 +69,21 @@ public class ShortsService {
         }
 
         String videoUrl = s3Service.uploadFile(video).getImgUrl();
-        String thumbnailImageUrl = s3Service.uploadFile(thumbnailImage).getImgUrl();
 
         Shorts shorts = Shorts.toEntity(user, climbingGym, sector, route, videoUrl,
-            thumbnailImageUrl, createShortsRequest);
+            createShortsRequest);
 
         shortsRepository.save(shorts);
     }
 
     public PageResponseDto<List<ShortsSimpleInfo>> findShortsLatest(User user, Long gymId,
-        Long sectorId, List<Long> routeIds, int page, int size) {
+        Long sectorId, Long routeId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         List<ShortsVisibility> shortsVisibilities = ShortsVisibility.getPublicAndFollowersOnlyList();
 
         Slice<Shorts> shortsSlice = null;
 
-        if (routeIds == null) {
+        if (routeId == null) {
             //암장으로 필터링
             if (sectorId == null) {
                 shortsSlice = shortsRepository.findAllByShortsVisibilityInAndClimbingGymIdOrderByCreatedAtDesc(
@@ -97,11 +96,11 @@ public class ShortsService {
             }
         }
         //루트 리스트로 필터링
-        if (routeIds != null) {
-            shortsSlice = shortsRepository.findAllByShortsVisibilityInAndRouteIdInOrderByCreatedAtDesc(
-                shortsVisibilities, routeIds, pageable);
+        if (routeId != null) {
+            shortsSlice = shortsRepository.findAllByShortsVisibilityInAndRouteIdOrderByCreatedAtDesc(
+                shortsVisibilities, routeId, pageable);
         }
-        if (gymId == null && sectorId == null && routeIds == null) {
+        if (gymId == null && sectorId == null && routeId == null) {
             shortsSlice = shortsRepository.findAllByShortsVisibilityInOrderByCreatedAtDesc(
                 ShortsVisibility.getPublicAndFollowersOnlyList(), pageable);
         }
@@ -142,12 +141,12 @@ public class ShortsService {
     }
 
     public PageResponseDto<List<ShortsSimpleInfo>> findShortsPopular(User user, Long gymId,
-        Long sectorId, List<Long> routeIds, int page, int size) {
+        Long sectorId, Long routeId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
 
         Slice<Shorts> shortsSlice = null;
 
-        if (routeIds == null) {
+        if (routeId == null) {
             //암장으로 필터링
             if (sectorId == null) {
                 shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndClimbingGymIdOrderByRankingAscCreatedAtDesc(
@@ -159,10 +158,10 @@ public class ShortsService {
                     sectorId, pageable);
             }
         }
-        if (routeIds != null) {
+        if (routeId != null) {
             //루트 리스트로 필터링
-            shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdInOrderByRankingAscCreatedAtDesc(
-                routeIds, pageable);
+            shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdOrderByRankingAscCreatedAtDesc(
+                routeId, pageable);
         }
         if (gymId == null) {
             shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -131,11 +131,33 @@ public class ShortsService {
             shortsInfoList);
     }
 
-    public PageResponseDto<List<ShortsSimpleInfo>> findShortsPopular(User user, int page,
-        int size) {
+    public PageResponseDto<List<ShortsSimpleInfo>> findShortsPopular(User user, Long gymId,
+        Long sectorId, List<Long> routeIds, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Slice<Shorts> shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(
-            pageable);
+
+        Slice<Shorts> shortsSlice = null;
+
+        if (routeIds == null) {
+            //암장으로 필터링
+            if (sectorId == null) {
+                shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndClimbingGymIdOrderByRankingAscCreatedAtDesc(
+                    gymId, pageable);
+            }
+            //섹터로 필터링
+            if (sectorId != null) {
+                shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndSectorIdOrderByRankingAscCreatedAtDesc(
+                    sectorId, pageable);
+            }
+        }
+        if (routeIds != null) {
+            //루트 리스트로 필터링
+            shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdInOrderByRankingAscCreatedAtDesc(
+                routeIds, pageable);
+        }
+        if (gymId == null) {
+            shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(
+                pageable);
+        }
 
         List<ShortsSimpleInfo> shortsInfoList = shortsSlice.stream().map(shorts -> {
             DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndDifficulty(

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsVisibility.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsVisibility.java
@@ -1,0 +1,11 @@
+package com.climeet.climeet_backend.domain.shorts;
+
+import java.util.List;
+
+public enum ShortsVisibility {
+    PUBLIC, FOLLOWERS_ONLY, PRIVATE;
+
+    public static List<ShortsVisibility> getPublicAndFollowersOnlyList() {
+        return List.of(PUBLIC, FOLLOWERS_ONLY);
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.shorts.dto;
 
 import com.climeet.climeet_backend.domain.shorts.ShortsVisibility;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +16,8 @@ public class ShortsRequestDto {
         private Long sectorId;
         private String description;
         boolean isSoundEnabled;
+
+        @NotNull
         ShortsVisibility shortsVisibility;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.shorts.dto;
 
+import com.climeet.climeet_backend.domain.shorts.ShortsVisibility;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,6 @@ public class ShortsRequestDto {
         private Long sectorId;
         private String description;
         boolean isSoundEnabled;
-        boolean isPublic;
+        ShortsVisibility shortsVisibility;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsRequestDto.java
@@ -14,8 +14,9 @@ public class ShortsRequestDto {
         private Long climbingGymId;
         private Long routeId;
         private Long sectorId;
+        private String thumbnailImageUrl;
         private String description;
-        boolean isSoundEnabled;
+        private boolean isSoundEnabled;
 
         @NotNull
         ShortsVisibility shortsVisibility;

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
@@ -26,7 +26,7 @@ public class ShortsResponseDto {
         private String gymDifficultyName;
         private String gymDifficultyColor;
         private String climeetDifficultyName;
-        private boolean isManager;
+        private Boolean isManager;
         private ShortsDetailInfo shortsDetailInfo;
 
         public static ShortsSimpleInfo toDTO(Long shortsId, String thumbnailImageUrl,
@@ -61,8 +61,8 @@ public class ShortsResponseDto {
         private int commentCount;
         private int bookmarkCount;
         private int shareCount;
-        private boolean isLiked;
-        private boolean isBookmarked;
+        private Boolean isLiked;
+        private Boolean isBookmarked;
         private String description;
         private String routeImageUrl;
         private String gymDifficultyName;
@@ -111,7 +111,6 @@ public class ShortsResponseDto {
                 .build();
 
         }
-
 
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
@@ -26,10 +26,11 @@ public class ShortsResponseDto {
         private String gymDifficultyName;
         private String gymDifficultyColor;
         private String climeetDifficultyName;
+        private boolean isManager;
         private ShortsDetailInfo shortsDetailInfo;
 
         public static ShortsSimpleInfo toDTO(Long shortsId, String thumbnailImageUrl,
-            String gymName, ShortsDetailInfo shortsDetailInfo, DifficultyMapping difficultyMapping) {
+            String gymName, ShortsDetailInfo shortsDetailInfo, DifficultyMapping difficultyMapping, boolean isManager) {
             return ShortsSimpleInfo.builder()
                 .shortsId(shortsId)
                 .thumbnailImageUrl(thumbnailImageUrl)
@@ -37,6 +38,7 @@ public class ShortsResponseDto {
                 .gymDifficultyName(difficultyMapping.getGymDifficultyName())
                 .gymDifficultyColor(difficultyMapping.getGymDifficultyColor())
                 .climeetDifficultyName(difficultyMapping.getClimeetDifficultyName())
+                .isManager(isManager)
                 .shortsDetailInfo(shortsDetailInfo)
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
@@ -30,16 +30,18 @@ public class ShortsResponseDto {
         private ShortsDetailInfo shortsDetailInfo;
 
         public static ShortsSimpleInfo toDTO(Long shortsId, String thumbnailImageUrl,
-            String gymName, ShortsDetailInfo shortsDetailInfo, DifficultyMapping difficultyMapping, boolean isManager) {
-            return ShortsSimpleInfo.builder()
-                .shortsId(shortsId)
+            ClimbingGym climbingGym, ShortsDetailInfo shortsDetailInfo, String gymDifficultyName,
+            String gymDifficultyColor, String gymClimeetDifficultyName, boolean isManager) {
+            String gymName = null;
+            if(climbingGym != null) gymName = climbingGym.getName();
+
+            return ShortsSimpleInfo.builder().shortsId(shortsId)
                 .thumbnailImageUrl(thumbnailImageUrl)
                 .gymName(gymName)
-                .gymDifficultyName(difficultyMapping.getGymDifficultyName())
-                .gymDifficultyColor(difficultyMapping.getGymDifficultyColor())
-                .climeetDifficultyName(difficultyMapping.getClimeetDifficultyName())
-                .isManager(isManager)
-                .shortsDetailInfo(shortsDetailInfo)
+                .gymDifficultyName(gymDifficultyName)
+                .gymDifficultyColor(gymDifficultyColor)
+                .climeetDifficultyName(gymClimeetDifficultyName)
+                .isManager(isManager).shortsDetailInfo(shortsDetailInfo)
                 .build();
         }
     }
@@ -70,45 +72,59 @@ public class ShortsResponseDto {
         private Boolean isSoundEnabled;
 
         public static ShortsDetailInfo toDTO(User user, Shorts shorts, ClimbingGym climbingGym,
-            Sector sector, boolean isLiked, boolean isBookmarked, DifficultyMapping difficultyMapping) {
+            Sector sector, boolean isLiked, boolean isBookmarked, String gymDifficultyName,
+            String gymDifficultyColor) {
+            Long gymId = null;
+            String gymName = null;
+            Long sectorId = null;
+            String sectorName = null;
+            if(climbingGym != null) {
+                gymId = climbingGym.getId();
+                gymName = climbingGym.getName();
+            }
+            if(sector != null) {
+                sectorId = sector.getId();
+                sectorName = sector.getSectorName();
+            }
+
             return ShortsDetailInfo.builder()
                 .userShortsSimpleInfo(UserShortsSimpleInfo.toDto(user))
                 .shortsId(shorts.getId())
-                .gymName(climbingGym.getName())
-                .sectorName(sector.getSectorName())
-                .gymId(climbingGym.getId())
-                .sectorId(sector.getId())
+                .gymName(gymName)
+                .sectorName(sectorName)
+                .gymId(gymId)
+                .sectorId(sectorId)
                 .videoUrl(shorts.getVideoUrl())
                 .likeCount(shorts.getLikeCount())
                 .commentCount(shorts.getCommentCount())
                 .bookmarkCount(shorts.getBookmarkCount())
                 .shareCount(shorts.getShareCount())
-                .isLiked(isLiked)
-                .isBookmarked(isBookmarked)
+                .isLiked(isLiked).isBookmarked(isBookmarked)
                 .description(shorts.getDescription())
-                .gymDifficultyName(difficultyMapping.getGymDifficultyName())
-                .gymDifficultyColor(difficultyMapping.getGymDifficultyColor())
+                .gymDifficultyName(gymDifficultyName)
+                .gymDifficultyColor(gymDifficultyColor)
                 .isSoundEnabled(shorts.getIsSoundEnabled())
                 .build();
         }
     }
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ShortsProfileSimpleInfo{
+    public static class ShortsProfileSimpleInfo {
+
         private Long followingUserId;
         private String followingUserName;
         private String followingUserProfileUrl;
         private Boolean isUploadRecent;
 
-        public static ShortsProfileSimpleInfo toDTO(User user, FollowRelationship followRelationship){
-            return ShortsProfileSimpleInfo.builder()
-                .followingUserId(user.getId())
+        public static ShortsProfileSimpleInfo toDTO(User user,
+            FollowRelationship followRelationship) {
+            return ShortsProfileSimpleInfo.builder().followingUserId(user.getId())
                 .followingUserName(user.getProfileName())
                 .followingUserProfileUrl(user.getProfileImageUrl())
-                .isUploadRecent(followRelationship.getIsUploadShortsRecent())
-                .build();
+                .isUploadRecent(followRelationship.getIsUploadShortsRecent()).build();
 
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentController.java
@@ -69,7 +69,7 @@ public class ShortsCommentController {
             shortsCommentService.findShortsChildCommentList(user, shortsId, parentCommentId, page, size));
     }
 
-    @Operation(summary = "숏츠 댓글 상호작용")
+    @Operation(summary = "숏츠 댓글 상호작용", description = "**shortsVisibility** : LIKE, DISLIKE, NONE")
     @SwaggerApiError({ErrorStatus._EMPTY_SHORTS_COMMENT})
     @PatchMapping("/shortsComments/{shortsCommentId}")
     public ResponseEntity<String> changeShortsCommentLikeStatus(

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -122,6 +122,7 @@ public class ShortsCommentService {
             responses);
     }
 
+    @Transactional
     public void changeShortsCommentLikeStatus(User user, Long shortsCommentId, boolean isLike,
         boolean isDislike) {
         ShortsComment shortsComment = shortsCommentRepository.findById(shortsCommentId)


### PR DESCRIPTION
## 요약

- 기획 변경사항에 따른 수정
- 숏츠 공개범위 : 공개/비공개에서 공개/팔로우만 공개/비공개로 변경
     - 숏츠 업로드시 boolean isPublic을 ENUM값으로 변경
     - 조회시 현재 유저가 업로더의 팔로워인지 확인, 팔로워일때만 해당 영상 조회
- 숏츠 업로드시 암장, 섹터, 루트입력은 필수가 아님
     -  각각 암장,섹터, 루트가 입력되지 않으면 db에 null로 들어가도록 수정
- 해당 영상의 업로더가 관리자인지 아닌지 값을 내려주는 isManager값 추가

- 숏츠 조회시 gymId, sectorId, routeId리스트를 받아서 값이 있다면 해당 값에 따른 필터링 조회 추가

---

## 상세 내용

#### 숏츠 공개 범위 변경  
```java
List<ShortsSimpleInfo> shortsInfoList = shortsSlice.stream()
            //필터를 통해 팔로워만 허용한 쇼츠에서 현재 유저가 볼 수 있는지 확인
            .filter(shorts -> {
                if (shorts.getShortsVisibility() == ShortsVisibility.FOLLOWERS_ONLY) {
                    return followRelationshipRepository.existsByFollowerIdAndFollowingId(
                        user.getId(), shorts.getUser().getId());
                }
                //public이면 통과
                return true;
            })
            .map(shorts -> {
                DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndDifficulty(
                    shorts.getClimbingGym(),
                    shorts.getRoute().getDifficultyMapping().getDifficulty());
```

- ENUM생성했고, 이전 stream에서 filter단을 추가해 검증했습니다.
- 현재는 숏츠를 가져온 후에 filter처리로 현재 유저가 팔로워인지 확인하지만 추후 DB단에서 Follow_relationship테이블과 조인으로 jpql문을 쓰는 것이 성능에 더 좋을 것 같습니다.
   

#### 숏츠 업로드시 필수/비필수값 입력
```java
ClimbingGym climbingGym = null;
        if (createShortsRequest.getClimbingGymId() != null) {
            climbingGym = climbingGymRepository.findById(createShortsRequest.getClimbingGymId())
                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
        }
```
  - id값을 확인해 입력하지 않았다면 null이 들어가도록 했습니다.


#### isManager 추가
- 간단하게 shorts의 user를 즉시로딩으로 변경해 작성했습니다. 
`shorts.getUser() instanceof Manager`
-  이 또한 추후 즉시로딩을 쓰지않는 식으로 수정할 예정입니다.

#### 필터링 조회 추가
- 처음에는 필터링 조회 api를 분리해 구현했지만 프론트에서의 편의를 위해 기존 조회api에 쿼리파라미터를 붙였습니다.(대신 서비스코드가 더럽습니다ㅠ)
```java
        if (routeIds == null) {
            //암장으로 필터링
            if (sectorId == null) {
                shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndClimbingGymIdOrderByRankingAscCreatedAtDesc(
                    gymId, pageable);
            }
            //섹터로 필터링
            if (sectorId != null) {
                shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndSectorIdOrderByRankingAscCreatedAtDesc(
                    sectorId, pageable);
            }
        }
        if (routeIds != null) {
            //루트 리스트로 필터링
            shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroAndRouteIdInOrderByRankingAscCreatedAtDesc(
                routeIds, pageable);
        }
        if (gymId == null) {
            shortsSlice = shortsRepository.findAllByShortsVisibilityPublicANDByRankingNotZeroOrderByRankingAscCreatedAtDesc(
                pageable);
        }
```
- 암장, 섹터, 루트로 구분이 가능한데 루트값이 주어지면 암장과 섹터 상관없이 루트Id로만 조회하면 되기 때문에 routeIds부터 조건문으로 검사합니다. 최대한 보기 편하도록 if문으로만 작성했습니다!
- 세개의 값이 모두 null일 경우, 기존 작성한 전체 조회로 가져옵니다.
- 기존 최신순, 인기순 조회에서 각각 `암장id로 조회` `섹터Id로 조회` `루트Id리스트로 조회` `전체 조회`로 나눠져서 조회합니다


---


## 테스트 확인 내용

<img width="1294" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/117848386/6a6a9bd9-fa01-4fd4-bb4f-a2ed57369d13">

- 현재 유저가 Manager일때 isManager true 확인
- 영상이 FOLLOWERS_ONLY일때 팔로워한테만 보이는 지 확인
- 암장, 섹터, 루트 필터링 조회 확인
- 영상의 암장,섹터, 루트 정보없을때 null로 잘 내려오는지 확인

## 이외
- 암장과 섹터, 루트가 null일 수 있는 변경사항때문에 코드가 매우 더럽습니다ㅠ 리팩토링시 중복 코드 정리와, null검증부분을 분리, difficulty부분도 분리해 리팩토링하겠습니다!

