### PR TITLE
[SPR-148] 회원가입 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -60,4 +60,12 @@ public class Climber extends User {
     public String getPayload(){
         return this.getId()+"+climber";
     }
+
+    public static Climber toEntity(String socialId, SocialType socialType, String profileImg){
+        return Climber.builder()
+            .socialId(socialId)
+            .socialType(socialType)
+            .profileImageUrl(profileImg)
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -66,6 +67,12 @@ public class Climber extends User {
             .socialId(socialId)
             .socialType(socialType)
             .profileImageUrl(profileImg)
+            .status(true)
+            .followerCount(0L)
+            .followingCount(0L)
+            .thisWeekCompleteCount(0)
+            .thisWeekTotalClimbingTime(0L)
+            .createdAt(LocalDateTime.now())
             .build();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -92,10 +92,7 @@ public class ClimberService {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
-        Climber climber = Climber.builder()
-            .socialId(socialId)
-            .socialType(SocialType.valueOf(socialType))
-            .profileImageUrl(profileImg).build();
+        Climber climber = Climber.toEntity(socialId, SocialType.valueOf(socialType), profileImg);
         climberRepository.save(climber);
 
         String accessToken = jwtTokenProvider.createAccessToken(climber.getPayload());

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
@@ -54,7 +54,7 @@ public class Manager extends User {
             .profileName(createManagerRequest.getName())
             .phoneNumber(createManagerRequest.getPhoneNumber())
             .email(createManagerRequest.getEmail())
-            .isRegistered(true)
+            .isRegistered(false)
             .climbingGym(gym)
             .followerCount(0L)
             .followingCount(0L)

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/Manager.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -55,6 +56,11 @@ public class Manager extends User {
             .email(createManagerRequest.getEmail())
             .isRegistered(true)
             .climbingGym(gym)
+            .followerCount(0L)
+            .followingCount(0L)
+            .thisWeekCompleteCount(0)
+            .thisWeekTotalClimbingTime(0L)
+            .createdAt(LocalDateTime.now())
             .build();
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -37,10 +37,10 @@ public class ManagerController {
     @PostMapping("/signup")
     @Operation(summary = "관리자 회원가입", description = "**Enum 설명**\n\n**ServiceBitmask** :  샤워\\_시설,  샤워\\_용품,  수건\\_제공,  간이\\_세면대,  초크\\_대여,  암벽화\\_대여,  삼각대\\_대여,  운동복\\_대여")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._DUPLICATE_LOGINID})
-    public ResponseEntity<ManagerSimpleInfo> signUp(@RequestBody
+    public ResponseEntity<String> signUp(@RequestBody
         CreateManagerRequest createManagerRequest){
-        ManagerSimpleInfo managerSimpleInfo = managerService.signUp(createManagerRequest);
-       return ResponseEntity.ok(managerSimpleInfo);
+        managerService.signUp(createManagerRequest);
+       return ResponseEntity.ok("회원가입 완료. 승인 대기 중.");
     }
 
     @Operation(summary = "암장 등록 중복 확인", description = "이미 관리자가 등록된 암장인지 확인하는 API \n\n **이미 관리자 등록 되어있음** : false \n\n **관리자 등록 안되어 있음** : true")

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 public interface ManagerRepository extends JpaRepository<Manager, Long> {
 
     Optional<Manager> findByLoginId(String loginId);
+
+    Optional<Manager> findByLoginIdAndisRegistered(String loginId, Boolean status);
     Optional<Manager> findByClimbingGym(ClimbingGym climbingGym);
 
     boolean existsByClimbingGym(ClimbingGym gym);

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerRepository.java
@@ -10,7 +10,7 @@ public interface ManagerRepository extends JpaRepository<Manager, Long> {
 
     Optional<Manager> findByLoginId(String loginId);
 
-    Optional<Manager> findByLoginIdAndisRegistered(String loginId, Boolean status);
+    Optional<Manager> findByLoginIdAndIsRegistered(String loginId, Boolean status);
     Optional<Manager> findByClimbingGym(ClimbingGym climbingGym);
 
     boolean existsByClimbingGym(ClimbingGym gym);

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
@@ -10,7 +10,6 @@ import com.climeet.climeet_backend.domain.climbinggymimage.ClimbingGymBackground
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateAccessTokenRequest;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateManagerRequest;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerResponseDto.ManagerSimpleInfo;
-import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
@@ -41,7 +40,7 @@ public class ManagerService {
         managerRepository.findByLoginId(loginId)
             .orElseThrow(()-> new GeneralException(ErrorStatus._WRONG_LOGINID_PASSWORD));
 
-        Manager IdManager = managerRepository.findByLoginIdAndisRegistered(loginId, true)
+        Manager IdManager = managerRepository.findByLoginIdAndIsRegistered(loginId, true)
             .orElseThrow(()-> new GeneralException(ErrorStatus._PENDING_APPROVAL));
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
@@ -38,8 +38,12 @@ public class ManagerService {
     public ManagerSimpleInfo login(@RequestBody CreateAccessTokenRequest createAccessTokenRequest){
         String loginId = createAccessTokenRequest.getLoginId();
         String password = createAccessTokenRequest.getPassword();
-        Manager IdManager = managerRepository.findByLoginId(loginId)
+        managerRepository.findByLoginId(loginId)
             .orElseThrow(()-> new GeneralException(ErrorStatus._WRONG_LOGINID_PASSWORD));
+
+        Manager IdManager = managerRepository.findByLoginIdAndisRegistered(loginId, true)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._PENDING_APPROVAL));
+
 
         if(!IdManager.checkPassword(password, passwordEncoder)){
             throw new GeneralException(ErrorStatus._WRONG_LOGINID_PASSWORD);
@@ -62,7 +66,7 @@ public class ManagerService {
 
 
     @Transactional
-    public ManagerSimpleInfo signUp(@RequestBody CreateManagerRequest createManagerRequest) {
+    public void signUp(@RequestBody CreateManagerRequest createManagerRequest) {
         ClimbingGym gym = climbingGymRepository.findById(createManagerRequest.getGymId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
@@ -95,7 +99,6 @@ public class ManagerService {
         List<ServiceBitmask> gymServiceList = createManagerRequest.getProvideServiceList();
         gym.updateServiceBitMask(bitmaskConverter.convertServiceListToBitmask(gymServiceList));
 
-        return new ManagerSimpleInfo(manager);
     }
     private void saveClimbingGymBackgroundImage(CreateManagerRequest createManagerRequest, ClimbingGym gym){
         ClimbingGymBackgroundImage climbingGymBackgroundImage = ClimbingGymBackgroundImage.builder()

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _WRONG_LOGINID_PASSWORD(HttpStatus.CONFLICT, "MEMBER_002", "아이디 또는 비밀번호가 일치하지 않습니다."),
     _DUPLICATE_LOGINID(HttpStatus.CONFLICT, "MEMBER_003", "중복된 ID입니다."),
     _INVALID_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_004", "올바르지 않은 사용자입니다."),
+    _PENDING_APPROVAL(HttpStatus.NOT_FOUND, "MEMBER_005", "승인을 대기 중인 사용자입니다."),
 
     //암장 관련
     _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),


### PR DESCRIPTION
## 요약

-  회원가입 시 default 값이 설정되어있지 않던 컬럼들에 대해 default 값 설정을 추가 하였습니다(followingCount, followerCount 등)

- 클라이머 회원가입 api가 초반에 설계 되어서 service에서 builder를 사용하였기 때문에, toEntity 함수로 바꿔주는 리팩토링 과정을 진행 하였습니다. 

- 기존에는 관리자 회원가입 시 회원가입이 완료되면 바로 access token과 refresh token이 발급 되었지만, 관리자 회원가입은 클밋의 승인이 필요하므로 회원가입이 완료 되었을 때 code 200과 함께 `회원가입 완료. 승인 대기 중. ` 문구를 리턴하도록 변경하였습니다. 
- 관리자 로그인 시 isRegistrered 컬럼이 True일 때만 access token과 refresh token을 발급하도록 로직을 수정 하였습니다. 

## 상세 내용
-관리자 회원가입 후 결과 창입니다. 
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/1a70be7c-6211-4a60-8b28-bda032e78646)

-승인되지 않은 경우 결과입니다. 
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/e63cabb4-9ad3-4207-aef4-bbfe7dcf894b)

-승인 후 로그인 했을 시 결과입니다. 
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/ee6b8737-39aa-41a4-aef7-8d1639a4af74)

## 테스트 확인 내용


## 질문 및 이외 사항
-백엔드 측에서는 db 컬럼 설정을 바꿔서 바로 활성화된 계정을 만들 수 있지만, 안드로이드 측에서는 그게 어려우므로 매니저 데이터를 몇 개 생성하여 Id와 Password를 넘겨줘야 할 것 같습니다!
