### PR TITLE
[SPR-120] 홈화면 홈짐 바로가기(홈짐 조회) api

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -57,7 +57,6 @@ public class UserController {
     @GetMapping("/home/homegyms")
     @Operation(summary = "홈 화면 홈짐 바로가기")
     public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser){
-        List<UserHomeGymSimpleInfo> userHomeGymSimpleInfos = userService.getHomeGyms(currentUser);
-        return ResponseEntity.ok(userHomeGymSimpleInfos);
+        return ResponseEntity.ok(userService.getHomeGyms(currentUser));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -1,6 +1,7 @@
 package com.climeet.climeet_backend.domain.user;
 
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
+import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserHomeGymSimpleInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
@@ -51,5 +52,12 @@ public class UserController {
         List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser, userCategory);
         return ResponseEntity.ok(userFollowDetailResponseList);
 
+    }
+
+    @GetMapping("/home/homegyms")
+    @Operation(summary = "홈 화면 홈짐 바로가기")
+    public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser){
+        List<UserHomeGymSimpleInfo> userHomeGymSimpleInfos = userService.getHomeGyms(currentUser);
+        return ResponseEntity.ok(userHomeGymSimpleInfos);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -6,6 +6,7 @@ import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
+import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserHomeGymSimpleInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
@@ -133,6 +134,17 @@ public class UserService {
         return userFollowDetailResponseList;
     }
 
+    public List<UserHomeGymSimpleInfo> getHomeGyms(User currentUser){
+        List<FollowRelationship> followRelationships = followRelationshipRepository.findByFollowerId(currentUser.getId());
+
+        return followRelationships.stream()
+            .filter(followRelationship -> followRelationship.getFollowing() instanceof Manager)
+            .map(followRelationship ->{
+                User gymManamger = followRelationship.getFollowing();
+                return UserHomeGymSimpleInfo.toDTO(gymManamger);
+            }).toList();
+
+    }
 
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.user;
 
 
 import com.climeet.climeet_backend.domain.climber.Climber;
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.manager.Manager;
@@ -140,8 +141,8 @@ public class UserService {
         return followRelationships.stream()
             .filter(followRelationship -> followRelationship.getFollowing() instanceof Manager)
             .map(followRelationship ->{
-                User gymManamger = followRelationship.getFollowing();
-                return UserHomeGymSimpleInfo.toDTO(gymManamger);
+                ClimbingGym climbingGym = ((Manager) followRelationship.getFollowing()).getClimbingGym();
+                return UserHomeGymSimpleInfo.toDTO(climbingGym);
             }).toList();
 
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.user.dto;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.user.User;
 import lombok.AllArgsConstructor;
@@ -70,15 +71,15 @@ public class UserResponseDto {
     @NoArgsConstructor
     @Builder
     public static class UserHomeGymSimpleInfo{
-        private Long userId;
-        private String userProfileUrl;
+        private Long gymId;
+        private String gymProfileUrl;
         private String gymName;
 
-        public static UserHomeGymSimpleInfo toDTO(User gymManager){
+        public static UserHomeGymSimpleInfo toDTO(ClimbingGym gym){
             return UserHomeGymSimpleInfo.builder()
-                .userId(gymManager.getId())
-                .userProfileUrl(gymManager.getProfileImageUrl())
-                .gymName(gymManager.getProfileName())
+                .gymId(gym.getId())
+                .gymProfileUrl(gym.getProfileImageUrl())
+                .gymName(gym.getName())
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
@@ -64,4 +64,22 @@ public class UserResponseDto {
         }
 
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class UserHomeGymSimpleInfo{
+        private Long userId;
+        private String userProfileUrl;
+        private String gymName;
+
+        public static UserHomeGymSimpleInfo toDTO(User gymManager){
+            return UserHomeGymSimpleInfo.builder()
+                .userId(gymManager.getId())
+                .userProfileUrl(gymManager.getProfileImageUrl())
+                .gymName(gymManager.getProfileName())
+                .build();
+        }
+    }
 }


### PR DESCRIPTION
## 요약
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/fadc0aa8-11e4-4d9c-8b25-8a5d29df8540)
홈 화면의 홈짐 바로가기(홈짐 조회) 기능을 구현하였습니다. 

## 상세 내용

- CurrentUser 어노테이션을 사용하여 해당 유저가 팔로우하고 있는 암장의 프로필 사진, 암장 이름, 암장 인덱스를 불러옵니다. 

- controller 코드 입니다. userHomeGymSimpleInfo responseDto를 리스트 형태로 반환합니다. 
```java
@GetMapping("/home/homegyms")
    @Operation(summary = "홈 화면 홈짐 바로가기")
    public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser){
        List<UserHomeGymSimpleInfo> userHomeGymSimpleInfos = userService.getHomeGyms(currentUser);
        return ResponseEntity.ok(userHomeGymSimpleInfos);
    }
```

- service 코드입니다. currentUser가 follwer인 FollowRelationship을 리스트에 저장하고, following이 manager인 관계만 UserHomeGymSimpleInfo에 넣어서 리턴합니다. 

```java
 public List<UserHomeGymSimpleInfo> getHomeGyms(User currentUser){
        List<FollowRelationship> followRelationships = followRelationshipRepository.findByFollowerId(currentUser.getId());

        return followRelationships.stream()
            .filter(followRelationship -> followRelationship.getFollowing() instanceof Manager)
            .map(followRelationship ->{
                ClimbingGym climbingGym = ((Manager) followRelationship.getFollowing()).getClimbingGym();
                return UserHomeGymSimpleInfo.toDTO(climbingGym);
            }).toList();

    }
```

## 테스트 확인 내용
- gym 1, 2번을 팔로우 하고 있는 유저의 조회 화면입니다. follow 관계에 climber가 포함되어 있어도 climber는 포함되지 않음을 확인 했습니다. 
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/76a81ef8-424e-4cf4-99c5-ec33bda00404)


## 질문 및 이외 사항

아주 간단한 코드라 금방 보실듯 합니다!-!
