### PR TITLE
[SPR-124] 로그인 계정 정보 조회 & 알림 on/off 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -73,26 +74,28 @@ public class User {
         this.refreshToken = refreshToken;
     }
 
-    public void updateNotification(boolean isAllowFollowNotification, boolean isAllowLikeNotification, boolean isAllowCommentNotification, boolean isAllowAdNotification){
+    public void updateNotification(boolean isAllowFollowNotification,
+        boolean isAllowLikeNotification, boolean isAllowCommentNotification,
+        boolean isAllowAdNotification) {
         this.isAllowFollowNotification = isAllowFollowNotification;
         this.isAllowLikeNotification = isAllowLikeNotification;
         this.isAllowCommentNotification = isAllowCommentNotification;
         this.isAllowAdNotification = isAllowAdNotification;
     }
 
-    public void thisWeekTotalClimbingTimeUp(Long sec){
+    public void thisWeekTotalClimbingTimeUp(Long sec) {
         this.thisWeekTotalClimbingTime += sec;
     }
 
-    public void thisWeekTotalClimbingTimeDown(Long sec){
+    public void thisWeekTotalClimbingTimeDown(Long sec) {
         this.thisWeekTotalClimbingTime -= sec;
     }
 
-    public void increaseFollwerCount(){
+    public void increaseFollwerCount() {
         this.followerCount++;
     }
 
-    public void decreaseFollwerCount(){
+    public void decreaseFollwerCount() {
         this.followerCount++;
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.user;
 
+import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserAccountDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserHomeGymSimpleInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
@@ -58,5 +59,11 @@ public class UserController {
     @Operation(summary = "홈 화면 홈짐 바로가기")
     public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getHomeGyms(currentUser));
+    }
+
+    @GetMapping("/users/accounts")
+    @Operation(summary = "로그인 계정 정보")
+    public ResponseEntity<UserAccountDetailInfo> getLoginUserProfiles(@CurrentUser User currentUser){
+        return ResponseEntity.ok(userService.getLoginUserProfiles(currentUser));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -71,14 +71,16 @@ public class UserController {
     }
 
     @GetMapping("/users/accounts")
-    @Operation(summary = "로그인 계정 정보")
+    @Operation(summary = "로그인 계정 정보 조회")
+    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<UserAccountDetailInfo> getLoginUserProfiles(
         @CurrentUser User currentUser) {
         return ResponseEntity.ok(userService.getLoginUserProfiles(currentUser));
     }
 
-    @PatchMapping("/users/notification")
+    @PatchMapping("/users/notifications")
     @Operation(summary = "notificaion 허용 범위 수정")
+    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<String> updateUserNotification(@CurrentUser User currentUser, @RequestBody
     UpdateUserAllowNotificationRequest updateRequestDto) {
         return ResponseEntity.ok(userService.updateUserNotification(currentUser, updateRequestDto));

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.user;
 
+import com.climeet.climeet_backend.domain.user.dto.UserRequestDto.UpdateUserAllowNotificationRequest;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserAccountDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserHomeGymSimpleInfo;
@@ -16,32 +17,38 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name="User")
+@Tag(name = "User")
 @RequiredArgsConstructor
 @RestController
 public class UserController {
+
     private final UserService userService;
 
     @PostMapping("/refresh-token")
     @Operation(summary = "소셜 Access token, Refresh token 재발급 ")
-    @SwaggerApiError({ErrorStatus._INVALID_JWT, ErrorStatus._EXPIRED_JWT, ErrorStatus._INVALID_MEMBER})
-    public ResponseEntity<UserTokenSimpleInfo> refreshToken(@RequestParam String refreshToken){
+    @SwaggerApiError({ErrorStatus._INVALID_JWT, ErrorStatus._EXPIRED_JWT,
+        ErrorStatus._INVALID_MEMBER})
+    public ResponseEntity<UserTokenSimpleInfo> refreshToken(@RequestParam String refreshToken) {
         UserTokenSimpleInfo userTokenSimpleInfo = userService.updateUserToken(refreshToken);
         return ResponseEntity.ok(userTokenSimpleInfo);
 
 
     }
+
     @GetMapping("/followers")
     @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
-    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
-        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollower(userId, currentUser, userCategory);
+    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId,
+        @RequestParam String userCategory, @CurrentUser User currentUser) {
+        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollower(userId,
+            currentUser, userCategory);
         return ResponseEntity.ok(userFollowDetailResponseList);
 
     }
@@ -49,21 +56,31 @@ public class UserController {
     @GetMapping("/followees")
     @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
-    public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
-        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId, currentUser, userCategory);
+    public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId,
+        @RequestParam String userCategory, @CurrentUser User currentUser) {
+        List<UserFollowDetailInfo> userFollowDetailResponseList = userService.getFollowing(userId,
+            currentUser, userCategory);
         return ResponseEntity.ok(userFollowDetailResponseList);
 
     }
 
     @GetMapping("/home/homegyms")
     @Operation(summary = "홈 화면 홈짐 바로가기")
-    public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser){
+    public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser) {
         return ResponseEntity.ok(userService.getHomeGyms(currentUser));
     }
 
     @GetMapping("/users/accounts")
     @Operation(summary = "로그인 계정 정보")
-    public ResponseEntity<UserAccountDetailInfo> getLoginUserProfiles(@CurrentUser User currentUser){
+    public ResponseEntity<UserAccountDetailInfo> getLoginUserProfiles(
+        @CurrentUser User currentUser) {
         return ResponseEntity.ok(userService.getLoginUserProfiles(currentUser));
+    }
+
+    @PatchMapping("/users/notification")
+    @Operation(summary = "notificaion 허용 범위 수정")
+    public ResponseEntity<String> updateUserNotification(@CurrentUser User currentUser, @RequestBody
+    UpdateUserAllowNotificationRequest updateRequestDto) {
+        return ResponseEntity.ok(userService.updateUserNotification(currentUser, updateRequestDto));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -178,7 +178,6 @@ public class UserService {
     }
 
     @Transactional
-
     public String updateUserNotification(User currentUser,
         UpdateUserAllowNotificationRequest request) {
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -9,6 +9,7 @@ import com.climeet.climeet_backend.domain.followrelationship.FollowRelationship;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
+import com.climeet.climeet_backend.domain.user.dto.UserRequestDto.UpdateUserAllowNotificationRequest;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserAccountDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserFollowDetailInfo;
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserHomeGymSimpleInfo;
@@ -163,7 +164,6 @@ public class UserService {
         boolean isManager = true;
         SocialType socialType = null;
 
-
         if (manager.isEmpty() && climber.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_USER);
         }
@@ -175,6 +175,35 @@ public class UserService {
         }
 
         return UserAccountDetailInfo.toDTO(currentUser, isManager, socialType);
+    }
+
+    @Transactional
+
+    public String updateUserNotification(User currentUser,
+        UpdateUserAllowNotificationRequest request) {
+
+        boolean isAllowFollowNotification = currentUser.getIsAllowFollowNotification();
+        boolean isAllowLikeNotification = currentUser.getIsAllowLikeNotification();
+        boolean isAllowCommentNotification = currentUser.getIsAllowCommentNotification();
+        boolean isAllowAdNotification = currentUser.getIsAllowAdNotification();
+
+        if (request.getIsAllowFollowNotification() != null) {
+            isAllowFollowNotification = request.getIsAllowFollowNotification();
+        }
+        if (request.getIsAllowLikeNotification() != null) {
+            isAllowLikeNotification = request.getIsAllowLikeNotification();
+        }
+        if (request.getIsAllowCommentNotification() != null) {
+            isAllowCommentNotification = request.getIsAllowCommentNotification();
+        }
+        if (request.getIsAllowAdNotification() != null) {
+            isAllowAdNotification = request.getIsAllowAdNotification();
+        }
+
+        currentUser.updateNotification(isAllowFollowNotification, isAllowLikeNotification,
+            isAllowCommentNotification, isAllowAdNotification);
+
+        return "업데이트 완료";
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserRequestDto.java
@@ -2,9 +2,17 @@ package com.climeet.climeet_backend.domain.user.dto;
 
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class UserRequestDto {
 
-
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateUserAllowNotificationRequest {
+        private Boolean isAllowFollowNotification;
+        private Boolean isAllowLikeNotification;
+        private Boolean isAllowCommentNotification;
+        private Boolean isAllowAdNotification;
+    }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.user.dto;
 
+import com.climeet.climeet_backend.domain.climber.enums.SocialType;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.followrelationship.FollowRelationshipRepository;
 import com.climeet.climeet_backend.domain.user.User;
@@ -80,6 +81,28 @@ public class UserResponseDto {
                 .gymId(gym.getId())
                 .gymProfileUrl(gym.getProfileImageUrl())
                 .gymName(gym.getName())
+                .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class UserAccountDetailInfo{
+        private Long userId;
+        private String userName;
+        private String userProfileUrl;
+        private boolean isManager;
+        private SocialType socialType;
+
+        public static UserAccountDetailInfo toDTO(User user,boolean isManager, SocialType socialType){
+            return UserAccountDetailInfo.builder()
+                .userId(user.getId())
+                .userName(user.getProfileName())
+                .userProfileUrl(user.getProfileImageUrl())
+                .isManager(isManager)
+                .socialType(socialType)
                 .build();
         }
     }


### PR DESCRIPTION
## 요약
- 로그인 계정 정보 조회
- 알림 on/off 기능 구현

## 상세 내용
### 로그인 계정 정보 조회
<img width="587" alt="스크린샷 2024-02-13 오후 7 12 15" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/7bb47b85-217b-4770-af63-d3a1fd02c90e">

1. climber일 때
- userId, userName, userProfileUrl, socialType, manager여부 반환

2. manager일 때
- userId, userName, userProfileUrl, socialType(null로 반환), manager여부 반환

### 알림 on/off 기능 구현
<img width="373" alt="스크린샷 2024-02-13 오후 7 13 04" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/0204952a-abd6-481e-9ead-196bb03569b6">


```java
@Transactional
    public String updateUserNotification(User currentUser,
        UpdateUserAllowNotificationRequest request) {

        boolean isAllowFollowNotification = currentUser.getIsAllowFollowNotification();
        boolean isAllowLikeNotification = currentUser.getIsAllowLikeNotification();
        boolean isAllowCommentNotification = currentUser.getIsAllowCommentNotification();
        boolean isAllowAdNotification = currentUser.getIsAllowAdNotification();

        if (request.getIsAllowFollowNotification() != null) {
            isAllowFollowNotification = request.getIsAllowFollowNotification();
        }
        if (request.getIsAllowLikeNotification() != null) {
            isAllowLikeNotification = request.getIsAllowLikeNotification();
        }
        if (request.getIsAllowCommentNotification() != null) {
            isAllowCommentNotification = request.getIsAllowCommentNotification();
        }
        if (request.getIsAllowAdNotification() != null) {
            isAllowAdNotification = request.getIsAllowAdNotification();
        }

        currentUser.updateNotification(isAllowFollowNotification, isAllowLikeNotification,
            isAllowCommentNotification, isAllowAdNotification);

        return "업데이트 완료";
    }
```
- 더티체킹을 통해 구현하였습니다.
- 더 좋은 방법 있다면 조언해주세요!

## 테스트 확인 내용
### 로그인 계정 정보 조회
<img width="641" alt="스크린샷 2024-02-13 오후 7 09 39" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/27ecb407-7302-46ef-a41d-5b30c95783fe">


### 알림 on/off 기능 구현
<호출 전>
<img width="1104" alt="스크린샷 2024-02-13 오후 7 05 50" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/d3597f2c-716d-4b96-b8fd-1f0d1b2e39b4">

<postman 호출>
<img width="634" alt="스크린샷 2024-02-13 오후 7 06 30" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/260bb83d-8213-4d5a-955b-049da4c75322">

<호출 후>
<img width="1059" alt="스크린샷 2024-02-13 오후 7 06 48" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/1f24e8ae-afc7-4888-885a-d90592d2ad34">

- isAllowFollowNotification&isAllowLikeNotification 값 변경됨.

## 질문 및 이외 사항
- @DynamicUpdate를 사용해보려 했지만 DynamicUpdate를 사용해야 하는 경우가 따로 있는 것으로 보였습니다.
- @DynamicUpdate 어노테이션 사용은 얼핏 보면 변경이 필요하지 않은 값들까지 변경하지 않아도 되어 성능상 좋아보이지만 오히려 캐싱되지 않은 동적쿼리를 생성함으로써 성능 오버헤드가 생길 수 있습니다.
- 참고한 블로그들을 아래 적어놓을테니 참고하시면 좋을 것 같습니다!
- [DynamicUpdate의 단점 - 동적쿼리와 캐싱](https://hyune-c.tistory.com/entry/DynamicUpdate-%ED%99%9C%EC%9A%A9%EA%B8%B0)
- [DynamicUpdate Dto에 담을 때 null 체크](https://velog.io/@recordsbeat/DynamicUpdate%EA%B0%80-%EC%99%B8%EC%95%8A%EB%90%82%EB%8D%B0)
- [DynamicUpdate를 사용하면 좋은 상황](https://multifrontgarden.tistory.com/299)
