### PR TITLE
[SPR-155] 홈화면 식별자 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/dto/BestClearClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/clear/dto/BestClearClimberResponseDto.java
@@ -14,6 +14,8 @@ public class BestClearClimberResponseDto {
     @Builder
     public static class BestClearClimberDetailInfo{
 
+        private Long userId;
+
         private int ranking;
 
         private String profileImageUrl;
@@ -24,6 +26,7 @@ public class BestClearClimberResponseDto {
 
         public static BestClearClimberDetailInfo toDTO(BestClearClimber bestClearClimber){
             return BestClearClimberDetailInfo.builder()
+                .userId(bestClearClimber.getUserId())
                 .ranking(bestClearClimber.getRanking())
                 .profileImageUrl(bestClearClimber.getProfileImageUrl())
                 .thisWeekClearCount(bestClearClimber.getThisWeekClearCount())

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/dto/BestLevelClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/level/dto/BestLevelClimberResponseDto.java
@@ -14,6 +14,8 @@ public class BestLevelClimberResponseDto {
     @Builder
     public static class BestLevelClimberDetailInfo{
 
+        private Long userId;
+
         private int ranking;
 
         private String profileImageUrl;
@@ -27,6 +29,7 @@ public class BestLevelClimberResponseDto {
         public static BestLevelClimberDetailInfo toDTO(
             BestLevelClimber bestLevelClimber){
             return BestLevelClimberDetailInfo.builder()
+                .userId(bestLevelClimber.getUserId())
                 .ranking(bestLevelClimber.getRanking())
                 .profileImageUrl(bestLevelClimber.getProfileImageUrl())
                 .thisWeekHighDifficulty(bestLevelClimber.getDifficulty())

--- a/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/dto/BestTimeClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestclimber/time/dto/BestTimeClimberResponseDto.java
@@ -16,6 +16,8 @@ public class BestTimeClimberResponseDto {
     @Builder
     public static class BestTimeClimberDetailInfo{
 
+        private Long userId;
+
         private int ranking;
 
         private String profileImageUrl;
@@ -27,6 +29,7 @@ public class BestTimeClimberResponseDto {
         public static BestTimeClimberDetailInfo toDTO(
             BestTimeClimber bestTimeClimber){
             return BestTimeClimberDetailInfo.builder()
+                .userId(bestTimeClimber.getUserId())
                 .ranking(bestTimeClimber.getRanking())
                 .profileImageUrl(bestTimeClimber.getProfileImageUrl())
                 .thisWeekTotalClimbingTime(convertDoubleToStringTime(bestTimeClimber.getThisWeekTotalClimbingTime()))

--- a/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/dto/BestFollowGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestfollowgym/dto/BestFollowGymResponseDto.java
@@ -14,6 +14,7 @@ public class BestFollowGymResponseDto {
     @Builder
     public static class BestFollowGymDetailInfo {
 
+        private Long gymId;
         private int ranking;
         private String profileImageUrl;
         private String gymName;
@@ -23,6 +24,7 @@ public class BestFollowGymResponseDto {
 
         public static BestFollowGymDetailInfo toDTO(BestFollowGym bestFollowGym) {
             return BestFollowGymDetailInfo.builder()
+                .gymId(bestFollowGym.getClimbingGym().getId())
                 .ranking(bestFollowGym.getRanking())
                 .thisWeekFollowerCount(bestFollowGym.getThisWeekFollowCount())
                 .profileImageUrl(bestFollowGym.getProfileImageUrl())

--- a/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/dto/BestRecordGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestrecordgym/dto/BestRecordGymResponseDto.java
@@ -14,6 +14,7 @@ public class BestRecordGymResponseDto {
     @Builder
     public static class BestRecordGymDetailInfo {
 
+        private Long gymId;
         private int ranking;
         private String profileImageUrl;
         private String gymName;
@@ -23,6 +24,7 @@ public class BestRecordGymResponseDto {
 
         public static BestRecordGymDetailInfo toDTO(BestRecordGym bestRecordGym) {
             return BestRecordGymDetailInfo.builder()
+                .gymId(bestRecordGym.getClimbingGym().getId())
                 .ranking(bestRecordGym.getRanking())
                 .thisWeekSelectionCount(bestRecordGym.getThisWeekSelectionCount())
                 .profileImageUrl(bestRecordGym.getProfileImageUrl())

--- a/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/bestroute/dto/BestRouteResponseDto.java
@@ -15,6 +15,7 @@ public class BestRouteResponseDto {
     @Builder
     public static class BestRouteDetailInfo {
 
+        private Long routeId;
         private int ranking;
         private int thisWeekSelectionCount;
         private String routeImageUrl;
@@ -26,6 +27,7 @@ public class BestRouteResponseDto {
 
         public static BestRouteDetailInfo toDTO(BestRoute bestRoute) {
             return BestRouteDetailInfo.builder()
+                .routeId(bestRoute.getRoute().getId())
                 .ranking(bestRoute.getRanking())
                 .thisWeekSelectionCount(bestRoute.getThisWeekSelectionCount())
                 .routeImageUrl(bestRoute.getRouteImageUrl())

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -73,7 +73,7 @@ public class ClimbingRecordController {
 
     @Operation(summary = "나의 클라이밍 기록 날짜 조회")
     @GetMapping("/between-dates")
-    @SwaggerApiError({ErrorStatus._INVALID_DATE_RANGE, ErrorStatus._EMPTY_CLIMBING_RECORD,
+    @SwaggerApiError({ErrorStatus._INVALID_DATE_RANGE,
         ErrorStatus._INVALID_MEMBER})
     public ResponseEntity<List<ClimbingRecordSimpleInfo>> getClimbingRecordListBetweenDates(
         @CurrentUser User user,

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -137,10 +137,6 @@ public class ClimbingRecordService {
         List<ClimbingRecord> climbingRecordList = climbingRecordRepository.findByClimbingDateBetweenAndUser(
             startDate, endDate, user);
 
-        if (climbingRecordList.isEmpty()) {
-            throw new GeneralException(ErrorStatus._EMPTY_CLIMBING_RECORD);
-        }
-
         return climbingRecordList.stream()
             .map(record -> ClimbingRecordSimpleInfo.toDTO(record))
             .collect(Collectors.toList());

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -173,7 +173,10 @@ public class ClimbingRecordService {
         Long updateTime = 0L;
         // updateClimbingRecordDto의 time이 null이 아니면 업데이트 수행
         if (newTime != null) {
-            updateTime = oldTime.toNanoOfDay()/NANO_TO_SEC - newTime.toNanoOfDay()/NANO_TO_SEC;
+            updateTime = newTime.toNanoOfDay()/NANO_TO_SEC - oldTime.toNanoOfDay()/NANO_TO_SEC;
+            System.out.println("oldTIme = " + oldTime);
+            System.out.println("newTime = " + newTime);
+            System.out.println("updateTime = " + updateTime);
             oldTime = newTime;
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -64,6 +64,8 @@ public class ClimbingRecordService {
     public static final int CLIMEET_LEVEL = 0;
     public static final int LEVEL_COUNT = 1;
 
+    public static final int NANO_TO_SEC = 1000000000;
+
 
     /**
      * 클라이밍기록 생성(루트기록생성포함)
@@ -79,7 +81,7 @@ public class ClimbingRecordService {
 
         //선택받았으니 하나 추가
         climbingGym.thisWeekSelectionCountUp();
-        Long totalTime = requestDto.getTime().toNanoOfDay() / 1000000000;
+        Long totalTime = requestDto.getTime().toNanoOfDay() / NANO_TO_SEC;
         user.thisWeekTotalClimbingTimeUp(totalTime);
 
         List<CreateRouteRecord> routeRecords = requestDto.getRouteRecordRequestDtoList();
@@ -168,12 +170,16 @@ public class ClimbingRecordService {
             oldDate = newDate;
         }
 
+        Long updateTime = 0L;
         // updateClimbingRecordDto의 time이 null이 아니면 업데이트 수행
         if (newTime != null) {
+            updateTime = oldTime.toNanoOfDay()/NANO_TO_SEC - newTime.toNanoOfDay()/NANO_TO_SEC;
             oldTime = newTime;
         }
 
         climbingRecord.update(oldDate, oldTime);
+
+        user.thisWeekTotalClimbingTimeUp(updateTime);
 
         return ClimbingRecordSimpleInfo.toDTO(climbingRecord);
     }
@@ -188,7 +194,7 @@ public class ClimbingRecordService {
             throw new GeneralException(ErrorStatus._INVALID_MEMBER);
         }
 
-        Long totalTime = climbingRecord.getClimbingTime().toNanoOfDay() / 1000000000;
+        Long totalTime = climbingRecord.getClimbingTime().toNanoOfDay() / NANO_TO_SEC;
         user.thisWeekTotalClimbingTimeDown(totalTime);
         climbingRecord.getGym().thisWeekSelectionCountDown();
         climbingRecordRepository.deleteById(id);

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -188,9 +188,10 @@ public class ClimbingRecordService {
             throw new GeneralException(ErrorStatus._INVALID_MEMBER);
         }
 
-        climbingRecordRepository.deleteById(id);
-
+        Long totalTime = climbingRecord.getClimbingTime().toNanoOfDay() / 1000000000;
+        user.thisWeekTotalClimbingTimeDown(totalTime);
         climbingRecord.getGym().thisWeekSelectionCountDown();
+        climbingRecordRepository.deleteById(id);
 
         return ResponseEntity.ok("클라이밍기록이 삭제되었습니다.");
     }
@@ -289,7 +290,7 @@ public class ClimbingRecordService {
                     gym, ((int) arr[CLIMEET_LEVEL]));
                 Long levelCount = (Long) arr[LEVEL_COUNT];
 
-                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount );
+                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount);
             })
             .collect(Collectors.toList());
 
@@ -324,7 +325,7 @@ public class ClimbingRecordService {
                     gym, ((int) arr[CLIMEET_LEVEL]));
                 Long levelCount = (Long) arr[LEVEL_COUNT];
 
-                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount );
+                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount);
             })
             .collect(Collectors.toList());
 
@@ -366,7 +367,8 @@ public class ClimbingRecordService {
         List<BestTimeUserSimpleInfo> ranking = bestUserRanking.stream()
             .map(userRankMap -> {
                 User user = (User) userRankMap[RANKING_USER];
-                String totalTime = convertDoubleToStringTime((Double) userRankMap[RANKING_CONDITION]);
+                String totalTime = convertDoubleToStringTime(
+                    (Double) userRankMap[RANKING_CONDITION]);
                 return BestTimeUserSimpleInfo.toDTO(user, rank[0]++, totalTime);
             })
             .collect(Collectors.toList());
@@ -394,9 +396,8 @@ public class ClimbingRecordService {
                 Number count = (Number) userRankMap[RANKING_COUNT];
                 int highDifficultyCount = count.intValue();
 
-
                 DifficultyMapping difficultyMapping = difficultyMappingList.stream()
-                    .filter(iter -> iter.getDifficulty() == highDifficulty )
+                    .filter(iter -> iter.getDifficulty() == highDifficulty)
                     .findAny().get();
 
                 String climeetDifficultyName = difficultyMapping.getClimeetDifficultyName();
@@ -404,7 +405,8 @@ public class ClimbingRecordService {
                 String gymDifficultyColor = difficultyMapping.getGymDifficultyColor();
 
                 return BestLevelUserSimpleInfo.toDTO(user, rank[0]++, highDifficulty,
-                    highDifficultyCount, climeetDifficultyName, gymDifficultyName, gymDifficultyColor);
+                    highDifficultyCount, climeetDifficultyName, gymDifficultyName,
+                    gymDifficultyColor);
             })
             .collect(Collectors.toList());
 
@@ -463,7 +465,8 @@ public class ClimbingRecordService {
     }
 
 
-    public ClimbingRecordUserAndGymStatisticsDetailInfo getUserStatisticsByGym(Long userId, Long gymId) {
+    public ClimbingRecordUserAndGymStatisticsDetailInfo getUserStatisticsByGym(Long userId,
+        Long gymId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_MEMBER));
 
@@ -481,14 +484,13 @@ public class ClimbingRecordService {
         List<Object[]> difficulties = routeRecordRepository
             .findAllRouteRecordDifficultyAndUserAndGym(user, gym);
 
-
         List<GymDifficultyMappingInfo> difficultyList = difficulties.stream()
             .map(arr -> {
                 DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndDifficulty(
                     gym, ((int) arr[CLIMEET_LEVEL]));
                 Long levelCount = (Long) arr[LEVEL_COUNT];
 
-                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount );
+                return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount);
             })
             .collect(Collectors.toList());
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordRequestDto.java
@@ -18,10 +18,10 @@ public class  ClimbingRecordRequestDto {
         @Schema(example = "1", description = "짐 id")
         private Long gymId;
 
-        @Schema(example = "LocalDate.of(2024, 1, 4)", description = "날짜입력")
+        @Schema(example = "2024-01-01", description = "날짜입력")
         private LocalDate date;
 
-        @Schema(example = "LocalTime.of(1, 30)", description = "시간")
+        @Schema(example = "00:00:00", description = "시간")
         private LocalTime time;
 
         @Schema(example = "3", description = "평균 레벨")
@@ -34,10 +34,10 @@ public class  ClimbingRecordRequestDto {
     @Getter
     @NoArgsConstructor
     public static class UpdateClimbingRecord {
-        @Schema(example = "LocalDate.of(2024, 1, 4)", description = "날짜입력")
+        @Schema(example = "2024-01-01", description = "날짜입력")
         private LocalDate date;
 
-        @Schema(example = "LocalTime.of(1, 30)", description = "시간")
+        @Schema(example = "00:00:00", description = "시간")
         private LocalTime time;
 
     }


### PR DESCRIPTION
## 요약
- 홈화면 식별자 추가
- 암장기록 간편 조회 리팩터링
- climbingRecord 삭제 시 해당 유저의 금주 운동시간 줄이기

## 상세 내용
### 홈화면 식별자 추가
- 홈화면의 랭킹에서 랭킹의 주체가 되는 객체들을 클릭 시 해당 객체에 대한 detail 함수를 호출할 수 있도록 식별자를 반환하였습니다.
- 예시) 랭킹 1등 암장 클릭 -> 암장 프로필로 이동
- 이 전에는 식별자를 따로 반환해주지 않았음.

### 암장기록 간편 조회 리팩터링
- 기존 캘린더에서 특정 일자의 기록이 없을 때 에러처리를 해주어 프론트 단에서도 예외문구가 화면에 출력되는 것을 확인하였습니다.
- 이는 논리적으로 맞지 않습니다.
- 실제로 빈 배열인 경우 204로 성공 메세지를 보내주는 경우가 많습니다.
- 이에 따라 실제 climbingRecord가 존재하지 않을 때 에러가 표출되어야 하는 통계기록 조회의 경우만 제외하고 해당 예외처리를 제거하였습니다.

### climbingRecord 삭제 & 수정 시 해당 유저의 금주 운동시간 줄이기
- 홈화면의 금주 베스트 클라이머 랭킹이 시간 기준일 때 사용되는 필드인 thisWeekClimbingTime에 대한 값 변경을 보완하였습니다.
- 기존에는 생성 시에만 값이 업데이트 되었으나 현재는 수정 및 삭제 시에도 업데이트 됩니다.

## 테스트 확인 내용
### 홈화면 식별자 추가
- 홈화면의 (베스트)route, gym, climber의 Id가 반환되는 것을 확인하였습니다.

### 암장기록 간편 조회 리팩터링
- 캘린더의 간편운동기록 between-date 조회 시 빈 배열일 때 그대로 빈 배열을 반환하는 것을 확인하였습니다.

### climbingRecord 삭제 & 수정 시 해당 유저의 금주 운동시간 줄이기
- 삭제와 업데이트 시 해당 유저의 thisWeekTotalClimbingTime 필드의 값이 알맞게 바뀌는 것을 확인하였습니다.

## 질문 및 이외 사항
- 높은 확률로 유저, 클라이밍기록, 루트 등 각 테이블의 this(*) 인 필드들은 모두 삭제되고 쿼리를 통해 주간 통계 및 랭킹에서 계산되는 값으로 변경될 예정입니다.
- 즉, 관계있는 데이터의 삽입, 삭제, 수정 시 this(*) 필드값이 바뀌는 것이 아닌 주마다 한번씩 계산되는 로직으로 바뀔 예정입니다.