### PR TITLE
[SPR-156] refactor: 팔로우 & 취소 시 암장일 때 팔로우 count update

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FollowRelationshipController {
     private final FollowRelationshipService followRelationshipService;
 
-    @PostMapping("/follow-relationship/{userId}")
+    @PostMapping("/follow-relationship")
     @Operation(summary = "유저 팔로우")
     @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._EXIST_FOLLOW_RELATIONSHIP})
     public ResponseEntity<String> followUser(@RequestParam Long followingUserId, @CurrentUser User currentUser){
@@ -30,7 +30,7 @@ public class FollowRelationshipController {
         return ResponseEntity.ok("팔로우 완료");
     }
 
-    @DeleteMapping("/follow-relationship/{userId}")
+    @DeleteMapping("/follow-relationship")
     @Operation(summary = "유저 팔로우 취소")
     @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._EXIST_FOLLOW_RELATIONSHIP})
     public ResponseEntity<String> unfollowUser(@RequestParam Long followingUserId, @CurrentUser User currentUser){

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -1,10 +1,13 @@
 package com.climeet.climeet_backend.domain.followrelationship;
 
 
+import com.climeet.climeet_backend.domain.manager.Manager;
+import com.climeet.climeet_backend.domain.manager.ManagerRepository;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.domain.user.UserRepository;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +17,7 @@ public class FollowRelationshipService {
 
     private final FollowRelationshipRepository followRelationshipRepository;
     private final UserRepository userRepository;
+    private final ManagerRepository managerRepository;
 
     public User findByUserId(Long userId){
         return userRepository.findById(userId)
@@ -24,6 +28,8 @@ public class FollowRelationshipService {
             following.getId()).isPresent()){
             throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
         }
+        Optional<Manager> manager = managerRepository.findById(following.getId());
+        manager.ifPresent(value -> value.getClimbingGym().thisWeekFollowCountUp());
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, following);
         followRelationshipRepository.save(followRelationship);
         follower.increaseFollwerCount();
@@ -32,6 +38,8 @@ public class FollowRelationshipService {
     public void deleteFollowRelationship(User following, User follower){
         FollowRelationship followRelationship = followRelationshipRepository.findByFollowerIdAndFollowingId(follower.getId(), following.getId())
             .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_FOLLOW_RELATIONSHIP));
+        Optional<Manager> manager = managerRepository.findById(following.getId());
+        manager.ifPresent(value -> value.getClimbingGym().thisWeekFollowCountDown());
         followRelationshipRepository.deleteById(followRelationship.getId());
         followRelationship.getFollower().decreaseFollwerCount();
     }


### PR DESCRIPTION
## 요약
- 팔루우, 팔로우 취소할 때 상대방이 암장일 경우 해당 암장의 금주 팔로우 수를 업데이트 하는 로직을 추가하였습니다.

## 상세 내용
- 요약과 같음.

## 테스트 확인 내용
- 팔로우관계를 생성하고 삭제하며 암장의 thisWeekFollowCount가 업데이트 되는 것을 확인하였습니다.

## 질문 및 이외 사항
- 데모데이 끝난 후 필드 없애고 람다 실행 시 쿼리로 구할 수 있도록 수정할 예정
