### PR TITLE
[SPR-141] 루트, 섹터 수정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -35,6 +35,8 @@ public class Route extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private DifficultyMapping difficultyMapping;
 
+    private String holdColor;
+
     private String routeImageUrl;
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -48,19 +48,20 @@ public class Route extends BaseTimeEntity {
     private int selectionCount;
 
     public static Route toEntity(Sector sector,
-        String routeImageUrl, DifficultyMapping difficultyMapping) {
+        String routeImageUrl, DifficultyMapping difficultyMapping, String holdColor) {
         return Route.builder()
             .sector(sector)
             .difficultyMapping(difficultyMapping)
             .routeImageUrl(routeImageUrl)
+            .holdColor(holdColor)
             .build();
     }
 
-    public void thisWeekSelectionCountUp(){
+    public void thisWeekSelectionCountUp() {
         this.thisWeekSelectionCount++;
     }
 
-    public void thisWeekSelectionCountDown(){
+    public void thisWeekSelectionCountDown() {
         this.thisWeekSelectionCount--;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -24,7 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "ClimbingRoute", description = "클라이밍 루트 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/gym")
+@RequestMapping("api/gyms")
 public class RouteController {
 
     private final RouteService routeService;

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -45,7 +45,8 @@ public class RouteService {
         String routeImageUrl = s3Service.uploadFile(routeImage).getImgUrl();
 
         Route route = routeRepository.save(
-            Route.toEntity(sector, routeImageUrl, difficultyMapping));
+            Route.toEntity(sector, routeImageUrl, difficultyMapping,
+                createRouteRequest.getHoldColor()));
 
         return RouteSimpleResponse.toDto(route);
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -11,5 +11,6 @@ public class RouteRequestDto {
 
         private Long sectorId;
         private String gymDifficultyName;
+        private String holdColor;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteResponseDto.java
@@ -20,6 +20,7 @@ public class RouteResponseDto {
         private String gymDifficultyName;
         private String gymDifficultyColor;
         private String routeImageUrl;
+        private String holdColor;
 
         public static RouteDetailResponse toDto(Route route) {
             return RouteDetailResponse.builder()
@@ -31,6 +32,7 @@ public class RouteResponseDto {
                 .gymDifficultyName(route.getDifficultyMapping().getGymDifficultyName())
                 .gymDifficultyColor(route.getDifficultyMapping().getGymDifficultyColor())
                 .routeImageUrl(route.getRouteImageUrl())
+                .holdColor(route.getHoldColor())
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -36,7 +36,7 @@ public class Sector extends BaseTimeEntity {
 
     private String sectorImageUrl;
 
-    private int floor = 0;
+    private int floor = 1;
 
     public static Sector toEntity(CreateSectorRequest requestDto, ClimbingGym climbingGym,
         String sectorImageUrl) {

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -23,7 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "ClimbingSector", description = "클라이밍 섹터 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/gym")
+@RequestMapping("api/gyms")
 public class SectorController {
 
     private final SectorService sectorService;

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -31,14 +31,14 @@ public class SectorService {
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
-//        // 섹터 이름 중복 체크 (같은 섹터에서 중복일 경우)
-//        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
-//            manager.getClimbingGym().getId());
-//        for (Sector sector : sectorList) {
-//            if (sector.getSectorName().equals(createSectorRequest.getName())) {
-//                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
-//            }
-//        }
+        // 섹터 이름 중복 체크 (같은 섹터에서 중복일 경우)
+        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
+            manager.getClimbingGym().getId());
+        for (Sector sector : sectorList) {
+            if (sector.getSectorName().equals(createSectorRequest.getName())) {
+                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
+            }
+        }
 
         String sectorImageUrl = s3Service.uploadFile(sectorImage).getImgUrl();
 

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -31,14 +31,14 @@ public class SectorService {
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
-        // 루트 이름 중복 체크 (같은 섹터에서 중복일 경우)
-        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
-            manager.getClimbingGym().getId());
-        for (Sector sector : sectorList) {
-            if (sector.getSectorName().equals(createSectorRequest.getName())) {
-                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
-            }
-        }
+//        // 섹터 이름 중복 체크 (같은 섹터에서 중복일 경우)
+//        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
+//            manager.getClimbingGym().getId());
+//        for (Sector sector : sectorList) {
+//            if (sector.getSectorName().equals(createSectorRequest.getName())) {
+//                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
+//            }
+//        }
 
         String sectorImageUrl = s3Service.uploadFile(sectorImage).getImgUrl();
 

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
@@ -9,6 +9,8 @@ public class SectorRequestDto {
     @NoArgsConstructor
     public static class CreateSectorRequest {
         private String name;
-        private int floor;
+        private int floor = 1;
+
+
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
@@ -19,14 +19,12 @@ public class SectorResponseDto {
         private Long sectorId;
         private String name;
         private int floor;
-        private String sectorImageUrl;
 
         public static SectorDetailResponse toDto(Sector sector) {
             return SectorDetailResponse.builder()
                 .sectorId(sector.getId())
                 .name(sector.getSectorName())
                 .floor(sector.getFloor())
-                .sectorImageUrl(sector.getSectorImageUrl())
                 .build();
 
         }


### PR DESCRIPTION
## 요약

- route에 holdColor 컬럼 추가 + 반환값에 holdColor도 추가
- api/gym -> api/gyms
- sector floor 기본값 1로 설정
- sectorImage 반환 제거

## 상세 내용

- 간단간단 수정입니다. 코드 보시면 바로 알 수 있습니다.

## 테스트 확인 내용

- 루트 조회시 반환값입니다.
``` json
{
        "routeId": 1,
        "sectorId": 1,
        "sectorName": "Mario",
        "climeetDifficultyName": "VB",
        "difficulty": 0,
        "gymDifficultyName": "하양",
        "gymDifficultyColor": "#FFFFFF",
        "routeImageUrl": "https://climeet-production-bucket.s3.ap-northeast-2.amazonaws.com/02669ae8-d0d7-45b9-8339-4e2123b378a4.jpg",
        "holdColor": "하양"
    },
```
holdColor만 추가되었습니다

## 질문 및 이외 사항
- 뭔가 많이 바꾸려고 했는데, 데모데이까지는 이정도면 충분할 것 같아서 꼭 필요한 수정사항만 반영했습니다. 데모데이 이후 다시 수정 진행하겠습니다
