### PR TITLE
[SPR-125] feat: 공지사항 조회 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/board/BoardController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/BoardController.java
@@ -1,11 +1,14 @@
 package com.climeet.climeet_backend.domain.board;
 
 import com.climeet.climeet_backend.domain.board.dto.boardRequestDto.PostBoardRequest;
+import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardDetailInfo;
+import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardRetoolSimpleInfo;
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardSimpleInfo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +26,17 @@ public class BoardController {
     }
 
     @GetMapping("/retool/boards")
-    public ResponseEntity<List<BoardSimpleInfo>> findBoards() {
+    public ResponseEntity<List<BoardRetoolSimpleInfo>> findBoards() {
         return ResponseEntity.ok(boardService.findBoards());
+    }
+
+    @GetMapping("/boards")
+    public ResponseEntity<List<BoardSimpleInfo>> findBoardList(){
+        return ResponseEntity.ok(boardService.findBoardList());
+    }
+
+    @GetMapping("/boards/{boardId}")
+    public ResponseEntity<BoardDetailInfo> findBoardById(@PathVariable Long boardId){
+        return ResponseEntity.ok(boardService.findBoardById(boardId));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/board/BoardController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/BoardController.java
@@ -4,6 +4,9 @@ import com.climeet.climeet_backend.domain.board.dto.boardRequestDto.PostBoardReq
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardDetailInfo;
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardRetoolSimpleInfo;
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardSimpleInfo;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,11 +34,15 @@ public class BoardController {
     }
 
     @GetMapping("/boards")
+    @SwaggerApiError(ErrorStatus._EMPTY_USER)
+    @Operation(summary = "공지사항 전체 조회, 공지사항 글에 image없으면 null로 반환")
     public ResponseEntity<List<BoardSimpleInfo>> findBoardList(){
         return ResponseEntity.ok(boardService.findBoardList());
     }
 
     @GetMapping("/boards/{boardId}")
+    @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._BOARD_NOT_FOUND})
+    @Operation(summary = "특정 공지사항 조회")
     public ResponseEntity<BoardDetailInfo> findBoardById(@PathVariable Long boardId){
         return ResponseEntity.ok(boardService.findBoardById(boardId));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/board/BoardService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/BoardService.java
@@ -51,6 +51,7 @@ public class BoardService {
     public List<BoardSimpleInfo> findBoardList() {
         User climeetOfficialAccount = userRepository.findById(CLIMEET_OFFICIAL_ACCOUNT)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+
         List<Board> boardList = boardRepository.findAll();
         return boardList.stream()
             .map(board -> {

--- a/src/main/java/com/climeet/climeet_backend/domain/board/BoardService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/BoardService.java
@@ -1,7 +1,11 @@
 package com.climeet.climeet_backend.domain.board;
 
 import com.climeet.climeet_backend.domain.board.dto.boardRequestDto.PostBoardRequest;
+import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardDetailInfo;
+import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardRetoolSimpleInfo;
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardSimpleInfo;
+import com.climeet.climeet_backend.domain.boardImage.BoardImage;
+import com.climeet.climeet_backend.domain.boardImage.BoardImageRepository;
 import com.climeet.climeet_backend.domain.boardImage.BoardImageService;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.domain.user.UserRepository;
@@ -19,6 +23,9 @@ public class BoardService {
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
     private final BoardImageService boardImageService;
+    private final BoardImageRepository boardImageRepository;
+    public static final Long CLIMEET_OFFICIAL_ACCOUNT = 1L;
+
 
     @Transactional
     public void createBoard(PostBoardRequest postBoardRequest) {
@@ -33,11 +40,37 @@ public class BoardService {
 
     }
 
-    public List<BoardSimpleInfo> findBoards() {
+    public List<BoardRetoolSimpleInfo> findBoards() {
 
         List<Board> boardList = boardRepository.findAll();
 
-        return boardList.stream().map(BoardSimpleInfo::toDTO)
+        return boardList.stream().map(BoardRetoolSimpleInfo::toDTO)
             .toList();
+    }
+
+    public List<BoardSimpleInfo> findBoardList() {
+        User climeetOfficialAccount = userRepository.findById(CLIMEET_OFFICIAL_ACCOUNT)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+        List<Board> boardList = boardRepository.findAll();
+        return boardList.stream()
+            .map(board -> {
+                List<BoardImage> boardImageList = boardImageRepository.findAllByBoardId(board.getId());
+                if (boardImageList.isEmpty()) {
+                    return BoardSimpleInfo.toDTO(board, null, climeetOfficialAccount);
+                } else {
+                    return BoardSimpleInfo.toDTO(board, boardImageList.get(0).getImageUrl(), climeetOfficialAccount);
+                }
+            })
+            .toList();
+    }
+
+    public BoardDetailInfo findBoardById(Long boardId) {
+        User climeetOfficialAccount = userRepository.findById(CLIMEET_OFFICIAL_ACCOUNT)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+        Board board = boardRepository.findById(boardId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._BOARD_NOT_FOUND));
+        return BoardDetailInfo.toDTO(board, boardImageRepository
+            .findAllByBoardId(boardId).stream().map(BoardImage::getImageUrl).toList(),
+            climeetOfficialAccount);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/board/dto/boardResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/dto/boardResponseDto.java
@@ -1,7 +1,10 @@
 package com.climeet.climeet_backend.domain.board.dto;
 
 import com.climeet.climeet_backend.domain.board.Board;
+import com.climeet.climeet_backend.domain.boardImage.BoardImage;
+import com.climeet.climeet_backend.domain.user.User;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,18 +16,78 @@ public class boardResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class BoardSimpleInfo {
+    public static class BoardRetoolSimpleInfo {
 
         private LocalDateTime createdAt;
         private String title;
         private int viewCount;
         private int likeCount;
-        public static BoardSimpleInfo toDTO(Board board) {
-            return BoardSimpleInfo.builder()
+        public static BoardRetoolSimpleInfo toDTO(Board board) {
+            return BoardRetoolSimpleInfo.builder()
                 .createdAt(board.getCreatedAt())
                 .title(board.getTitle())
                 .viewCount(board.getViewCount())
                 .likeCount(board.getLikeCount())
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardSimpleInfo {
+
+        private Long boardId;
+        private LocalDateTime createdAt;
+        private int likeCount;
+        private String title;
+        private String content;
+        private String profileImageUrl;
+        private String image;
+
+        public static BoardSimpleInfo toDTO(Board board, String thumbnailImageUrl, User user) {
+            return BoardSimpleInfo.builder()
+                .boardId(board.getId())
+                .createdAt(board.getCreatedAt())
+                .likeCount(board.getLikeCount())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .profileImageUrl(user.getProfileImageUrl())
+                .image(thumbnailImageUrl)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardDetailInfo {
+
+        private Long boardId;
+        private String title;
+        private LocalDateTime createdAt;
+        private String profileImageUrl;
+        private String profileName;
+        private Long followerCount;
+        private Long followingCount;
+        private String content;
+        private int likeCount;
+        private List<String> imageList;
+
+        public static BoardDetailInfo toDTO(Board board, List<String> boardImageList, User user) {
+            return BoardDetailInfo.builder()
+                .boardId(board.getId())
+                .title(board.getTitle())
+                .createdAt(board.getCreatedAt())
+                .profileImageUrl(user.getProfileImageUrl())
+                .profileName(user.getProfileName())
+                .followerCount(user.getFollowerCount())
+                .followingCount(user.getFollowingCount())
+                .content(board.getContent())
+                .likeCount(board.getLikeCount())
+                .imageList(boardImageList)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/boardImage/BoardImageRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/boardImage/BoardImageRepository.java
@@ -1,7 +1,9 @@
 package com.climeet.climeet_backend.domain.boardImage;
 
+import com.climeet.climeet_backend.domain.board.Board;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
-
+    List<BoardImage> findAllByBoardId(Long boardId);
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -94,10 +94,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _EXIST_FOLLOW_RELATIONSHIP(HttpStatus.CONFLICT, "FOLLOW_RELATION_002", "이미 존재하는 팔로우 관계입니다."),
   
     //암장 회원가입 관련
-    _EMPTY_GYM_REGISTRATION(HttpStatus.CONFLICT, "GYM_REGISTRATION_001", "존재하지 안는 암장입니다.");
+    _EMPTY_GYM_REGISTRATION(HttpStatus.CONFLICT, "GYM_REGISTRATION_001", "존재하지 안는 암장입니다."),
+
+    //공지사항 관련
+    _BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "존재하지 않는 공지사항입니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
+
 
     @Override
     public ErrorReasonDto getReasonHttpStatus() {


### PR DESCRIPTION
## 요약
- 공지사항 전체 조회
- 공지사항 ID로 조회

## 상세 내용
<img width="405" alt="스크린샷 2024-02-14 오후 9 00 00" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/0e00d379-198b-4140-bcf8-5350d98a803f">
- 해당 화면을 구현하였습니다.
### 공지사항 전체 조회
- Image리스트의 경우 공지사항 안에 image가 존재하지 않을 시 null을 반환합니다.
- 만약 리스트가 존재할 시 가장 앞의 이미지를 썸네일로 가져옵니다.

### 공지사항 ID로 조회
- detail 조회이므로 이미지 전부를 조회합니다.

## 테스트 확인 내용
### 공지사항 전체 조회
<img width="604" alt="스크린샷 2024-02-14 오후 9 01 05" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/8875b4b1-b54d-45a0-8338-027cbd521521">

### 공지사항 ID로 조회
<img width="603" alt="스크린샷 2024-02-14 오후 8 59 35" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/8e776755-337a-4955-9f6a-16efd5119b0c">


## 질문 및 이외 사항
