### PR TITLE
[SPR-168] refactor: 통계 리팩터링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -131,6 +130,7 @@ public class ClimbingRecordResponseDto {
         private String gymDifficultyName;
         private String gymDifficultyColor;
         private Long count;
+        private int difficulty;
         public static GymDifficultyMappingInfo toDTO(
             DifficultyMapping difficultyMapping,
             Long count
@@ -140,6 +140,7 @@ public class ClimbingRecordResponseDto {
                 .gymDifficultyName(difficultyMapping.getGymDifficultyName())
                 .gymDifficultyColor(difficultyMapping.getGymDifficultyColor())
                 .count(count)
+                .difficulty(difficultyMapping.getDifficulty())
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -1,7 +1,6 @@
 package com.climeet.climeet_backend.domain.routerecord;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.user.User;
 import java.time.LocalDate;
 import java.util.List;


### PR DESCRIPTION
## 요약
- 통계 리팩터링

## 상세 내용
<img width="564" alt="스크린샷 2024-02-20 오전 3 15 27" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/da9c0052-406b-4b69-bb75-624b4a7165ad">

- 해당 API들에 대해 리팩토링하였습니다. (해당 API에 대한 설명은 노션페이지 -> 개인공간 -> 인우를 위한 ~~~ 에 정리해두었습니다.)
- 기존에는 반환하는 통계의 순서와 개수가 제각각이었습니다.
- 예를 들어 0,1,2,3,... 의 레벨 순이더라도 3,1,2,0,... 이런 식으로 말이죠!
- 또한 count되지 않은 기록에 대해서는 아예 보내주지 않았습니다.
- 결국 불균형한 그래프 차트가 그려졌습니다.
- 따라서 레벨의 순서대로, 또한 Count가 없다면 0으로 반환하였습니다.


## 테스트 확인 내용
### [암장 프로필] 암장별 주간 평균 완등률 통계
<img width="668" alt="스크린샷 2024-02-20 오전 3 08 54" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/787bb2d0-4176-4556-8df8-9a69e48d8ded">

### [유저 프로필] 유저별 특정 암장에 대한 누적 통계
<img width="523" alt="스크린샷 2024-02-20 오전 3 09 41" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/f7d9750d-c51b-408e-959e-f80cfd5494ed">

- V1, V2의 경우 count되지 않아도 count : 0 으로 넘겨주는 것을 확인할 수 있음


### [유저 프로필] 유저별 전체 암장에 대한 누적 통계
<img width="515" alt="스크린샷 2024-02-20 오전 3 10 41" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/ba3faf49-ab20-4125-9e17-465736c266e5">


### [캘린더/통계] 특정 암장에 대한 나의 월 통계
<img width="497" alt="스크린샷 2024-02-20 오전 3 12 35" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/3f8ad079-07b2-4a90-a831-9e811c2fc26b">


### [캘린더/통계] 나의 월별 운동기록 통계
<img width="500" alt="스크린샷 2024-02-20 오전 3 13 18" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/7d57d894-2c8a-4cff-a513-1364bac1c0d1">


## 질문 및 이외 사항
- 이외 사항으로 드디어 더미데이터에 대해 제대로 된 count가 세어지니 마음이 편안해집니다..^.^
