### PR TITLE
[SPR-170] 특정 암장 기준으로 내 현재 실력 조회기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -86,7 +86,7 @@ public class ClimbingGymController {
     public ResponseEntity<List<ClimbingGymAverageLevelDetailResponse>> getFollowingUserAverageLevelInClimbingGym(
         @PathVariable Long gymId, @CurrentUser User user) {
         return ResponseEntity.ok(
-            climbingGymService.getFollowingUserAverageLevelInClimbingGym(gymId));
+            climbingGymService.getFollowingUserAverageLevelInClimbingGym(gymId, user));
     }
 
     @Operation(summary = "암장 배경사진 변경 (1개만 등록 가능)")
@@ -132,6 +132,14 @@ public class ClimbingGymController {
     ) {
         return ResponseEntity.ok(
             climbingGymService.searchAcceptedClimbingGymWithFollow(gymName, page, size, user));
+    }
+
+    @Operation(summary = "특정 암장에서의 현재 내 실력 조회")
+    @SwaggerApiError({})
+    @GetMapping("/{gymId}/my-skill")
+    public ResponseEntity<String> getFollowingUserAverageLevelInClimbingGym(
+        @CurrentUser User user, @PathVariable Long gymId) {
+        return ResponseEntity.ok(climbingGymService.getClimberAverageDifficulty(user, gymId));
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -27,7 +27,6 @@ import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.s3.S3Service;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -177,7 +176,7 @@ public class ClimbingGymService {
     }
 
     public List<ClimbingGymAverageLevelDetailResponse> getFollowingUserAverageLevelInClimbingGym(
-        Long gymId) {
+        Long gymId, User user) {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
@@ -305,7 +304,18 @@ public class ClimbingGymService {
 
     }
 
-    private DifficultyMapping getClosestGymDifficulty(Integer level,
+    public String getClimberAverageDifficulty(User user, Long gymId) {
+
+        Float userAverageDifficulty = routeRecordRepository.findAverageDifficultyByUser(user);
+        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
+        List<DifficultyMapping> difficultyMapping = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
+            climbingGym);
+        return getClosestGymDifficulty(Math.round(userAverageDifficulty),
+            difficultyMapping).getGymDifficultyName();
+    }
+
+    public DifficultyMapping getClosestGymDifficulty(Integer level,
         List<DifficultyMapping> difficultyMappingList) {
         DifficultyMapping difficulty = null;
         int minDifference = Integer.MAX_VALUE;

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -4,6 +4,7 @@ import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.user.User;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -80,6 +81,6 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
         "   AVG(rr.difficulty) as averageDifficulty " +
         "FROM RouteRecord rr " +
         "WHERE rr.user = :user ")
-    Float findAverageDifficultyByUser(@Param("user") User user);
+    Optional<Float> findAverageDifficultyByUser(@Param("user") User user);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -1,7 +1,6 @@
 package com.climeet.climeet_backend.domain.routerecord;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.user.User;
 import java.time.LocalDate;
 import java.util.List;
@@ -76,5 +75,11 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
         "WHERE rr.isCompleted = true AND fr.following = :manager " +
         "GROUP BY rr.user")
     List<Float> getFollowUserSumCountDifficultyInClimbingGym(@Param("manager") User manager);
+
+    @Query("SELECT " +
+        "   AVG(rr.difficulty) as averageDifficulty " +
+        "FROM RouteRecord rr " +
+        "WHERE rr.user = :user ")
+    Float findAverageDifficultyByUser(@Param("user") User user);
 
 }


### PR DESCRIPTION
## 요약
![image](https://github.com/TheClimeet/climeet-spring/assets/62535229/84a42348-ca46-4481-9831-5b1df63f090d)

위에 이미지에 보이는 현재 내 실력 부분에서 내 실력이 어느 색에 속하는지를 반환하는 기능을 구현했습니다.
원래 저 그래프 데이터 반환 API에 넣으려 했으나, 한곳에서만 사용되는 것이 아닐 것 같아 현재는 간편하게 API로 반환하는 기능을 구현했습니다.

## 상세 내용

``` java
    @Operation(summary = "특정 암장에서의 현재 내 실력 조회")
    @SwaggerApiError({})
    @GetMapping("/{gymId}/my-skill")
    public ResponseEntity<String> getFollowingUserAverageLevelInClimbingGym(
        @CurrentUser User user, @PathVariable Long gymId) {
        return ResponseEntity.ok(climbingGymService.getClimberAverageDifficulty(user, gymId));
    }
```
암장 ID를 입력받고 실행합니다.

``` java

    public String getClimberAverageDifficulty(User user, Long gymId) {

        Optional<Float> userAverageDifficulty = routeRecordRepository.findAverageDifficultyByUser(user);
        if(userAverageDifficulty.isEmpty()){
            return null;
        }

        ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
            climbingGym);
        if (difficultyMappingList.isEmpty()) {
            throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);
        }

        return getClosestGymDifficulty(Math.round(userAverageDifficulty.get()),
            difficultyMappingList).getGymDifficultyName();
    }
```
아래 쿼리를 통해서 사용자의 평균 difficulty Float 값을 가져옵니다. 만약 값이 없다면 null을 반환하는데, null이면 그대로 null 반환을 해달라고 하여, null 체크 후 맞다면 null을 그대로 반환하도록 했습니다. (만약 여기서 return 을 안하면 아래에서 에러가 발생할것이라... 혹시 더 나은 방법이 있다면 의견 부탁합니다!!(지금은 생각이 잘 안나네용)
만약 null이 아니라면, 암장의 difficulty 데이터를 모두 가져와서, 현재 Float에 가장 가까운 난이도를 구하게 되고, String으로 암장 기준 난이도의 이름을 반환하게 됩니다.


``` java
    @Query("SELECT " +
        "   AVG(rr.difficulty) as averageDifficulty " +
        "FROM RouteRecord rr " +
        "WHERE rr.user = :user ")
    Optional<Float> findAverageDifficultyByUser(@Param("user") User user);
```
위처럼 간단하게 특정 사용자의 루트 기록에서 난이도 평균을 구하는 쿼리를 작성했습니다.


## 테스트 확인 내용
<img width="502" alt="스크린샷 2024-02-20 오후 7 05 17" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/90fa5b84-858f-4cf5-83a6-d05a956fd7e2">

Postman으로 루트 데이터가 존재하는 유저를 조회한 결과입니다.

<img width="444" alt="스크린샷 2024-02-20 오후 7 07 56" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/22a3b2eb-84d0-4f64-9249-3cedd8dacf5e">
루트 데이터가 존재하지 않는 유저를 조회한 결과입니다 (반환되는 값이 없습니다 - 프론트에서 이렇게 처리해달라고 했습니다)

## 질문 및 이외 사항
- 저기 저 null 처리하는 부분에서 return하는게 애매하긴 한데, 괜찮을까요?
