### PR TITLE
[SPR-183] 특정 유저의 월별 운동한 암장리스트

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -12,6 +12,7 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRespo
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserAndGymStatisticsDetailInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserStatisticsSimpleInfo;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.VisitedClimbingGym;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
@@ -185,5 +186,15 @@ public class ClimbingRecordController {
         @PathVariable Long gymId
     ) {
         return ResponseEntity.ok(climbingRecordService.getUserStatisticsByGym(userId, gymId));
+    }
+
+    @Operation(summary = "유저별 운동한 암장 리스트 조회")
+    @GetMapping("/users/{userId}/gyms/{gymId}/list")
+    public ResponseEntity<List<VisitedClimbingGym>> getFollowingUserAverageLevelInClimbingGym(
+            @CurrentUser User user,
+            @PathVariable Long userId,
+            @RequestParam int year,
+            @RequestParam int month) {
+        return ResponseEntity.ok(climbingRecordService.getVisitedGymList(userId, year, month));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -189,8 +189,8 @@ public class ClimbingRecordController {
     }
 
     @Operation(summary = "유저별 운동한 암장 리스트 조회")
-    @GetMapping("/users/{userId}/gyms/{gymId}/list")
-    public ResponseEntity<List<VisitedClimbingGym>> getFollowingUserAverageLevelInClimbingGym(
+    @GetMapping("/users/{userId}/months/list")
+    public ResponseEntity<List<VisitedClimbingGym>> getVisitedGymList(
             @CurrentUser User user,
             @PathVariable Long userId,
             @RequestParam int year,

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordRepository.java
@@ -5,11 +5,11 @@ import com.climeet.climeet_backend.domain.user.User;
 import jakarta.persistence.Tuple;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.parameters.P;
 
 public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, Long> {
 
@@ -94,4 +94,11 @@ public interface ClimbingRecordRepository extends JpaRepository<ClimbingRecord, 
     List<Object[]> findByLevelRankingClimbingDateBetweenAndClimbingGym(LocalDate startDate,
         LocalDate endDate, ClimbingGym climbingGym);
 
+    @Query(
+        "SELECT cr.gym.id, cr.gym.name "
+            + "FROM ClimbingRecord cr "
+            + "WHERE cr.user = :user and cr.climbingDate BETWEEN :startDate AND :endDate "
+            + "GROUP BY cr.gym.id"
+    )
+    List<Object[]> findAllByUserAndClimbingDateBetween(User user, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -17,6 +17,7 @@ import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordRespo
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserAndGymStatisticsDetailInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.ClimbingRecordUserStatisticsSimpleInfo;
 import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.GymDifficultyMappingInfo;
+import com.climeet.climeet_backend.domain.climbingrecord.dto.ClimbingRecordResponseDto.VisitedClimbingGym;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
@@ -67,6 +68,8 @@ public class ClimbingRecordService {
     public static final int CLIMEET_LEVEL = 0;
     public static final int LEVEL_COUNT = 1;
     public static final int NANO_TO_SEC = 1000000000;
+    public static final int GYM_ID = 0;
+    public static final int GYM_NAME = 1;
 
 
 
@@ -552,5 +555,24 @@ public class ClimbingRecordService {
             attemptRouteCount,
             difficultyList
         );
+    }
+
+    public List<VisitedClimbingGym> getVisitedGymList(Long userId, int year, int month){
+        User user = userRepository.findById(userId).
+                orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
+
+
+        LocalDate startDate = LocalDate.of(year, month, START_DAY_OF_MONTH);
+        LocalDate endDate = YearMonth.of(year, month).atEndOfMonth();
+
+        List<Object[]> climbingGymList = climbingRecordRepository.findAllByUserAndClimbingDateBetween(
+                user,
+                startDate,
+                endDate
+        );
+
+        return climbingGymList.stream()
+            .map(gym -> new VisitedClimbingGym((Long)gym[GYM_ID], (String)gym[GYM_NAME]))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -290,4 +290,11 @@ public class ClimbingRecordResponseDto {
                 .build();
         }
     }
+
+    @AllArgsConstructor
+    @Getter
+    public static class VisitedClimbingGym {
+        private Long gymId;
+        private String gymName;
+    }
 }


### PR DESCRIPTION
## 요약
- 특정 유저의 월별 운동한 암장리스트 조회

## 상세 내용
<img width="1399" alt="스크린샷 2024-05-09 오후 3 28 40" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/1fa96b47-4ecb-4f96-8f30-b2027174eae1">

- 프론트측 요청에 따라 유저별 운동한 암장 기록을 가져오는 Get API를 구현하였습니다.


## 테스트 확인 내용
**해당 월에 암장 두 곳만 갔을 때**
<img width="1365" alt="스크린샷 2024-05-09 오후 3 27 32" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/c6848c13-6621-41fb-8112-67dd7ff5e3f5">

**해당 월에 암장 10곳을 갔을 때**
<img width="1340" alt="스크린샷 2024-05-09 오후 3 27 50" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/fe8f67b5-94de-44bf-afca-1763e237178d">

## 질문 및 이외 사항
- 현재는 단순 쿼리로만 진행되며 데이터를 넣고 부하테스트를 진행하며 연결테이블을 만들었을 때와 그 결과를 공유하고자 합니다.
- 비교는 다음 PR에서 볼 수 있기를 기대합니다!(스스로에게)
