### PR TITLE
[SPR-187] 유저 정보 수정 기능, 유저별 정보 공개 여부(숏츠/홈짐/평균완등률/평균완등레벨) 조회 및 업데이트 기능 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -62,7 +62,7 @@ public class Climber extends User {
     }
 
     public void updateIsAverageCompletionLevelPublic(){
-        this.isAverageCompletionLevelPublic = !isAverageCompletionRatePublic;
+        this.isAverageCompletionLevelPublic = !isAverageCompletionLevelPublic;
     }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -41,6 +41,30 @@ public class Climber extends User {
 
     private boolean status = true;
 
+    private boolean isShortsPublic = true;
+
+    private boolean isHomeGymPublic = true;
+
+    private boolean isAverageCompletionRatePublic = true;
+
+    private boolean isAverageCompletionLevelPublic = true;
+
+    public void updateIsShortsPublic(){
+        this.isShortsPublic = !isShortsPublic;
+    }
+
+    public void updateIsHomeGymPublic(){
+        this.isHomeGymPublic = !isHomeGymPublic;
+    }
+
+    public void updateIsAverageCompletionRatePublic(){
+        this.isAverageCompletionLevelPublic = !isAverageCompletionLevelPublic;
+    }
+
+    public void updateIsAverageCompletionLevelPublic(){
+        this.isAverageCompletionLevelPublic = !isAverageCompletionRatePublic;
+    }
+
 
     public void updateProfileName(String profileName) {
         this.profileName = profileName; // User 클래스의 profileName 필드를 업데이트
@@ -68,6 +92,10 @@ public class Climber extends User {
             .socialType(socialType)
             .profileImageUrl(profileImg)
             .status(true)
+            .isShortsPublic(true)
+            .isHomeGymPublic(true)
+            .isAverageCompletionLevelPublic(true)
+            .isAverageCompletionRatePublic(true)
             .followerCount(0L)
             .followingCount(0L)
             .thisWeekCompleteCount(0)

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -58,7 +58,7 @@ public class Climber extends User {
     }
 
     public void updateIsAverageCompletionRatePublic(){
-        this.isAverageCompletionLevelPublic = !isAverageCompletionLevelPublic;
+        this.isAverageCompletionRatePublic = !isAverageCompletionRatePublic;
     }
 
     public void updateIsAverageCompletionLevelPublic(){

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
@@ -77,21 +77,21 @@ public class ClimberController {
         return ResponseEntity.ok("공개 여부 변경 완료");
     }
 
-    @PatchMapping("/shorts-privacy-setting")
+    @PatchMapping("/homegym-privacy-setting")
     @Operation(summary = "클라이머 홈짐 공개 여부 변경")
     public ResponseEntity<String> updateHomeGymPrivacyStatus(@CurrentUser User user){
         climberService.updateHomeGymPrivacySetting(user);
         return ResponseEntity.ok("공개 여부 변경 완료");
     }
 
-    @PatchMapping("/shorts-privacy-setting")
+    @PatchMapping("/averageCompletionRate-privacy-setting")
     @Operation(summary = "클라이머 평균완등률 공개 여부 변경")
     public ResponseEntity<String> updateAverageCompletionRatePrivacyStatus(@CurrentUser User user){
         climberService.updateAverageCompletionRatePrivacySetting(user);
         return ResponseEntity.ok("공개 여부 변경 완료");
     }
 
-    @PatchMapping("/shorts-privacy-setting")
+    @PatchMapping("/averageCompletionLevel-privacy-setting")
     @Operation(summary = "클라이머 평균완등레벨 공개 여부 변경")
     public ResponseEntity<String> updateAverageCompletionLevelPrivacyStatus(@CurrentUser User user){
         climberService.updateAverageCompletionLevelPrivacySetting(user);

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
@@ -2,6 +2,7 @@ package com.climeet.climeet_backend.domain.climber;
 
 import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.CreateClimberRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberDetailInfo;
+import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberPrivacySettingInfo;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberSimpleInfo;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,6 +61,41 @@ public class ClimberController {
     @Operation(summary = "클라이머 검색 기능")
     public ResponseEntity<PageResponseDto<List<ClimberDetailInfo>>> getClimberSearchingList(@CurrentUser User currentUser, @RequestParam int page, @RequestParam int size, @RequestParam String climberName){
         return ResponseEntity.ok(climberService.searchClimber(currentUser, climberName, page, size));
+    }
+
+    @GetMapping("/privacy-setting")
+    @Operation(summary = "클라이머 정보 공개 여부 조회(쇼츠, 홈짐, 평균완등률, 평균레벨)")
+    public ResponseEntity<ClimberPrivacySettingInfo> getClimberPrivacyStatus(@CurrentUser User currentUser, @RequestParam long climberId){
+        return ResponseEntity.ok(climberService.getClimberPrivacySetting(climberId));
+
+    }
+
+    @PatchMapping("/shorts-privacy-setting")
+    @Operation(summary = "클라이머 쇼츠 공개 여부 변경")
+    public ResponseEntity<String> updateShortsPrivacyStatus(@CurrentUser User user){
+        climberService.updateShortsPrivacySetting(user);
+        return ResponseEntity.ok("공개 여부 변경 완료");
+    }
+
+    @PatchMapping("/shorts-privacy-setting")
+    @Operation(summary = "클라이머 홈짐 공개 여부 변경")
+    public ResponseEntity<String> updateHomeGymPrivacyStatus(@CurrentUser User user){
+        climberService.updateHomeGymPrivacySetting(user);
+        return ResponseEntity.ok("공개 여부 변경 완료");
+    }
+
+    @PatchMapping("/shorts-privacy-setting")
+    @Operation(summary = "클라이머 평균완등률 공개 여부 변경")
+    public ResponseEntity<String> updateAverageCompletionRatePrivacyStatus(@CurrentUser User user){
+        climberService.updateAverageCompletionRatePrivacySetting(user);
+        return ResponseEntity.ok("공개 여부 변경 완료");
+    }
+
+    @PatchMapping("/shorts-privacy-setting")
+    @Operation(summary = "클라이머 평균완등레벨 공개 여부 변경")
+    public ResponseEntity<String> updateAverageCompletionLevelPrivacyStatus(@CurrentUser User user){
+        climberService.updateAverageCompletionLevelPrivacySetting(user);
+        return ResponseEntity.ok("공개 여부 변경 완료");
     }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberRepository.java
@@ -11,10 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface ClimberRepository  extends JpaRepository<Climber, Long> {
 
     Optional<Climber> findBySocialIdAndSocialType(String socialId, SocialType socialType);
-    Optional<Climber> findByAccessTokenAndSocialType(String accessToken, SocialType socialType);
 
     Page<Climber> findByProfileNameContaining(String climberName, Pageable pageable);
 
-    //Optional<Climber> findById(long id);
 }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberRepository.java
@@ -14,5 +14,7 @@ public interface ClimberRepository  extends JpaRepository<Climber, Long> {
     Optional<Climber> findByAccessTokenAndSocialType(String accessToken, SocialType socialType);
 
     Page<Climber> findByProfileNameContaining(String climberName, Pageable pageable);
+
+    //Optional<Climber> findById(long id);
 }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -239,21 +239,25 @@ public class ClimberService {
         return ClimberPrivacySettingInfo.toDTO(climber);
     }
 
+    @Transactional
     public void updateShortsPrivacySetting(User user){
         Climber climber = (Climber) user;
         climber.updateIsShortsPublic();
     }
 
+    @Transactional
     public void updateHomeGymPrivacySetting(User user){
         Climber climber = (Climber) user;
         climber.updateIsHomeGymPublic();
     }
 
+    @Transactional
     public void updateAverageCompletionRatePrivacySetting(User user){
         Climber climber = (Climber) user;
         climber.updateIsAverageCompletionRatePublic();
     }
 
+    @Transactional
     public void updateAverageCompletionLevelPrivacySetting(User user){
         Climber climber = (Climber) user;
         climber.updateIsAverageCompletionLevelPublic();

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.climber;
 
 import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.CreateClimberRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberDetailInfo;
+import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberPrivacySettingInfo;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberSimpleInfo;
 import com.climeet.climeet_backend.domain.climber.enums.SocialType;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
@@ -230,6 +231,32 @@ public class ClimberService {
         return new PageResponseDto<>(pageable.getPageNumber(), climberSlice.hasNext(),
             climberDetailInfoList);
 
+    }
+
+    public ClimberPrivacySettingInfo getClimberPrivacySetting(long climberId){
+        Climber climber = climberRepository.findById(climberId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._INVALID_MEMBER));
+        return ClimberPrivacySettingInfo.toDTO(climber);
+    }
+
+    public void updateShortsPrivacySetting(User user){
+        Climber climber = (Climber) user;
+        climber.updateIsShortsPublic();
+    }
+
+    public void updateHomeGymPrivacySetting(User user){
+        Climber climber = (Climber) user;
+        climber.updateIsHomeGymPublic();
+    }
+
+    public void updateAverageCompletionRatePrivacySetting(User user){
+        Climber climber = (Climber) user;
+        climber.updateIsAverageCompletionRatePublic();
+    }
+
+    public void updateAverageCompletionLevelPrivacySetting(User user){
+        Climber climber = (Climber) user;
+        climber.updateIsAverageCompletionLevelPublic();
     }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/dto/ClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/dto/ClimberResponseDto.java
@@ -64,6 +64,28 @@ public class ClimberResponseDto {
 
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClimberPrivacySettingInfo {
+
+        private boolean isShortsPublic;
+        private boolean isHomeGymPublic;
+        private boolean isAverageCompletionRatePublic;
+        private boolean isAverageCompletionLevelPublic;
+
+        public static ClimberPrivacySettingInfo toDTO(Climber climber){
+            return ClimberPrivacySettingInfo.builder()
+                .isShortsPublic(climber.isShortsPublic())
+                .isHomeGymPublic(climber.isHomeGymPublic())
+                .isAverageCompletionRatePublic(climber.isAverageCompletionRatePublic())
+                .isAverageCompletionLevelPublic(climber.isAverageCompletionLevelPublic())
+                .build();
+        }
+
+    }
+
 }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -71,6 +71,10 @@ public class User {
     @NotNull
     private String fcmToken;
 
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void updateToken(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
@@ -85,6 +89,10 @@ public class User {
         this.isAllowLikeNotification = isAllowLikeNotification;
         this.isAllowCommentNotification = isAllowCommentNotification;
         this.isAllowAdNotification = isAllowAdNotification;
+    }
+
+    public void updateProfileName(String name){
+        this.profileName = name;
     }
 
     public void thisWeekTotalClimbingTimeUp(Long sec) {

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -23,8 +23,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "User")
 @RequiredArgsConstructor
@@ -117,5 +119,20 @@ public class UserController {
     @Operation(summary = "특정 유저 홈짐 조회")
     public ResponseEntity<List<UserHomeGymSimpleInfo>> getHomeGyms(@CurrentUser User currentUser, @PathVariable Long userId){
         return ResponseEntity.ok(userService.getUserHomeGyms(userId));
+    }
+
+    @PatchMapping("/profile-image")
+    @Operation(summary = "유저 프로필 사진 업데이트")
+    public ResponseEntity<String> updateUserProfileImage(@CurrentUser User currentUser, @RequestPart
+        MultipartFile image){
+        userService.updateUserProfileImage(currentUser, image);
+        return ResponseEntity.ok("프로필 사진 업데이트 완료");
+    }
+
+    @PatchMapping("/profile-name")
+    @Operation(summary = "유저 프로필 이름 업데이트")
+    public ResponseEntity<String> updateUserProfileName(@CurrentUser User currentUser, @RequestParam String name){
+        userService.updateUserProfileName(currentUser, name);
+        return ResponseEntity.ok("프로필 이름 업데이트 완료");
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -21,12 +21,14 @@ import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserProfileDe
 import com.climeet.climeet_backend.domain.user.dto.UserResponseDto.UserTokenSimpleInfo;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import com.climeet.climeet_backend.global.s3.S3Service;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -38,6 +40,7 @@ public class UserService {
     private final ClimberRepository climberRepository;
     private final ManagerRepository managerRepository;
     private final RouteVersionService routeVersionService;
+    private final S3Service s3Service;
 
     @Transactional
     public User updateNotification(User user, boolean isAllowFollowNotification,
@@ -281,6 +284,23 @@ public class UserService {
     @Transactional
     public void updateUserFcmToken(User user, String token){
         user.updateFCMToken(token);
+    }
+
+    @Transactional
+    public void updateUserProfileImage(User user, MultipartFile image){
+        String profileImageUrl = s3Service.uploadFile(image).getImgUrl();
+        user.updateProfileImageUrl(profileImageUrl);
+    }
+
+    @Transactional
+    public void updateUserProfileName(User user, String nickName){
+        if(checkProfileNameDuplication(nickName)){
+            throw new GeneralException(ErrorStatus._DUPLICATE_NAME);
+        }
+        user.updateProfileName(nickName);
+    }
+    public boolean checkProfileNameDuplication(String name) {
+        return userRepository.findByprofileName(name).isPresent();
     }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserRequestDto.java
@@ -20,4 +20,8 @@ public class UserRequestDto {
         private String fcmToken;
     }
 
+    public static class UpdateUserProfile{
+
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER_004", "올바르지 않은 사용자입니다."),
     _PENDING_APPROVAL(HttpStatus.NOT_FOUND, "MEMBER_005", "승인을 대기 중인 사용자입니다."),
     _EXIST_USER(HttpStatus.CONFLICT, "MEMBER_006", "이미 존재하는 사용자입니다"),
+    _DUPLICATE_NAME(HttpStatus.CONFLICT, "MEMBER_007", "이미 사용 중인 닉네임입니다."),
 
     //암장 관련
     _EMPTY_CLIMBING_GYM(HttpStatus.CONFLICT, "CLIMBING_GYM_001", "존재하지 않는 암장입니다."),


### PR DESCRIPTION
## 요약
-데모데이 전에 유저 정보 조회 기능만 만들어 놓고 수정 기능은 미뤄놨던걸 깜빡해서 어제 회의 끝나고 급하게 만들었습니다..!
-안드에서 쇼츠, 홈짐, 평균완등률, 평균완등레벨 공개/비공개 여부를 조회하는 api가 필요하다고 해서 조회 api와 각각의 상태를 Update 하는 api를 구현하였습니다

## 상세 내용

- 유저 정보 수정 기능은 User 도메인의 프로필 사진과 닉네임을 업데이트 하는 로직을 구현하였습니다
- 유저 정보 공개 여부는 클라이머에만 할당되는 기능이므로 Climber 도메인에서 조회와 수정 로직을 구현하였습니다.
   정보 공개 여부를 저장하는 변수가 없는 것 같아서 클라이머 도메인에 해당 변수들을 추가 하였습니다!
```java
    private boolean isShortsPublic = true;

    private boolean isHomeGymPublic = true;

    private boolean isAverageCompletionRatePublic = true;

    private boolean isAverageCompletionLevelPublic = true;
```

        

## 테스트 확인 내용

- 

## 질문 및 이외 사항

- 
