### PR TITLE
[SPR-188] feat: 소셜로그인 과정 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/Climber.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -48,6 +49,9 @@ public class Climber extends User {
     private boolean isAverageCompletionRatePublic = true;
 
     private boolean isAverageCompletionLevelPublic = true;
+
+    @Setter
+    private LocalDateTime lastLogin;
 
     public void updateIsShortsPublic(){
         this.isShortsPublic = !isShortsPublic;
@@ -96,6 +100,7 @@ public class Climber extends User {
             .isHomeGymPublic(true)
             .isAverageCompletionLevelPublic(true)
             .isAverageCompletionRatePublic(true)
+            .lastLogin(LocalDateTime.now())
             .followerCount(0L)
             .followingCount(0L)
             .thisWeekCompleteCount(0)

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberController.java
@@ -1,9 +1,10 @@
 package com.climeet.climeet_backend.domain.climber;
 
+import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.ClimberTokenRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberRequestDto.CreateClimberRequest;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberDetailInfo;
 import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberPrivacySettingInfo;
-import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.ClimberSimpleInfo;
+import com.climeet.climeet_backend.domain.climber.dto.ClimberResponseDto.LoginSimpleInfo;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -21,7 +22,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,19 +35,21 @@ public class ClimberController {
     private final ClimberService climberService;
 
     @PostMapping("/login")
-    @Operation(summary = "OAuth 2.0 소셜 로그인", description = "**Enum 설명**\n\n**ClimbingLevel** : BEGINNER, NOVICE, INTERMEDIATE, ADVANCED, EXPERT\n\n**DiscoveryChannel** : INSTAGRAM_FACEBOOK, YOUTUBE, FRIEND_RECOMMENDATION, BLOG_CAFE_COMMUNITY, OTHER\n\n**SocialType(provider에 입력)**: KAKAO, NAVER \n\n **로그인 시 climberRequestDto 빈 값으로 보내기, 회원가입 시에만 채워서 보내기!**")
+    @Operation(summary = "OAuth 2.0 소셜 로그인", description = "**Enum 설명** : SocialType(provider에 입력)**: KAKAO, NAVER, APPLE \n\n responseType : SIGN_IN - 로그인 성공, SIGN_UP : 회원가입 필요, accessToken 필드의 토큰을 추가정보 입력 api에 넣어서 회원가입을 진행합니다.")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_MANAGER_GYM, ErrorStatus._INVALID_JWT, ErrorStatus._EXPIRED_JWT})
-    public ResponseEntity<ClimberSimpleInfo> login(@RequestParam String provider, @RequestHeader("Authorization") String accessToken, @RequestBody(required = false)
-    CreateClimberRequest climberRequestDto) throws FirebaseMessagingException {
-        if (accessToken != null && accessToken.startsWith("Bearer ")) {
-            accessToken = accessToken.substring("Bearer ".length());
-        }
-        ClimberSimpleInfo climberSimpleResponseDto = climberService.handleSocialLogin(provider, accessToken, climberRequestDto);
+    public ResponseEntity<LoginSimpleInfo> login(@RequestParam String provider, @RequestBody
+        ClimberTokenRequest climberTokenRequest) {
+        LoginSimpleInfo climberSimpleResponseDto = climberService.login(provider, climberTokenRequest);
 
         return ResponseEntity.ok(climberSimpleResponseDto);
 
     }
 
+    @PostMapping("/signup/extra")
+    @Operation(summary = "회원가입 추가 정보 입력 api", description = "\n\n**ClimbingLevel** : BEGINNER, NOVICE, INTERMEDIATE, ADVANCED, EXPERT\n\n**DiscoveryChannel** : INSTAGRAM_FACEBOOK, YOUTUBE, FRIEND_RECOMMENDATION, BLOG_CAFE_COMMUNITY, OTHER**")
+    public ResponseEntity<LoginSimpleInfo> signUp(@RequestBody CreateClimberRequest createClimberRequest) {
+        return ResponseEntity.ok(climberService.signUp(createClimberRequest));
+    }
 
     @GetMapping("/check-nickname/{nickName}")
     @Operation(summary = "클라이머 닉네임 중복 확인", description = "**이미 존재하는 닉네임** : false \n\n **사용 가능한 닉네임** : true")

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -86,9 +86,9 @@ public class ClimberService {
     public LoginSimpleInfo signUp(CreateClimberRequest createClimberRequest)  {
         String payload = jwtTokenProvider.validateTempTokenAndGetSocialId(
             createClimberRequest.getToken());
-        List<String> userInfoList = getUserInfoInPayload(payload);
-        String socialId = userInfoList.get(0);
-        String profileImg = userInfoList.get(1);
+        Map<String, String> userInfo = getUserInfoInPayload(payload);
+        String socialId = userInfo.get("socialId");
+        String profileImg = userInfo.get("profileImg");
         SocialType socialType = createClimberRequest.getSocialType();
         if (climberRepository.findBySocialIdAndSocialType(socialId, socialType).isPresent())
             throw new GeneralException(ErrorStatus._EXIST_USER);
@@ -119,22 +119,17 @@ public class ClimberService {
     }
 
 
-    public List<String> getUserInfoInPayload (String payload){
+    public Map<String, String> getUserInfoInPayload (String payload){
         String[] parts = payload.split("\\+");
-        List<String> list = new ArrayList<>();
+        Map<String, String> map = new HashMap<>();
 
-        if (parts.length >= 2) {
             String socialId = parts[0];
             String profileImg = parts[1];
 
-            list.add(socialId);
-            list.add(profileImg);
-        } else {
-            list.add("");  // socialId를 기본값으로 추가
-            list.add("");  // profileImg를 기본값으로 추가
-        }
+            map.put("socialId", socialId);
+            map.put("profileImg", profileImg);
 
-        return list;
+        return map;
     }
 
 
@@ -179,19 +174,19 @@ public class ClimberService {
 
     HashMap<String, String> getClimberProfileByToken(String providerName, String userToken)
         throws RuntimeException {
-        if (!providerName.equals("KAKAO") && !providerName.equals("NAVER")) {
+        if (!providerName.equals(SocialType.KAKAO.toString()) && !providerName.equals(SocialType.NAVER.toString())) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
         String socialId = null;
         String profileImg = null;
-        if (providerName.equals("KAKAO")) {
+        if (providerName.equals(SocialType.KAKAO.toString())) {
             Map<String, Object> userAttributesByToken = getClimberKaKaoAttributesByToken(userToken);
             KaKaoUserInfo kaKaoUserInfo = new KaKaoUserInfo(userAttributesByToken);
             socialId = Long.toString(kaKaoUserInfo.getID());
             profileImg = kaKaoUserInfo.getProfileImg();
 
         }
-        if (providerName.equals("NAVER")) {
+        if (providerName.equals(SocialType.NAVER.toString())) {
             Map<String, Object> userAttributesByToken = getClimberNaverAttributesByToken(userToken);
             NaverUserInfo naverUserInfo = new NaverUserInfo(userAttributesByToken);
             socialId = naverUserInfo.getId();

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/dto/ClimberRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/dto/ClimberRequestDto.java
@@ -2,15 +2,22 @@ package com.climeet.climeet_backend.domain.climber.dto;
 
 import com.climeet.climeet_backend.domain.climber.enums.ClimbingLevel;
 import com.climeet.climeet_backend.domain.climber.enums.DiscoveryChannel;
+import com.climeet.climeet_backend.domain.climber.enums.SocialType;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Data
 public class ClimberRequestDto {
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class CreateClimberRequest {
 
+        private String token;
+        private SocialType socialType;
         private String nickName;
         private ClimbingLevel climbingLevel;
         private DiscoveryChannel discoveryChannel;
@@ -21,6 +28,14 @@ public class ClimberRequestDto {
         private Boolean isAllowCommentNotification;
         private Boolean isAllowAdNotification;
 
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClimberTokenRequest{
+        private String accessToken;
 
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/dto/ClimberResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/dto/ClimberResponseDto.java
@@ -1,11 +1,11 @@
 package com.climeet.climeet_backend.domain.climber.dto;
 
 import com.climeet.climeet_backend.domain.climber.Climber;
+import com.climeet.climeet_backend.domain.climber.enums.ResponseType;
 import com.climeet.climeet_backend.domain.climber.enums.SocialType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,18 +15,20 @@ public class ClimberResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ClimberSimpleInfo {
+    public static class LoginSimpleInfo {
 
         private SocialType socialType;
         private String accessToken;
         private String refreshToken;
+        private ResponseType responseType;
 
 
-        public static ClimberSimpleInfo toDTO(Climber climber) {
-            return ClimberSimpleInfo.builder()
-                .socialType(climber.getSocialType())
-                .accessToken(climber.getAccessToken())
-                .refreshToken(climber.getRefreshToken())
+        public static LoginSimpleInfo toDTO(String socialType, String accessToken, String refreshToken, ResponseType responseType) {
+            return LoginSimpleInfo.builder()
+                .socialType(SocialType.valueOf(socialType))
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .responseType(responseType)
                 .build();
         }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/enums/ResponseType.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/enums/ResponseType.java
@@ -1,0 +1,6 @@
+package com.climeet.climeet_backend.domain.climber.enums;
+
+public enum ResponseType {
+    SIGN_IN, SIGN_UP, TOKEN_REFRESH
+}
+

--- a/src/main/java/com/climeet/climeet_backend/domain/climber/enums/SocialType.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/enums/SocialType.java
@@ -1,5 +1,5 @@
 package com.climeet.climeet_backend.domain.climber.enums;
 
 public enum SocialType {
-    KAKAO, NAVER
+    KAKAO, NAVER, APPLE
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -30,8 +30,7 @@ public class FollowRelationshipService {
         return userRepository.findById(userId)
             .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
     }
-    public void createFollowRelationship(User follower, User following)
-        throws FirebaseMessagingException {
+    public void createFollowRelationship(User follower, User following) {
         if(followRelationshipRepository.findByFollowerIdAndFollowingId(follower.getId(),
             following.getId()).isPresent()){
             throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
@@ -41,7 +40,7 @@ public class FollowRelationshipService {
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, following);
         followRelationshipRepository.save(followRelationship);
         follower.increaseFollwerCount();
-        fcmNotificationService.sendSingleUser(following.getId(), NotificationType.NEW_FOLLOWER.getTitle(follower.getProfileName()), NotificationType.NEW_FOLLOWER.getMessage(follower.getProfileName()) );
+        //fcmNotificationService.sendSingleUser(following.getId(), NotificationType.NEW_FOLLOWER.getTitle(follower.getProfileName()), NotificationType.NEW_FOLLOWER.getMessage(follower.getProfileName()) );
 
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -111,4 +111,12 @@ public class User {
         this.followerCount++;
     }
 
+    public void increaseFollwingCount() {
+        this.followingCount++;
+    }
+
+    public void decreaseFollwingCount() {
+        this.followingCount++;
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/climeet/climeet_backend/global/security/JwtTokenProvider.java
@@ -131,6 +131,30 @@ public class JwtTokenProvider {
         }
     }
 
+    public String generateTempToken(String socialId) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+            .setSubject(socialId)
+            .setIssuedAt(new Date(now))
+            .setExpiration(new Date(now + 1000 * 60 * 60))
+            .signWith(SignatureAlgorithm.HS256, getSecretKey())
+            .compact();
+    }
+
+    public String validateTempTokenAndGetSocialId(String token) {
+        try {
+            return Jwts.parser()
+                .setSigningKey(getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new GeneralException(ErrorStatus._EXPIRED_JWT);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+    }
+
 
 
 


### PR DESCRIPTION
## 요약
- 기존의 소셜로그인 과정에 오류가 발생할 여지가 있다고 생각해서 소셜로그인 과정을 리팩토링 하였습니다


## 상세 내용

- 기존 : 회원가입, 로그인 api를 하나로 사용(우리 서비스는 카카오, 네이버 등 Resource Server에서 제공하는 정보 말고도 추가 정보 입력이 필요한데, requestDto의 Null 여부로 회원가입/로그인 여부를 판단하였습니다)
- 개편 : Resource Server에서 받아온 SocialId 정보로 DB에 유저가 존재하는지 판단하고, 존재하면 기존과 같이 accessToken과 RefreshToken 제공. 존재하지 않는다면 회원가입(추가정보 입력)이 필요하므로 response의 refreshToken 값을 서버에서 발급한 유효기간 10분 정도의 임시 토큰으로 추가정보 입력 api를 호출 합니다. 프론트는 추가정보 입력 api를 한번 더 호출하고, 호출을 완료하면 회원가입이 완료되게 됩니다.
- 프론트에서는 리턴값의 ResponseType(SIGN_IN, SIGN_UP) 값으로 로그인인지, 추가 정보 입력인지 확인합니다
- 추가정보 입력에서 회원가입 과정이 완료되게 되는데, 로그인 api에서 이미 resource server에서 정보를 불러오는 api를 호출 하므로 회원가입 과정에서 중복 호출을 줄이기 위해 임시 토큰의 payload에는 socialId와 profileImgUrl이 들어가게 됩니다. 추가정보 입력 과정에서 token 파싱하여 사용합니다.
- lastLogined 필드를 추가하였습니다. 

## 테스트 확인 내용
-조건에 맞게 잘 작동됨을 확인하였습니다
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/5d6a73e0-7722-40b3-a300-29979b1a3f88)

## 질문 및 이외 사항

- JpaAuditing 어노테이션을 붙였는데, updatedAt이 작동하지 않는 이슈가 있습니다 ..! 우선 PR 올리고 좀 더 찾아보겠습니다
