### PR TITLE
[SPR-183] feat: 나의 운동한 암장 리스트 조회 엔드포인트 추가

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordController.java
@@ -197,4 +197,13 @@ public class ClimbingRecordController {
             @RequestParam int month) {
         return ResponseEntity.ok(climbingRecordService.getVisitedGymList(userId, year, month));
     }
+
+    @Operation(summary = "나의 운동한 암장 리스트 조회")
+    @GetMapping("/users/months/list")
+    public ResponseEntity<List<VisitedClimbingGym>> getVisitedGymList(
+        @CurrentUser User user,
+        @RequestParam int year,
+        @RequestParam int month) {
+        return ResponseEntity.ok(climbingRecordService.getVisitedGymList(user.getId(), year, month));
+    }
 }


### PR DESCRIPTION
## 요약
- 나의 운동한 암장 리스트 조회가 필요하다고 하여 controller에 추가하였습니다.
- 기존 특정 유저의 운동한 암장 리스트와 같은 service함수를 공유하며 오버로딩했습니다.
- 다른 점은 엔드포인트와 파라미터 차이입니다.
<img width="1166" alt="스크린샷 2024-06-06 오후 11 41 39" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/21b4082d-2e24-45e3-bb2a-653ab927af69">
<img width="718" alt="스크린샷 2024-06-06 오후 11 42 59" src="https://github.com/TheClimeet/climeet-spring/assets/100510247/dd0a94df-7045-433d-a817-106fb7f65715">

결과적으로 특정 유저에 로그인한 Id를 넣으면 정확히 동일하게 동작합니다.