### PR TITLE
[SPR-193] feat: 특정 유저가 올린 숏츠 조회 필터링 추가 - 인기순/최신순

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsController.java
@@ -103,8 +103,10 @@ public class ShortsController {
     public ResponseEntity<PageResponseDto<List<ShortsSimpleInfo>>> findShortsByUserId(@CurrentUser User user,
         @PathVariable Long uploaderId,
         @RequestParam int page,
-        @RequestParam int size) {
-        return ResponseEntity.ok(shortsService.findShortsByUserId(user, uploaderId, page, size));
+        @RequestParam int size,
+        @RequestParam SortType sortType
+        ) {
+        return ResponseEntity.ok(shortsService.findShortsByUserIdAndSortType(user, uploaderId, sortType, page, size));
     }
 
     @GetMapping("/shorts/my-shorts")

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsRepository.java
@@ -55,5 +55,7 @@ public interface ShortsRepository extends JpaRepository<Shorts, Long> {
 
     Slice<Shorts> findByUserAndShortsVisibilityInOrderByCreatedAtDesc(User uploader, List<ShortsVisibility> publicAndFollowersOnlyList, Pageable pageable);
 
+    Slice<Shorts> findByUserAndRankingNotAndShortsVisibilityInOrderByRankingAsc(User uploader, int rankingThreshold, List<ShortsVisibility> shortsVisibilities, Pageable pageable);
+
     Slice<Shorts> findByUserAndShortsVisibilityOrderByCreatedAtDesc(User uploader, ShortsVisibility shortsVisibility, Pageable pageable);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/SortType.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/SortType.java
@@ -1,0 +1,6 @@
+package com.climeet.climeet_backend.domain.shorts;
+
+public enum SortType {
+    LATEST,
+    POPULAR
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,5 +11,6 @@ spring:
 springdoc:
   swagger-ui:
     path: /
-    operations-sorter: alpha
+    operations-sorter: method
     display-request-duration: true
+    tags-sorter: alpha


### PR DESCRIPTION
## 요약

- 기존 단순히 생성일 기준으로 조회하던 api에 필터링을 추가했습니다.
<img width="415" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/117848386/b89ba47d-fe35-4971-a18f-826c02cc9ef0">

## 상세 내용

- enum타입추가, 쿼리파라미터에 추가
- 서비스에서 enum타입에 따라 shortsSlice를 다르게 가져옴
```java
public PageResponseDto<List<ShortsSimpleInfo>> findShortsByUserIdAndSortType(User user,
        Long uploaderId, SortType sortType,
        int page, int size) {
        Pageable pageable = PageRequest.of(page, size);

        Slice<Shorts> shortsSlice = null;

        User uploader = userRepository.findById(uploaderId)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));

        //최신순 조회
        if (sortType.equals(SortType.LATEST)) {
            shortsSlice = shortsRepository.findByUserAndShortsVisibilityInOrderByCreatedAtDesc(
                uploader,
                ShortsVisibility.getPublicAndFollowersOnlyList(), pageable);
        }
        //인기순 조회
        else {
            shortsSlice = shortsRepository.findByUserAndRankingNotAndShortsVisibilityInOrderByRankingAsc(
                uploader, rankingThreshold, ShortsVisibility.getPublicAndFollowersOnlyList(),
                pageable);
        }
        
       ...
```

- 람다 함수 수정(기존에는 최근 일주일동안의 쇼츠만 랭킹을 업데이트 시켜 기간에 상관없이 업데이트하도록 변경)


## 테스트 확인 내용

<img width="1404" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/117848386/11d486be-9f28-413c-889a-ad20e538e533">

최신순, 인기순 모두 확인했습니다!

## 질문 및 이외 사항

- 시험이 끝나자마자 스웨거에 api 담당자를 명시하는 작업을 하려합니다 => ios분들을 위해
- 각자 api을 수정할 일이 있을 때 수정하는 것보다 한명이 한번에 받아서 하는게 나아보이는데 어떠신가요(제 생각은 후자입니다,,,시험끝나구 제가 할게욥))
- 
