### PR TITLE
[SPR-194] FEAT : (기획변경) 관리자 없는 암장도 검색이 가능함에 따른 수정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -77,19 +77,21 @@ public class ClimbingGymResponseDto {
         private float averageRating;
         private int reviewCount;
         private Boolean isFollower;
+        private Boolean hasManager;
 
-        public static ClimbingGymDetailResponse toDTO(ClimbingGym climbingGym, Manager manager,
-            String gymBackGroundImageUrl, Boolean isFollower) {
+        public static ClimbingGymDetailResponse toDTO(ClimbingGym climbingGym,  Long followerCount, Long followingCount,
+            String gymBackGroundImageUrl, Boolean isFollower, Boolean hasManager) {
             return ClimbingGymDetailResponse.builder()
                 .gymId(climbingGym.getId())
                 .gymProfileImageUrl(climbingGym.getProfileImageUrl())
                 .gymBackGroundImageUrl(gymBackGroundImageUrl)
                 .gymName(climbingGym.getName())
-                .followerCount(manager.getFollowerCount())
-                .followingCount(manager.getFollowingCount())
+                .followerCount(followerCount)
+                .followingCount(followingCount)
                 .averageRating(climbingGym.getAverageRating())
                 .reviewCount(climbingGym.getReviewCount())
                 .isFollower(isFollower)
+                .hasManager(hasManager)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
@@ -54,11 +54,6 @@ public class ReviewService {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
-        // 관리자가 등록된 암장인지 확인
-        if (climbingGym.getManager() == null) {
-            throw new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM);
-        }
-
         Climber climber = climberRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
@@ -80,11 +75,6 @@ public class ReviewService {
 
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
-
-        // 관리자가 등록된 암장인지 확인
-        if (climbingGym.getManager() == null) {
-            throw new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM);
-        }
 
         Climber climber = climberRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
@@ -129,11 +119,6 @@ public class ReviewService {
 
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
-
-        // 관리자가 등록된 암장인지 확인
-        if (climbingGym.getManager() == null) {
-            throw new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM);
-        }
 
         Climber climber = climberRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));


### PR DESCRIPTION
## 요약
- 기획이 좀 변경되었기에 그에 따른 기능 수정입니다.
기존: 관리자가 등록된 암장만 정보 제공
변경: 관리자가 등록되지 않아도 일단 제공

→ 따라서 해당 부분의 변경사항을 적용하기 위해 매니저의 존재를 체크하고 
→ 있으면 기존 코드대로 사용, 없으면 매니저 관련 데이터를 default 값으로 반환하도록
의 형식으로 암장 상단 정보 가져오기 기능을 구성하였고,

리뷰 부분에서는 암장의 매니저가 등록되어있어야지만 리뷰에 접근할 수 있는 필터를 해두었었는데, 그 필터를 없애버렸습니다.

## 상세 내용
- 코드 변경점은 다음과 같습니다.
``` java
// 매니저가 없으면 null값을 넣고, toDTO를 실행하기 전에 체크
        Optional<Manager> optionalManager = managerRepository.findByClimbingGym(climbingGym);

        Boolean hasManager = optionalManager.isPresent();
        Boolean isFollow = false;
        Long followerCount = null;
        Long followingCount = null;

        if (hasManager) { // 매니저가 존재한다면 팔로우, 팔로잉 수를 업데이트
            Manager manager = optionalManager.get();
            followerCount = manager.getFollowerCount();
            followingCount = manager.getFollowingCount();

            // followRelationship이 있으면 true
            isFollow = followRelationshipRepository.findByFollowerIdAndFollowingId(user.getId(), manager.getId()).isPresent();
        }


        return ClimbingGymDetailResponse.toDTO(climbingGym, followerCount, followingCount, backgroundImage.getImgUrl(),isFollow, hasManager);
```

서비스 단만 보게되면 다음과 같습니다.
- hasManager는 관리자가 있는지 여부를 나타내며, 프론트측 요청에 따라 추가하였습니다.
- 관리자가 있어야지만 알 수 있는 정보인 팔로우 팔로잉이 없다면 null이 되도록 하였습니다.
- isFollow또한 값이 존재하다면 True가 되도록 수정하였는데, 이는 이전과 기능 차이는 없습니다.

- 리뷰 부분은 바뀐 부분이 정말로 너무 단순하기 때문에 패스하도록 하겠습니다.

## 테스트 확인 내용

- 아래와 같은 상단 정보에서의 응답을 받을 수 있습니다. (암장에 관리자가 없을 때 기준)
<img width="283" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/2522c942-b315-4ab5-b388-81ad4f11c41d">

- 리뷰 또한 모두 확인하였습니다.
- 추가로 현재 해당 기획 변경으로 인한 수정은 ClimbingGymService 와 Review 부분에서만 확인하였고, 앞으로 QA나 안드측의 요청이 있으면 추가적으로 바꾸도록 하겠습니다.

## 질문 및 이외 사항

- 약간 이제 클린 코드를 좀 공부해야하나 생각이 듭니다... 어떻게 코딩을 해야 깔끔하고, 야무지고, 까리할지 흠흠... 감사합니다.
