### PR TITLE
[SPR-192] 팔로우/팔로잉 오류 수정 및 조회 로직 변경

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climber/ClimberService.java
@@ -112,8 +112,8 @@ public class ClimberService {
             Manager manager = managerRepository.findByClimbingGym(optionalGym)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER_GYM));
             followRelationshipService.createFollowRelationship(manager, climber);
-            manager.increaseFollwerCount();
-            climber.increaseFollwingCount();
+            manager.increaseFollowerCount();
+            climber.increaseFollowingCount();
 
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -38,7 +38,10 @@ public class FollowRelationshipService {
             following.getId()).isPresent()){
             throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
         }
-        //manager.ifPresent(value -> value.getClimbingGym().thisWeekFollowCountUp());
+        if(following instanceof Manager){
+            Manager manager = (Manager)following;
+            manager.getClimbingGym().thisWeekFollowCountUp();
+        }
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, following);
         followRelationshipRepository.save(followRelationship);
         follower.increaseFollowingCount();

--- a/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/followrelationship/FollowRelationshipService.java
@@ -15,6 +15,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,27 +31,31 @@ public class FollowRelationshipService {
         return userRepository.findById(userId)
             .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_USER));
     }
+
+    @Transactional
     public void createFollowRelationship(User follower, User following) {
         if(followRelationshipRepository.findByFollowerIdAndFollowingId(follower.getId(),
             following.getId()).isPresent()){
             throw new GeneralException(ErrorStatus._EXIST_FOLLOW_RELATIONSHIP);
         }
-        Optional<Manager> manager = managerRepository.findById(following.getId());
-        manager.ifPresent(value -> value.getClimbingGym().thisWeekFollowCountUp());
+        //manager.ifPresent(value -> value.getClimbingGym().thisWeekFollowCountUp());
         FollowRelationship followRelationship = FollowRelationship.toEntity(follower, following);
         followRelationshipRepository.save(followRelationship);
-        follower.increaseFollwerCount();
+        follower.increaseFollowingCount();
+        following.increaseFollowerCount();
         //fcmNotificationService.sendSingleUser(following.getId(), NotificationType.NEW_FOLLOWER.getTitle(follower.getProfileName()), NotificationType.NEW_FOLLOWER.getMessage(follower.getProfileName()) );
 
     }
 
+    @Transactional
     public void deleteFollowRelationship(User following, User follower){
         FollowRelationship followRelationship = followRelationshipRepository.findByFollowerIdAndFollowingId(follower.getId(), following.getId())
             .orElseThrow(()-> new GeneralException(ErrorStatus._EMPTY_FOLLOW_RELATIONSHIP));
         Optional<Manager> manager = managerRepository.findById(following.getId());
         manager.ifPresent(value -> value.getClimbingGym().thisWeekFollowCountDown());
         followRelationshipRepository.deleteById(followRelationship.getId());
-        followRelationship.getFollower().decreaseFollwerCount();
+        followRelationship.getFollower().decreaseFollowingCount();
+        followRelationship.getFollowing().decreaseFollowerCount();
     }
 
     public User findManagerByGymID(Long gymId){

--- a/src/main/java/com/climeet/climeet_backend/domain/user/User.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/User.java
@@ -103,20 +103,20 @@ public class User {
         this.thisWeekTotalClimbingTime -= sec;
     }
 
-    public void increaseFollwerCount() {
+    public void increaseFollowerCount() {
         this.followerCount++;
     }
 
-    public void decreaseFollwerCount() {
-        this.followerCount++;
+    public void decreaseFollowerCount() {
+        this.followerCount--;
     }
 
-    public void increaseFollwingCount() {
+    public void increaseFollowingCount() {
         this.followingCount++;
     }
 
-    public void decreaseFollwingCount() {
-        this.followingCount++;
+    public void decreaseFollowingCount() {
+        this.followingCount--;
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -46,7 +46,7 @@ public class UserController {
     @GetMapping("/followers")
     @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
-    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
+    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam(required = false) Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollower(userId, currentUser, userCategory));
 
     }
@@ -54,7 +54,7 @@ public class UserController {
     @GetMapping("/followees")
     @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
-    public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
+    public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam(required = false) Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollowing(userId, currentUser, userCategory));
 
     }
@@ -135,4 +135,8 @@ public class UserController {
         userService.updateUserProfileName(currentUser, name);
         return ResponseEntity.ok("프로필 이름 업데이트 완료");
     }
+//    @PostMapping("/master-token")
+//    public String createMasterToken(){
+//        return userService.createMasterToken();
+//    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
     }
     @GetMapping("/followers")
-    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
+    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber\n\n 다른 사람의 팔로워를 조회하고 싶을 때 followingUserId를 채워서 보내고, 나 자신의 팔로워를 조회하고 싶을 때는 null로 보내면 됩니다.")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam(required = false) Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollower(userId, currentUser, userCategory));
@@ -52,7 +52,7 @@ public class UserController {
     }
 
     @GetMapping("/followees")
-    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
+    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber\n\n 다른 사람의 팔로잉를 조회하고 싶을 때 followingUserId를 채워서 보내고, 나 자신의 팔로잉를 조회하고 싶을 때는 null로 보내면 됩니다.")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam(required = false) Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollowing(userId, currentUser, userCategory));

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserService.java
@@ -70,6 +70,9 @@ public class UserService {
 
     public List<UserFollowDetailInfo> getFollower(Long targetUserId, User currentUser,
         String userCategory) {
+        if(targetUserId==null){ //자기 자신의 팔로워를 조회할 때
+            targetUserId = currentUser.getId();
+        }
         userRepository.findById(targetUserId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
         List<FollowRelationship> targetUserFollowerList = followRelationshipRepository.findByFollowingId(
@@ -88,12 +91,12 @@ public class UserService {
                         followRelationship.getFollower().getId()).isPresent()) {
                         currentUserRelation = true;
                     }
-                    return UserFollowDetailInfo.toDTO(followRelationship.getFollower(),
-                        currentUserRelation);
+                    User follower = followRelationship.getFollower();
+                    return UserFollowDetailInfo.toDTO(follower.getId(), follower.getProfileName(), follower.getProfileName(), follower.getFollowerCount(), follower.getFollowingCount(), currentUserRelation);
                 }).toList();
 
         }
-        if (userCategory.equals("Manager")) {
+        if (userCategory.equals("Manager")) { //암장 정보 리턴
             userFollowDetailResponseList = targetUserFollowerList.stream()
                 .filter(followRelationship -> followRelationship.getFollower() instanceof Manager)
                 .map(followRelationship -> {
@@ -103,8 +106,9 @@ public class UserService {
                         followRelationship.getFollower().getId()).isPresent()) {
                         currentUserRelation = true;
                     }
-                    return UserFollowDetailInfo.toDTO(followRelationship.getFollower(),
-                        currentUserRelation);
+                    ClimbingGym climbingGym= ((Manager) followRelationship.getFollower()).getClimbingGym();
+                    User follower = followRelationship.getFollower();
+                    return UserFollowDetailInfo.toDTO(climbingGym.getId(), climbingGym.getName(),climbingGym.getProfileImageUrl(), follower.getFollowerCount(), follower.getFollowingCount(), currentUserRelation);
                 }).toList();
         }
 
@@ -113,6 +117,9 @@ public class UserService {
 
     public List<UserFollowDetailInfo> getFollowing(Long targetUserId, User currentUser,
         String userCategory) {
+        if(targetUserId==null){ //자기 자신의 팔로워를 조회할 때
+            targetUserId = currentUser.getId();
+        }
         userRepository.findById(targetUserId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
         List<FollowRelationship> targetUserFollowerList = followRelationshipRepository.findByFollowerId(
@@ -131,8 +138,8 @@ public class UserService {
                         followRelationship.getFollowing().getId()).isPresent()) {
                         currentUserRelation = true;
                     }
-                    return UserFollowDetailInfo.toDTO(followRelationship.getFollowing(),
-                        currentUserRelation);
+                    User following = followRelationship.getFollowing();
+                    return UserFollowDetailInfo.toDTO(following.getId(), following.getProfileName(), following.getProfileName(), following.getFollowerCount(), following.getFollowingCount(), currentUserRelation);
                 }).toList();
 
         }
@@ -146,8 +153,9 @@ public class UserService {
                         followRelationship.getFollowing().getId()).isPresent()) {
                         currentUserRelation = true;
                     }
-                    return UserFollowDetailInfo.toDTO(followRelationship.getFollowing(),
-                        currentUserRelation);
+                    ClimbingGym climbingGym= ((Manager) followRelationship.getFollowing()).getClimbingGym();
+                    User following = followRelationship.getFollowing();
+                    return UserFollowDetailInfo.toDTO(climbingGym.getId(), climbingGym.getName(),climbingGym.getProfileImageUrl(), following.getFollowerCount(), following.getFollowingCount(), currentUserRelation);
                 }).toList();
         }
 
@@ -277,7 +285,7 @@ public class UserService {
         }
 
 
-        return UserFollowDetailInfo.toDTO(user, status);
+        return UserFollowDetailInfo.toDTO(user.getId(), user.getProfileName(), user.getProfileName(), user.getFollowerCount(), user.getFollowingCount(), status);
 
     }
 
@@ -302,6 +310,10 @@ public class UserService {
     public boolean checkProfileNameDuplication(String name) {
         return userRepository.findByprofileName(name).isPresent();
     }
+
+//    public String createMasterToken(){
+//        return jwtTokenProvider.createToken("1+master", 0);
+//    }
 
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/dto/UserResponseDto.java
@@ -58,13 +58,13 @@ public class UserResponseDto {
         private Long followingCount;
         private Boolean isFollower;
 
-        public static UserFollowDetailInfo toDTO(User follower, Boolean followStatus){
+        public static UserFollowDetailInfo toDTO(Long id, String name, String profileUrl, Long followerCount, Long followingCount, Boolean followStatus){
             return UserFollowDetailInfo.builder()
-                .userId(follower.getId())
-                .userName(follower.getProfileName())
-                .userProfileUrl(follower.getProfileImageUrl())
-                .followerCount(follower.getFollowerCount())
-                .followingCount(follower.getFollowingCount())
+                .userId(id)
+                .userName(name)
+                .userProfileUrl(profileUrl)
+                .followerCount(followerCount)
+                .followingCount(followingCount)
                 .isFollower(followStatus)
                 .build();
         }


### PR DESCRIPTION
## 요약

- 팔로우/팔로잉 수가 변하지 않는다는 제보를 듣고 오류를 수정하였습니다.
- 기존 팔로우 관계는 유저 끼리만 성립되기 때문에, 매니저와 유저 간의 팔로우가 가능하고, 조회도 매니저 정보를 조회 했는데, 기획이 변경 되어서 매니저 정보를 조회하는 것이 아닌 암장 정보를 조회할 수 있도록 Dto와 코드를 약간 수정하였습니다. 

## 상세 내용

```java
@GetMapping("/followers")
    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
    @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
    public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam(required = false) Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
        return ResponseEntity.ok(userService.getFollower(userId, currentUser, userCategory));

    }
```
조회 시 requstParam이 원래 필수 항목이었는데, required=false로 설정하여 만약 현재 유저(나)의 팔로워/팔로잉을 조회하고 싶을 때는 입력하지 않도록 서비스 로직과 컨트롤러를 변경하였습니다. 

## 테스트 확인 내용
Manager를 입력하여 조회한 경우 암장의 정보가 잘 나오는 것을 확인할 수 있습니다. 
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/a33eb1ae-7333-4b72-b655-9ce048ab73fb)


## 질문 및 이외 사항

