### PR TITLE
[SPR-195] 공지사항 좋아요 관련 API 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/board/BoardController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/BoardController.java
@@ -4,13 +4,16 @@ import com.climeet.climeet_backend.domain.board.dto.boardRequestDto.PostBoardReq
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardDetailInfo;
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardRetoolSimpleInfo;
 import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardSimpleInfo;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,7 +46,8 @@ public class BoardController {
     @GetMapping("/boards/{boardId}")
     @SwaggerApiError({ErrorStatus._EMPTY_USER, ErrorStatus._BOARD_NOT_FOUND})
     @Operation(summary = "특정 공지사항 조회")
-    public ResponseEntity<BoardDetailInfo> findBoardById(@PathVariable Long boardId){
-        return ResponseEntity.ok(boardService.findBoardById(boardId));
+    public ResponseEntity<BoardDetailInfo> findBoardById(@CurrentUser User user, @PathVariable Long boardId){
+        return ResponseEntity.ok(boardService.findBoardById(boardId, user));
     }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/board/BoardService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/BoardService.java
@@ -7,6 +7,8 @@ import com.climeet.climeet_backend.domain.board.dto.boardResponseDto.BoardSimple
 import com.climeet.climeet_backend.domain.boardImage.BoardImage;
 import com.climeet.climeet_backend.domain.boardImage.BoardImageRepository;
 import com.climeet.climeet_backend.domain.boardImage.BoardImageService;
+import com.climeet.climeet_backend.domain.boardlike.BoardLike;
+import com.climeet.climeet_backend.domain.boardlike.BoardLikeRepository;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.domain.user.UserRepository;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -24,6 +26,7 @@ public class BoardService {
     private final UserRepository userRepository;
     private final BoardImageService boardImageService;
     private final BoardImageRepository boardImageRepository;
+    private final BoardLikeRepository boardLikeRepository;
     public static final Long CLIMEET_OFFICIAL_ACCOUNT = 1L;
 
 
@@ -65,13 +68,17 @@ public class BoardService {
             .toList();
     }
 
-    public BoardDetailInfo findBoardById(Long boardId) {
+    public BoardDetailInfo findBoardById(Long boardId, User user) {
         User climeetOfficialAccount = userRepository.findById(CLIMEET_OFFICIAL_ACCOUNT)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_USER));
         Board board = boardRepository.findById(boardId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._BOARD_NOT_FOUND));
+        boolean likeStatus = false;
+        if(boardLikeRepository.findByUserAndBoard(user, board).isPresent()){
+            likeStatus = true;
+        }
         return BoardDetailInfo.toDTO(board, boardImageRepository
             .findAllByBoardId(boardId).stream().map(BoardImage::getImageUrl).toList(),
-            climeetOfficialAccount);
+            climeetOfficialAccount, likeStatus);
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/board/dto/boardResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/board/dto/boardResponseDto.java
@@ -75,8 +75,9 @@ public class boardResponseDto {
         private String content;
         private int likeCount;
         private List<String> imageList;
+        private Boolean likeStatus;
 
-        public static BoardDetailInfo toDTO(Board board, List<String> boardImageList, User user) {
+        public static BoardDetailInfo toDTO(Board board, List<String> boardImageList, User user, Boolean likeStatus) {
             return BoardDetailInfo.builder()
                 .boardId(board.getId())
                 .title(board.getTitle())
@@ -88,6 +89,7 @@ public class boardResponseDto {
                 .content(board.getContent())
                 .likeCount(board.getLikeCount())
                 .imageList(boardImageList)
+                .likeStatus(likeStatus)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLike.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLike.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Builder
 public class BoardLike extends BaseTimeEntity {
 
     @Id
@@ -29,4 +31,11 @@ public class BoardLike extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Board board;
+
+    public static BoardLike toEntity(User user, Board board){
+        return BoardLike.builder()
+            .user(user)
+            .board(board)
+            .build();
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeController.java
@@ -1,0 +1,31 @@
+package com.climeet.climeet_backend.domain.boardlike;
+
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.security.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BoardLikeController {
+    private final BoardLikeService boardLikeService;
+
+    @PatchMapping("/boards/{boardId}/like")
+    @Operation(summary = "특정 공지사항 좋아요")
+    public ResponseEntity<String> likeNotice(@CurrentUser User user, @PathVariable Long boardId){
+        boardLikeService.boardLike(user, boardId);
+        return ResponseEntity.ok("좋아요 완료");
+    }
+
+    @PatchMapping("/boards/{boardId}/unlike")
+    @Operation(summary = "특정 공지사항 좋아요 취소")
+    public ResponseEntity<String> unLikeNotice(@CurrentUser User user, @PathVariable Long boardId){
+        boardLikeService.boardUnLike(user, boardId);
+        return ResponseEntity.ok("좋아요 취소 완료");
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeController.java
@@ -1,7 +1,9 @@
 package com.climeet.climeet_backend.domain.boardlike;
 
 import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
+import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,7 @@ public class BoardLikeController {
     private final BoardLikeService boardLikeService;
 
     @PatchMapping("/boards/{boardId}/like")
+    @SwaggerApiError({ErrorStatus._BOARD_NOT_FOUND, ErrorStatus._EXIST_BOARD_LIKE})
     @Operation(summary = "특정 공지사항 좋아요")
     public ResponseEntity<String> likeNotice(@CurrentUser User user, @PathVariable Long boardId){
         boardLikeService.boardLike(user, boardId);
@@ -22,6 +25,7 @@ public class BoardLikeController {
     }
 
     @PatchMapping("/boards/{boardId}/unlike")
+    @SwaggerApiError({ErrorStatus._BOARD_NOT_FOUND, ErrorStatus._UNEXIST_BOARD_LIKE})
     @Operation(summary = "특정 공지사항 좋아요 취소")
     public ResponseEntity<String> unLikeNotice(@CurrentUser User user, @PathVariable Long boardId){
         boardLikeService.boardUnLike(user, boardId);

--- a/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeRepository.java
@@ -1,0 +1,10 @@
+package com.climeet.climeet_backend.domain.boardlike;
+
+import com.climeet.climeet_backend.domain.board.Board;
+import com.climeet.climeet_backend.domain.user.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    Optional<BoardLike> findByUserAndBoard(User user, Board board);
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/boardlike/BoardLikeService.java
@@ -1,0 +1,38 @@
+package com.climeet.climeet_backend.domain.boardlike;
+
+import com.climeet.climeet_backend.domain.board.Board;
+import com.climeet.climeet_backend.domain.board.BoardRepository;
+import com.climeet.climeet_backend.domain.user.User;
+import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.response.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardLikeService {
+    private final BoardLikeRepository boardLikeRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public void boardLike(User user, Long boardId){
+        Board board = boardRepository.findById(boardId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._BOARD_NOT_FOUND));
+        if(boardLikeRepository.findByUserAndBoard(user, board).isPresent()){
+            throw new GeneralException(ErrorStatus._EXIST_BOARD_LIKE);
+        }
+        BoardLike boardLike = BoardLike.toEntity(user, board);
+        boardLikeRepository.save(boardLike);
+    }
+
+    @Transactional
+    public void boardUnLike(User user, Long boardId){
+        Board board = boardRepository.findById(boardId)
+            .orElseThrow(()-> new GeneralException(ErrorStatus._BOARD_NOT_FOUND));
+        BoardLike boardLike = boardLikeRepository.findByUserAndBoard(user, board)
+                .orElseThrow(()-> new GeneralException(ErrorStatus._UNEXIST_BOARD_LIKE));
+        boardLikeRepository.delete(boardLike);
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
     }
     @GetMapping("/followers")
-    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber\n\n 다른 사람의 팔로워를 조회하고 싶을 때 followingUserId를 채워서 보내고, 나 자신의 팔로워를 조회하고 싶을 때는 null로 보내면 됩니다.")
+    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollower(userId, currentUser, userCategory));
@@ -52,7 +52,7 @@ public class UserController {
     }
 
     @GetMapping("/followees")
-    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber\n\n 다른 사람의 팔로잉를 조회하고 싶을 때 followingUserId를 채워서 보내고, 나 자신의 팔로잉를 조회하고 싶을 때는 null로 보내면 됩니다.")
+    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollowing(userId, currentUser, userCategory));

--- a/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/user/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
     }
     @GetMapping("/followers")
-    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber")
+    @Operation(summary = "특정 유저 팔로워 조회", description = "**userCategory** : Manager OR Climber\n\n 다른 사람의 팔로워를 조회하고 싶을 때 followingUserId를 채워서 보내고, 나 자신의 팔로워를 조회하고 싶을 때는 null로 보내면 됩니다.")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollower(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollower(userId, currentUser, userCategory));
@@ -52,7 +52,7 @@ public class UserController {
     }
 
     @GetMapping("/followees")
-    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber")
+    @Operation(summary = "특정 유저 팔로잉 조회", description = "**userCategory** : Manager OR Climber\n\n 다른 사람의 팔로잉를 조회하고 싶을 때 followingUserId를 채워서 보내고, 나 자신의 팔로잉를 조회하고 싶을 때는 null로 보내면 됩니다.")
     @SwaggerApiError({ErrorStatus._BAD_REQUEST, ErrorStatus._EMPTY_USER})
     public ResponseEntity<List<UserFollowDetailInfo>> getFollowing(@RequestParam Long userId, @RequestParam String userCategory, @CurrentUser User currentUser){
         return ResponseEntity.ok(userService.getFollowing(userId, currentUser, userCategory));

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -104,7 +104,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _FAIL_TO_SEND_NOTIFICATION(HttpStatus.CONFLICT, "NOTIFICATION_001", "알림 전송 실패하였습니다"),
 
     //공지사항 관련
-    _BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "존재하지 않는 공지사항입니다.");
+    _BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "존재하지 않는 공지사항입니다."),
+    _EXIST_BOARD_LIKE(HttpStatus.CONFLICT, "BOARD_002", "이미 좋아요를 누른 공지사항입니다."),
+    _UNEXIST_BOARD_LIKE(HttpStatus.CONFLICT, "BOARD_003", "좋아요를 취소할 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;


### PR DESCRIPTION
## 요약
- 공지사항 좋아요 관련 API를 구현하였습니다
- 기존 공지사항 상세 조회에서 CurrentUser가 좋아요를 눌렀는지 확인할 수 있도록 dto를 수정하였습니다.

## 상세 내용
- 기존 /boards/{boardId} api에 likeStatus 컬럼을 추가하였습니다.
![image](https://github.com/TheClimeet/climeet-spring/assets/85860891/e4f7917f-a62c-46a8-9141-5a3dbda4a2ff)

- 공지사항 좋아요 추가/취소 api를 만들었습니다. 각각 BoardLike 컬럼을 추가/삭제 합니다.

## 테스트 확인 내용



## 질문 및 이외 사항

