### PR TITLE
[SPR-202] feat: 관리자가 속한 암장의 id 값을 반환하는 API 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -55,7 +55,6 @@ public class ManagerController {
 
     @GetMapping("/check-id/{loginId}")
     @Operation(summary = "관리자 ID 중복 확인", description = "**이미 존재하는 ID** : false \n\n **사용 가능한 ID** : true")
-    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER})
     public ResponseEntity<Boolean> checkLoginId(@PathVariable String loginId){
         boolean isDuplicated = !managerService.checkLoginDuplication(loginId);
         return ResponseEntity.ok(isDuplicated);
@@ -64,6 +63,7 @@ public class ManagerController {
 
     @GetMapping("/gym-id")
     @Operation(summary = "관리자 관리 암장 확인. - 205 [무빗]", description = "관리자의 소속 암장 id를 확인합니다.")
+    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER})
     public ResponseEntity<Long> getClimbingGymIdOfManager(@CurrentUser User user){
         return ResponseEntity.ok(managerService.getClimbingGymIdOfManager(user));
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -55,6 +55,7 @@ public class ManagerController {
 
     @GetMapping("/check-id/{loginId}")
     @Operation(summary = "관리자 ID 중복 확인", description = "**이미 존재하는 ID** : false \n\n **사용 가능한 ID** : true")
+    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER})
     public ResponseEntity<Boolean> checkLoginId(@PathVariable String loginId){
         boolean isDuplicated = !managerService.checkLoginDuplication(loginId);
         return ResponseEntity.ok(isDuplicated);

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerController.java
@@ -3,7 +3,9 @@ package com.climeet.climeet_backend.domain.manager;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateAccessTokenRequest;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateManagerRequest;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerResponseDto.ManagerSimpleInfo;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
+import com.climeet.climeet_backend.global.security.CurrentUser;
 import com.climeet.climeet_backend.global.utils.SwaggerApiError;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -57,6 +59,12 @@ public class ManagerController {
         boolean isDuplicated = !managerService.checkLoginDuplication(loginId);
         return ResponseEntity.ok(isDuplicated);
 
+    }
+
+    @GetMapping("/gym-id")
+    @Operation(summary = "관리자 관리 암장 확인. - 205 [무빗]", description = "관리자의 소속 암장 id를 확인합니다.")
+    public ResponseEntity<Long> getClimbingGymIdOfManager(@CurrentUser User user){
+        return ResponseEntity.ok(managerService.getClimbingGymIdOfManager(user));
     }
 
 

--- a/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/manager/ManagerService.java
@@ -11,6 +11,7 @@ import com.climeet.climeet_backend.domain.climbinggymimage.ClimbingGymBackground
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateAccessTokenRequest;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerRequestDto.CreateManagerRequest;
 import com.climeet.climeet_backend.domain.manager.dto.ManagerResponseDto.ManagerSimpleInfo;
+import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.security.JwtTokenProvider;
@@ -112,6 +113,12 @@ public class ManagerService {
     @Transactional
     public boolean checkLoginDuplication(String loginId){
         return managerRepository.findByLoginId(loginId).isPresent();
+    }
+
+    public Long getClimbingGymIdOfManager(User user){
+        Manager manager = managerRepository.findById(user.getId())
+            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
+        return manager.getClimbingGym().getId();
     }
 
 


### PR DESCRIPTION
## 요약

- 정말정말 간단한 API 추가했습니다.
- 현재 관리자가 속한 암장의 id를 반환하는 api가 없다는 것을 깨달아서... 이제야 만듭니다.

## 상세 내용

- 몇줄 없으니 파일 변경사항 확인 부탁드립니다. (대략 10줄)
- 그 API 담당자 이름 넣는것도 일단 추가 했습니다. 나중에 컨트롤러에 번호 안넣게 된다고 하면 바꿔서 머지하겠습니다.
- 예외처리로 매니저가 아닐 때를 추가했습니다

## 테스트 확인 내용

- 단순하게 정수만 반환하게 하였기에 다음과 같은 응답을 보입니다.
<img width="1272" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/e74941f7-b788-4ab7-8374-525d0a9e0a0d">


## 질문 및 이외 사항
- 감사합니다.
