### PR TITLE
[SPR-203] feat: 암장 배경, 프로필 이미지를 Multipart에서 Url로 변경

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -26,9 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "ClimbingGym", description = "암장 관련 API")
 @RestController
@@ -93,16 +91,18 @@ public class ClimbingGymController {
     @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._EMPTY_BACKGROUND_IMAGE})
     @PatchMapping("/background-image")
     public ResponseEntity<String> changeClimbingGymBackgroundImage(@CurrentUser User user,
-        @RequestPart MultipartFile image) {
-        return ResponseEntity.ok(climbingGymService.changeClimbingGymBackgroundImage(user, image));
+        @RequestBody String imageUrl) {
+        climbingGymService.changeClimbingGymBackgroundImage(user, imageUrl);
+        return ResponseEntity.ok("암장 배경사진 변경을 완료했습니다.");
     }
 
     @Operation(summary = "암장 프로필 이미지 변경 (1개만 등록 가능)")
     @SwaggerApiError({ErrorStatus._EMPTY_MANAGER})
     @PatchMapping("/profile-image")
     public ResponseEntity<String> changeClimbingGymProfileImage(@CurrentUser User user,
-        @RequestPart MultipartFile image) {
-        return ResponseEntity.ok(climbingGymService.changeClimbingGymProfileImage(user, image));
+        @RequestBody String imageUrl) {
+        climbingGymService.changeClimbingGymProfileImage(user, imageUrl);
+        return ResponseEntity.ok("관리자 프로필 이미지 변경을 완료했습니다.");
     }
 
     @Operation(summary = "암장 제공 서비스 수정", description = "**Enum 설명**\n\n**ServiceBitmask** :  샤워\\_시설,  샤워\\_용품,  수건\\_제공,  간이\\_세면대,  초크\\_대여,  암벽화\\_대여,  삼각대\\_대여,  운동복\\_대여")

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -42,7 +42,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -228,7 +227,7 @@ public class ClimbingGymService {
             .toList();
     }
 
-    public String changeClimbingGymBackgroundImage(User user, MultipartFile image) {
+    public void changeClimbingGymBackgroundImage(User user, String imageUrl) {
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
@@ -236,21 +235,16 @@ public class ClimbingGymService {
                 manager.getClimbingGym())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_BACKGROUND_IMAGE));
 
-        String backgroundImageUrl = s3Service.uploadFile(image).getImgUrl();
-        climbingGymBackgroundImage.changeImgUrl(backgroundImageUrl);
+        climbingGymBackgroundImage.changeImgUrl(imageUrl);
         climbingGymBackgroundImageRepository.save(climbingGymBackgroundImage);
-
-        return backgroundImageUrl;
     }
 
-    public String changeClimbingGymProfileImage(User user, MultipartFile image) {
+    public void changeClimbingGymProfileImage(User user, String imageUrl) {
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
         ClimbingGym climbingGym = manager.getClimbingGym();
-        String profileImageUrl = s3Service.uploadFile(image).getImgUrl();
-        climbingGym.updateProfileImageUrl(profileImageUrl);
+        climbingGym.updateProfileImageUrl(imageUrl);
         climbingGymRepository.save(climbingGym);
-        return profileImageUrl;
     }
 
     public void updateClimbingGymService(User user,


### PR DESCRIPTION
## 요약

- 또 간단간단쓰입니다.
- 암장 배경이랑 프로필이 기존에는 Multipart로 구성되어있어서 이미지로 프론트에서 받아오고, 서버에서 업로드 후 저장을 진행했는데,
- 노아와 얘기를 했을 때 프론트에서 따로 업로드 하고, url을 서버로 보내주는걸로 통일하자! 라고 하여 바꿨습니다.

## 상세 내용

- 정말 간단합니다. 진짜 수정한거 별로 없어요.ㅎㅎ 변경사항으로 확인 부탁합니다!
- 변경점은 s3 업로드 부분을 삭제하고
- 프론트에서 보내준 url로 교체하는 부분입니다,.

## 테스트 확인 내용
<img width="332" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/1c5d3295-54a3-4912-b3c5-bc534df9938f">
정상적으로 잘 바뀝니다.
<img width="820" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/dcf33c2f-a46a-481a-8e16-59e4dc263678">
업로드 후 db에서 url 확인 후 직접 링크를 들어가보기까지 했습니다.

## 질문 및 이외 사항
- 감사합니다.
