### PR TITLE
[SPR-204] feat: 암장 관리자도 특정 암장 리뷰 조회 가능하도록 변경

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    Optional<Review> findByClimbingGymAndClimber(ClimbingGym climbingGym, Climber climber);
+    Optional<Review> findByClimbingGymAndClimberId(ClimbingGym climbingGym, Long userId);
 
-    Page<Review> findByClimbingGymAndClimberIsNotOrderByUpdatedAtDesc(ClimbingGym climbingGym,
-        Climber climber, Pageable pageable);
+    Page<Review> findByClimbingGymAndClimberIdIsNotOrderByUpdatedAtDesc(ClimbingGym climbingGym,
+        Long userId, Pageable pageable);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/review/ReviewService.java
@@ -58,8 +58,8 @@ public class ReviewService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
         // 이미 작성된 리뷰가 있는지 확인 (1명의 유저는 1개의 암장에 1개의 리뷰만 가능)
-        Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimber(
-            climbingGym, climber);
+        Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimberId(
+            climbingGym, user.getId());
         if (optionalReview.isPresent()) {
             throw new GeneralException(ErrorStatus._REVIEW_EXIST);
         }
@@ -76,14 +76,11 @@ public class ReviewService {
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
 
-        Climber climber = climberRepository.findById(user.getId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
-
         ReviewSummaryResponse reviewSummaryResponse = null;
         if (page == FIRST_PAGE) {
             // 사용자 리뷰가 있으면 가져오고, 없으면 null을 myReview에 넣음
-            Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimber(
-                climbingGym, climber);
+            Optional<Review> optionalReview = reviewRepository.findByClimbingGymAndClimberId(
+                climbingGym, user.getId());
             ReviewDetailResponse myReview = null;
             if (optionalReview.isPresent()) {
                 myReview = ReviewDetailResponse.toDTO(optionalReview.get());
@@ -94,9 +91,9 @@ public class ReviewService {
 
         Pageable pageable = PageRequest.of(page, size);
 
-        Slice<Review> reviewSlice = reviewRepository.findByClimbingGymAndClimberIsNotOrderByUpdatedAtDesc(
+        Slice<Review> reviewSlice = reviewRepository.findByClimbingGymAndClimberIdIsNotOrderByUpdatedAtDesc(
             climbingGym,
-            climber, pageable);
+            user.getId(), pageable);
 
         List<ReviewDetailResponse> reviewList = reviewSlice.stream()
             .map(review -> ReviewDetailResponse.toDTO(review))
@@ -124,8 +121,8 @@ public class ReviewService {
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MEMBER));
 
         // 리뷰 데이터 불러오기
-        Review review = reviewRepository.findByClimbingGymAndClimber(
-                climbingGym, climber)
+        Review review = reviewRepository.findByClimbingGymAndClimberId(
+                climbingGym, user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_REVIEW));
 
         // 리뷰 추가로 인한 평균 리뷰 갱신


### PR DESCRIPTION
## 요약

- 매우매우간단
- 암장 관리자는 못보도록 예외처리를 해뒀는데, 조회는 가능해야할거같아서 변경했습니다.
- 암장 관리자도 다른 암장에 리뷰 남길 수 있도록 하려고 했는데 그러려면 테이블 구조도 좀 변경해야해서 일단 조회만 해두었고, 나중에 기능이 필요하다고 생각되면 테이블 구조도 바꾸면서 적용하겠습니다.

## 상세 내용

- 조건 부분만 바뀌고, Repository 부분에서 climber로 검색되던걸 climberId로 검색되도록 바꾸기만 했습니다.
- climberId로 검색되도록 바꾼 이유는, manager는 climber테이블에 같이 존재할 수 없지만, user테이블의 id가 manager와 climber에 동시에 기본키로 참조되는 속성이기 때문에 id로 검색한다면 userid로 검색하는것과 같아진다고 생각했기 때문입니다.
- 따라서 기존 climber에서 climberid로 검색하도록 변경한 부분을 제외하고는 큰 차이는 없습니다!

## 테스트 확인 내용
- 조회기능 정상 작동 (클라이머)
<img width="422" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/fefa3486-533d-49b7-aafd-39b9fb609898">
- 리뷰 생성기능 정상 작동(클라이머)
<img width="693" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/e9f1fa5f-189c-47b9-b730-50bd5efa9186">
- 리뷰 업데이트 기능 정상 작동(클라이머)
<img width="667" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/bf04f96c-936d-43d6-9bf7-b6bbf1c20a2e">
- 조회기능 정상 작동(관리자)
<img width="428" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/84446c73-269a-41f1-9059-8dd5c430e063">
- 생성기능 정상 예외처리(관리자)
<img width="685" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/82811f0c-75ac-4786-86e9-62e09ce0b04e">
- 수정기능 정상 예외처리(관리자) 
<img width="678" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/cb7fa587-7c18-451d-b65c-f8097438a01e">

## 질문 및 이외 사항
- 감사합니다.
