### PR TITLE
[SPR-184] feat: 루트 버전 추가 API 전체 수정, 루트 버전 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImage.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImage.java
@@ -27,13 +27,23 @@ public class ClimbingGymLayoutImage extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ClimbingGym climbingGym;
+
+    private int floor;
+
     private String imgUrl;
 
-    public static ClimbingGymLayoutImage toEntity(String imgUrl) {
+    public static ClimbingGymLayoutImage toEntity(ClimbingGym climbingGym, int floor, String imgUrl) {
         return ClimbingGymLayoutImage.builder()
+            .climbingGym(climbingGym)
+            .floor(floor)
             .imgUrl(imgUrl)
             .build();
+    }
+
+    public void changeImgUrl(String imgUrl){
+        this.imgUrl = imgUrl;
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImageRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/ClimbingGymLayoutImageRepository.java
@@ -1,9 +1,13 @@
 package com.climeet.climeet_backend.domain.climbinggymlayoutimage;
 
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClimbingGymLayoutImageRepository extends JpaRepository<ClimbingGymLayoutImage, Long>{
 
+    List<ClimbingGymLayoutImage> findByIdIn(List<Long> layoutImgIdList);
+    List<ClimbingGymLayoutImage> findClimbingGymLayoutImageByClimbingGym(ClimbingGym climbingGym);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/dto/ClimbingGymLayoutImageResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/dto/ClimbingGymLayoutImageResponseDto.java
@@ -1,0 +1,24 @@
+package com.climeet.climeet_backend.domain.climbinggymlayoutimage.dto;
+
+import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ClimbingGymLayoutImageResponseDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LayoutImgListDetail {
+        private Long id;
+        private String imgUrl;
+        private int floor;
+        public static LayoutImgListDetail toDto(ClimbingGymLayoutImage climbingGymLayoutImage){
+            return LayoutImgListDetail.builder()
+                .id(climbingGymLayoutImage.getId())
+                .imgUrl(climbingGymLayoutImage.getImgUrl())
+                .floor(climbingGymLayoutImage.getFloor())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
@@ -57,4 +57,10 @@ public class DifficultyMapping extends BaseTimeEntity {
             .gymDifficultyColor(gymDifficulty.getColorCode())
             .build();
     }
+
+    public void changeDifficultyMapping(ClimeetDifficulty climeetDifficulty){
+        this.climeetDifficultyName = climeetDifficulty.getStringValue();
+        this.difficulty = climeetDifficulty.getIntValue();
+    }
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingController.java
@@ -1,6 +1,5 @@
 package com.climeet.climeet_backend.domain.difficultymapping;
 
-import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
@@ -14,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,17 +25,7 @@ public class DifficultyMappingController {
 
     private final DifficultyMappingService difficultyMappingService;
 
-    @Operation(summary = "클밋, 암장 난이도 매핑 생성 - 1501 [무빗]")
-    @SwaggerApiError({ErrorStatus._INVALID_DIFFICULTY, ErrorStatus._EMPTY_MANAGER})
-    @PostMapping("/difficulty")
-    public ResponseEntity<List<Long>> createDifficultyMapping(@CurrentUser User user,
-        @RequestBody CreateDifficultyMappingRequest createDifficultyMappingRequest
-    ) {
-        return ResponseEntity.ok(
-            difficultyMappingService.createDifficultyMapping(user, createDifficultyMappingRequest));
-    }
-
-    @Operation(summary = "클밋, 암장 난이도 매핑 조회 - 1502 [무빗]")
+    @Operation(summary = "클밋, 암장 난이도 매핑 조회 - 1501 [무빗]")
     @SwaggerApiError({ErrorStatus._INVALID_DIFFICULTY, ErrorStatus._EMPTY_CLIMBING_GYM,
         ErrorStatus._EMPTY_DIFFICULTY_LIST})
     @GetMapping("/{gymId}/difficulty")
@@ -48,7 +35,7 @@ public class DifficultyMappingController {
         return ResponseEntity.ok(difficultyMappingService.getDifficultyMapping(gymId));
     }
 
-    @Operation(summary = "암장 색 코드 목록 조회 - 1503 [무빗]")
+    @Operation(summary = "암장 색 코드 목록 조회 - 1502 [무빗]")
     @SwaggerApiError({})
     @GetMapping("/difficulty/color")
     public ResponseEntity<Map<String, String>> getGymDifficultyColorList(

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DifficultyMappingRepository extends JpaRepository<DifficultyMapping, Long> {
 
+    List<DifficultyMapping> findByIdIn(List<Long> difficultyIdList);
+
     DifficultyMapping findByClimbingGymAndDifficulty(ClimbingGym climbingGym, int difficulty);
 
     DifficultyMapping findByClimbingGymAndGymDifficultyName(ClimbingGym climbingGym, String gymDifficultyName);

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingService.java
@@ -2,13 +2,8 @@ package com.climeet.climeet_backend.domain.difficultymapping;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
-import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
-import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
 import com.climeet.climeet_backend.domain.difficultymapping.enums.GymDifficulty;
-import com.climeet.climeet_backend.domain.manager.Manager;
-import com.climeet.climeet_backend.domain.manager.ManagerRepository;
-import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import java.util.Arrays;
@@ -18,34 +13,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class DifficultyMappingService {
-
-    private final ManagerRepository managerRepository;
     private final ClimbingGymRepository climbingGymRepository;
     private final DifficultyMappingRepository difficultyMappingRepository;
-
-    @Transactional
-    public List<Long> createDifficultyMapping(User user,
-        CreateDifficultyMappingRequest createDifficultyMappingRequest) {
-
-        Manager manager = managerRepository.findById(user.getId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
-
-        return createDifficultyMappingRequest.getGymClimeetDifficulty().entrySet().stream()
-            .map((element) -> {
-                DifficultyMapping difficultyMapping = difficultyMappingRepository.save(
-                    DifficultyMapping.toEntity(
-                        GymDifficulty.findByName(element.getKey()),
-                        ClimeetDifficulty.findByString(element.getValue()),
-                        manager.getClimbingGym()));
-                return difficultyMapping.getId();
-            })
-            .toList();
-    }
 
     public List<DifficultyMappingDetailResponse> getDifficultyMapping(Long gymId) {
 

--- a/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/Route.java
@@ -48,7 +48,7 @@ public class Route extends BaseTimeEntity {
     private int selectionCount;
 
     public static Route toEntity(Sector sector,
-        String routeImageUrl, DifficultyMapping difficultyMapping, String holdColor) {
+        DifficultyMapping difficultyMapping, String routeImageUrl, String holdColor) {
         return Route.builder()
             .sector(sector)
             .difficultyMapping(difficultyMapping)

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteController.java
@@ -1,8 +1,6 @@
 package com.climeet.climeet_backend.domain.route;
 
-import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
@@ -14,11 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "ClimbingRoute", description = "클라이밍 루트 API")
@@ -29,17 +24,7 @@ public class RouteController {
 
     private final RouteService routeService;
 
-    @Operation(summary = "클라이밍 루트 생성 - 1601 [무빗]")
-    @SwaggerApiError({ErrorStatus._EMPTY_SECTOR})
-    @PostMapping("/route")
-    public ResponseEntity<RouteSimpleResponse> createRoute(
-        @RequestPart(value = "image") MultipartFile routeImage,
-        @RequestPart CreateRouteRequest createRouteRequest, @CurrentUser User user
-    ) {
-        return ResponseEntity.ok(routeService.createRoute(createRouteRequest, routeImage, user));
-    }
-
-    @Operation(summary = "클라이밍 루트 조회 - 1602 [무빗]")
+    @Operation(summary = "클라이밍 루트 조회 - 1601 [무빗]")
     @SwaggerApiError({ErrorStatus._EMPTY_ROUTE})
     @GetMapping("/route/{routeId}")
     public ResponseEntity<RouteDetailResponse> getRoute(@PathVariable Long routeId,
@@ -47,7 +32,7 @@ public class RouteController {
         return ResponseEntity.ok(routeService.getRoute(routeId));
     }
 
-    @Operation(summary = "클라이밍 암장 루트 목록 조회 - 1603 [무빗]")
+    @Operation(summary = "클라이밍 암장 루트 목록 조회 - 1602 [무빗]")
     @SwaggerApiError({ErrorStatus._EMPTY_ROUTE_LIST})
     @GetMapping("/{gymId}/routes")
     public ResponseEntity<List<RouteDetailResponse>> getRouteList(@PathVariable Long gymId,

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteRepository.java
@@ -7,9 +7,5 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
 
     List<Route> findBySectorClimbingGymId(Long gymId);
 
-    List<Route> findBySectorId(Long sectorId);
-
-    Route findByRouteImageUrl(String routeImageUrl);
-
     List<Route> findByIdIn(List<Long> routeIdList);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/RouteService.java
@@ -1,55 +1,18 @@
 package com.climeet.climeet_backend.domain.route;
 
-import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
-import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
-import com.climeet.climeet_backend.domain.manager.Manager;
-import com.climeet.climeet_backend.domain.manager.ManagerRepository;
-import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
-import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteSimpleResponse;
-import com.climeet.climeet_backend.domain.sector.Sector;
-import com.climeet.climeet_backend.domain.sector.SectorRepository;
-import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
 import com.climeet.climeet_backend.global.s3.S3Service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class RouteService {
-
-    private final ManagerRepository managerRepository;
-    private final DifficultyMappingRepository difficultyMappingRepository;
     private final RouteRepository routeRepository;
-    private final SectorRepository sectorRepository;
     private final S3Service s3Service;
-
-    @Transactional
-    public RouteSimpleResponse createRoute(CreateRouteRequest createRouteRequest,
-        MultipartFile routeImage, User user) {
-
-        Manager manager = managerRepository.findById(user.getId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
-
-        DifficultyMapping difficultyMapping = difficultyMappingRepository.findByClimbingGymAndGymDifficultyName(
-            manager.getClimbingGym(), createRouteRequest.getGymDifficultyName());
-
-        Sector sector = sectorRepository.findById(createRouteRequest.getSectorId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_SECTOR));
-
-        String routeImageUrl = s3Service.uploadFile(routeImage).getImgUrl();
-
-        Route route = routeRepository.save(
-            Route.toEntity(sector, routeImageUrl, difficultyMapping,
-                createRouteRequest.getHoldColor()));
-
-        return RouteSimpleResponse.toDTO(route);
-    }
 
     public RouteDetailResponse getRoute(Long routeId) {
         Route route = routeRepository.findById(routeId)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
@@ -64,4 +64,11 @@ public class RouteVersion extends BaseTimeEntity {
             .climbData(climbData)
             .build();
     }
+
+    public void changeRouteVersion(List<Long> difficultyMappingList,
+        List<Long> layoutList ,Map<String, List<Long>> climbData){
+        this.difficultyMappingList = difficultyMappingList;
+        this.layoutList = layoutList;
+        this.climbData = climbData;
+    }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersion.java
@@ -4,6 +4,7 @@ import io.hypersistence.utils.hibernate.type.json.JsonType;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImage;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import io.swagger.v3.core.util.Json;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -36,11 +38,16 @@ public class RouteVersion extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private ClimbingGym climbingGym;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private ClimbingGymLayoutImage climbingGymLayoutImage;
-
     @NotNull
     private LocalDate timePoint;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "json")
+    private List<Long> difficultyMappingList;
+
+    @Type(JsonType.class)
+    @Column(columnDefinition = "json")
+    private List<Long> layoutList;
 
     @Type(JsonType.class)
     @Column(columnDefinition = "json")
@@ -48,11 +55,12 @@ public class RouteVersion extends BaseTimeEntity {
 
 
     public static RouteVersion toEntity(ClimbingGym climbingGym, LocalDate timePoint,
-        Map<String, List<Long>> climbData, ClimbingGymLayoutImage climbingGymLayoutImage) {
+        List<Long> difficultyMappingList, List<Long> layoutList ,Map<String, List<Long>> climbData) {
         return RouteVersion.builder()
             .climbingGym(climbingGym)
-            .climbingGymLayoutImage(climbingGymLayoutImage)
             .timePoint(timePoint)
+            .difficultyMappingList(difficultyMappingList)
+            .layoutList(layoutList)
             .climbData(climbData)
             .build();
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.routeversion;
 import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.CreateRouteVersionRequest;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionRequestDto.GetFilteredRouteVersionRequest;
+import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionAllDataResponse;
 import com.climeet.climeet_backend.domain.routeversion.dto.RouteVersionResponseDto.RouteVersionFilteringKeyResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
@@ -22,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "RouteVersion", description = "암장 루트 버전 API")
@@ -43,8 +43,8 @@ public class RouteVersionController {
     }
 
     @Operation(summary = "암장의 루트 버전 추가 - 1104 [무빗]")
-    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._DUPLICATE_ROUTE_VERSION,
-        ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
+    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._MISMATCH_SECTOR_DATA,
+        ErrorStatus._MISMATCH_DIFFICULTY_DATA})
     @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
         @RequestBody CreateRouteVersionRequest createRouteVersionRequest,
@@ -55,8 +55,7 @@ public class RouteVersionController {
 
     @Operation(summary = "암장 특정 루트버전 필터링 키 불러오기 - 1101 [무빗]", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다.")
     @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
-        ErrorStatus._EMPTY_SECTOR_LIST, ErrorStatus._MISMATCH_SECTOR_IDS,
-        ErrorStatus._EMPTY_DIFFICULTY_LIST})
+        ErrorStatus._MISMATCH_SECTOR_IDS})
     @GetMapping("/{gymId}/version/key")
     public ResponseEntity<RouteVersionFilteringKeyResponse> getRouteVersionFilteringKey(
         @CurrentUser User user, @PathVariable Long gymId,
@@ -65,15 +64,23 @@ public class RouteVersionController {
             routeVersionService.getRouteVersionFilteringKey(gymId, timePoint));
     }
 
-    @Operation(summary = "암장 특정 루트버전 루트 리스트 불러오기 (필터링 포함)", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다. \n 각 List 필터링 값 또한 비필수이며, 만약 특정 List에 필터링될 값이 없다면 입력하지 않아도 문제 없습니다.")
-    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._EMPTY_VERSION,
-        ErrorStatus._EMPTY_ROUTE_LIST, ErrorStatus._MISMATCH_ROUTE_IDS})
-    @PostMapping("/{gymId}/version/route - 1103 [무빗]")
+    @Operation(summary = "암장 특정 루트버전 루트 리스트 불러오기 (필터링 포함) - 1103 [무빗]", description = "timePoint 값은 비필수 값이며, 입력되지 않았을 때의 default는 오늘 날짜입니다. \n 각 List 필터링 값 또한 비필수이며, 만약 특정 List에 필터링될 값이 없다면 입력하지 않아도 문제 없습니다.")
+    @SwaggerApiError({ErrorStatus._EMPTY_CLIMBING_GYM, ErrorStatus._MISMATCH_ROUTE_IDS})
+    @PostMapping("/{gymId}/version/route")
     public ResponseEntity<PageResponseDto<List<RouteDetailResponse>>> getRouteVersionFiltering(
         @CurrentUser User user, @PathVariable Long gymId,
         @RequestBody GetFilteredRouteVersionRequest getFilteredRouteVersionRequest) {
         return ResponseEntity.ok(
             routeVersionService.getRouteVersionFilteringRouteList(gymId,
                 getFilteredRouteVersionRequest));
+    }
+
+    @Operation(summary = "암장 특정 루트버전의 모든 데이터 불러오기 (루트버전 수정용) - 1105 [무빗]")
+    @SwaggerApiError({})
+    @GetMapping("/{gymId}/version/all")
+    public ResponseEntity<RouteVersionAllDataResponse> getRouteVersionAllData(
+        @CurrentUser User user, @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {
+        return ResponseEntity.ok(
+            routeVersionService.getRouteVersionAllData(user, timePoint));
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "RouteVersion", description = "암장 루트 버전 API")
 @RestController
@@ -48,9 +47,9 @@ public class RouteVersionController {
         ErrorStatus._MISMATCH_ROUTE_IDS, ErrorStatus._MISMATCH_SECTOR_IDS})
     @PostMapping("/version")
     public ResponseEntity<String> createRouteVersion(
-        @RequestPart(value = "request") CreateRouteVersionRequest createRouteVersionRequest,
-        @RequestPart(required = false) MultipartFile layoutImage, @CurrentUser User user) {
-        routeVersionService.createRouteVersion(createRouteVersionRequest, user, layoutImage);
+        @RequestBody CreateRouteVersionRequest createRouteVersionRequest,
+        @CurrentUser User user) {
+        routeVersionService.createRouteVersion(createRouteVersionRequest, user);
         return ResponseEntity.ok("루트 버전이 추가되었습니다.");
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionController.java
@@ -76,7 +76,7 @@ public class RouteVersionController {
     }
 
     @Operation(summary = "암장 특정 루트버전의 모든 데이터 불러오기 (루트버전 수정용) - 1105 [무빗]")
-    @SwaggerApiError({})
+    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._EMPTY_VERSION})
     @GetMapping("/{gymId}/version/all")
     public ResponseEntity<RouteVersionAllDataResponse> getRouteVersionAllData(
         @CurrentUser User user, @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate timePoint) {

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -146,8 +146,16 @@ public class RouteVersionService {
         climbData.put("route", routeList.stream().map(Route::getId).toList());
         climbData.put("sector", sectorList.stream().map(Sector::getId).toList());
 
-        routeVersionRepository.save(RouteVersion.toEntity(manager.getClimbingGym(),
-            requestDto.getTimePoint(), filteredDifficultyMappingIdList, filteredLayoutImageIdList, climbData));
+        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(manager.getClimbingGym(), requestDto.getTimePoint())
+            .orElse(null);
+        if(routeVersion != null){
+            routeVersion.changeRouteVersion(filteredDifficultyMappingIdList, filteredLayoutImageIdList, climbData);
+        } else{
+            routeVersion = RouteVersion.toEntity(manager.getClimbingGym(),
+                requestDto.getTimePoint(), filteredDifficultyMappingIdList, filteredLayoutImageIdList, climbData);
+        }
+
+        routeVersionRepository.save(routeVersion);
 
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -4,9 +4,12 @@ import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGymRepository;
 import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImage;
 import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImageRepository;
+import com.climeet.climeet_backend.domain.climbinggymlayoutimage.dto.ClimbingGymLayoutImageResponseDto.LayoutImgListDetail;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMappingRepository;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
+import com.climeet.climeet_backend.domain.difficultymapping.enums.ClimeetDifficulty;
+import com.climeet.climeet_backend.domain.difficultymapping.enums.GymDifficulty;
 import com.climeet.climeet_backend.domain.fcmNotification.FcmNotificationService;
 import com.climeet.climeet_backend.domain.manager.Manager;
 import com.climeet.climeet_backend.domain.manager.ManagerRepository;
@@ -23,16 +26,14 @@ import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.common.PageResponseDto;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
-import com.climeet.climeet_backend.global.s3.S3Service;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +46,6 @@ public class RouteVersionService {
     private final ManagerRepository managerRepository;
     private final DifficultyMappingRepository difficultyMappingRepository;
     private final ClimbingGymLayoutImageRepository climbingGymLayoutImageRepository;
-    private final S3Service s3Service;
     private final FcmNotificationService fcmNotificationService;
 
     public List<LocalDate> getRouteVersionList(Long gymId) {
@@ -56,59 +56,98 @@ public class RouteVersionService {
         return timePointList;
     }
 
-    public void createRouteVersion(CreateRouteVersionRequest createRouteVersionRequest, User user,
-        MultipartFile layoutImage) {
+    public void createRouteVersion(CreateRouteVersionRequest requestDto, User user) {
+        // user가 매니저인지 확인
         Manager manager = managerRepository.findById(user.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
 
-        // 암장 데이터와 TimePoint로 가장 가까운 시점의 RouteVersion 데이터를 가져옴
-        // 추가하려는 날짜의 해당 암장 루트 버전 데이터가 존재하는지 확인하기 위함
-        Optional<RouteVersion> routeVersionOptional = routeVersionRepository.findByClimbingGymAndTimePoint(
-            manager.getClimbingGym(), createRouteVersionRequest.getTimePoint());
-        if (routeVersionOptional.isPresent()) {
-            throw new GeneralException(ErrorStatus._DUPLICATE_ROUTE_VERSION);
-        }
+        // 암장 난이도 추가 변경
+        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(manager.getClimbingGym());
+        List<Long> filteredDifficultyMappingIdList = new ArrayList<>(difficultyMappingList.stream()
+            .filter(difficulty -> requestDto.getExistingData().getDifficulty()
+                .contains(difficulty.getGymDifficultyName()))
+            .map(DifficultyMapping::getId)
+            .toList());
+        List<Long> newDifficultyImageIdList = requestDto.getNewData().getDifficulty().stream()
+            .map(difficultyDto -> {
+                DifficultyMapping targetDifficulty = difficultyMappingList.stream()
+                    .filter(difficulty -> difficulty.getGymDifficultyName().equals(difficultyDto.getGymDifficultyName()))
+                    .findFirst()
+                    .orElse(null);
+                if(targetDifficulty != null) {
+                    targetDifficulty.changeDifficultyMapping(ClimeetDifficulty.findByString(
+                        difficultyDto.getClimeetDifficultyName()));
+                } else {
+                    targetDifficulty = DifficultyMapping.toEntity(
+                        GymDifficulty.findByName(difficultyDto.getGymDifficultyName()),
+                        ClimeetDifficulty.findByString(difficultyDto.getClimeetDifficultyName()),
+                        manager.getClimbingGym());
+                }
+                return difficultyMappingRepository.save(targetDifficulty).getId();
+            })
+            .toList();
+        filteredDifficultyMappingIdList.addAll(newDifficultyImageIdList);
 
-        // 루트리스트에 넣을 데이터가 실제로 다 추가되어있는지 확인
-        List<Route> routeList = routeRepository.findByIdIn(
-            createRouteVersionRequest.getRouteIdList());
-        if (routeList.size() != createRouteVersionRequest.getRouteIdList().size()) {
-            throw new GeneralException(ErrorStatus._MISMATCH_ROUTE_IDS);
-        }
 
-        // 섹터리스트에 넣을 데이터가 실제로 다 추가되어있는지 확인
-        List<Sector> sectorList = sectorRepository.findByIdIn(
-            createRouteVersionRequest.getSectorIdList());
-        if (sectorList.size() != createRouteVersionRequest.getSectorIdList().size()) {
-            throw new GeneralException(ErrorStatus._MISMATCH_SECTOR_IDS);
-        }
+        // 암장 층별 이미지 추가
+        List<ClimbingGymLayoutImage> layoutImageList = climbingGymLayoutImageRepository.findClimbingGymLayoutImageByClimbingGym(manager.getClimbingGym());
+        List<Long> filteredLayoutImageIdList = new ArrayList<>(layoutImageList.stream()
+            .filter(layout -> requestDto.getExistingData().getLayout().contains(layout.getFloor()))
+            .map(ClimbingGymLayoutImage::getId)
+            .toList());
+        List<Long> newLayoutImageIdList = requestDto.getNewData().getLayout().stream()
+            .map(layoutDto -> {
+                ClimbingGymLayoutImage targetLayoutImage = layoutImageList.stream()
+                    .filter( layout -> layout.getFloor() == layoutDto.getFloor())
+                    .findFirst()
+                    .orElse(null);
+                if (targetLayoutImage != null) {
+                    targetLayoutImage.changeImgUrl(layoutDto.getImgUrl());
+                } else {
+                    targetLayoutImage = ClimbingGymLayoutImage.toEntity(
+                        manager.getClimbingGym(), layoutDto.getFloor(), layoutDto.getImgUrl());
+                }
+                return climbingGymLayoutImageRepository.save(targetLayoutImage).getId();
+            })
+            .toList();
+        filteredLayoutImageIdList.addAll(newLayoutImageIdList);
+
+        // 기존 Sector 가져오기
+        List<Sector> sectorList = new ArrayList<>(sectorRepository.findByIdIn(requestDto.getExistingData().getSector()));
+        // 새 Sector 추가하기
+        List<Sector> newSectorList = requestDto.getNewData().getSector().stream()
+            .map(sectorDto -> {
+                return sectorRepository.save(Sector.toEntity(manager.getClimbingGym(), sectorDto.getName(), sectorDto.getFloor(),
+                    sectorDto.getImgUrl()));
+            })
+            .toList();
+        // Sector 데이터 병합(Route 추가시에 사용)
+        sectorList.addAll(newSectorList);
+
+        // 기존 Route 가져오기
+        List<Route> routeList = new ArrayList<>(routeRepository.findByIdIn(requestDto.getExistingData().getRoute()));
+        // 새 Route 추가하기
+        List<Route> newRouteList = requestDto.getNewData().getRoute().stream()
+            .map(routeDto-> {
+                Sector targetSector = sectorList.stream()
+                    .filter(sector -> sector.getSectorName().equals(routeDto.getSectorName()))
+                    .findFirst()
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._MISMATCH_SECTOR_DATA));
+                DifficultyMapping targetDifficulty = difficultyMappingList.stream()
+                    .filter(difficultyMapping -> difficultyMapping.getGymDifficultyName().equals(routeDto.getGymDifficultyName()))
+                    .findFirst()
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._MISMATCH_DIFFICULTY_DATA));
+                return routeRepository.save(Route.toEntity(targetSector, targetDifficulty, routeDto.getImgUrl(), routeDto.getHoldColor()));
+            })
+            .toList();
+        routeList.addAll(newRouteList);
 
         Map<String, List<Long>> climbData = new HashMap<>();
-        climbData.put("route", createRouteVersionRequest.getRouteIdList());
-        climbData.put("sector", createRouteVersionRequest.getSectorIdList());
-
-        // 이미지 url이나 이미지 파일이 들어오지 않았을 때 예외처리
-        if (layoutImage == null && createRouteVersionRequest.getLayoutImageId() == null) {
-            throw new GeneralException(ErrorStatus._EMPTY_LAYOUT_IMAGE);
-        }
-
-        ClimbingGymLayoutImage climbingGymLayoutImage = null;
-        // 이미지 파일이 들어왔으면 s3에 업로드 후 사용
-        if (layoutImage != null) {
-            String layoutImageUrl = s3Service.uploadFile(layoutImage).getImgUrl();
-            climbingGymLayoutImage = climbingGymLayoutImageRepository.save(
-                ClimbingGymLayoutImage.toEntity(layoutImageUrl));
-        }
-        // 이미지 파일이 안들어왔으면 기존 url 그대로 사용
-        else {
-            climbingGymLayoutImage = climbingGymLayoutImageRepository.findById(
-                    createRouteVersionRequest.getLayoutImageId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_LAYOUT_IMAGE));
-        }
+        climbData.put("route", routeList.stream().map(Route::getId).toList());
+        climbData.put("sector", sectorList.stream().map(Sector::getId).toList());
 
         routeVersionRepository.save(RouteVersion.toEntity(manager.getClimbingGym(),
-            createRouteVersionRequest.getTimePoint(), climbData,
-            climbingGymLayoutImage));
+            requestDto.getTimePoint(), filteredDifficultyMappingIdList, filteredLayoutImageIdList, climbData));
 
     }
 
@@ -125,26 +164,25 @@ public class RouteVersionService {
                 climbingGym, timePoint)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));
 
+        List<ClimbingGymLayoutImage> layoutImageList = climbingGymLayoutImageRepository.findByIdIn(routeVersion.getLayoutList());
+
         List<Sector> sectorList = sectorRepository.findByIdIn(routeVersion.getClimbData().get("sector"));
         if (sectorList.size() != routeVersion.getClimbData().get("sector").size()) {
             throw new GeneralException(ErrorStatus._MISMATCH_SECTOR_IDS);
         }
 
-        List<DifficultyMapping> difficultyList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
-            climbingGym);
-        if (difficultyList.isEmpty()) {
-            throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);
-        }
+        List<DifficultyMapping> difficultyList = difficultyMappingRepository.findByIdIn(routeVersion.getDifficultyMappingList());
 
         List<SectorDetailResponse> sectorDetailResponses = sectorList.stream()
             .map(SectorDetailResponse::toDTO).toList();
         List<DifficultyMappingDetailResponse> difficultyMappingDetailResponses = difficultyList.stream()
             .map(DifficultyMappingDetailResponse::toDTO).toList();
-        int maxFloor = sectorList.stream()
-            .mapToInt(Sector::getFloor).max().orElse(0);
+        int maxFloor = layoutImageList.stream()
+            .mapToInt(ClimbingGymLayoutImage::getFloor).max().orElse(0);
+        List<LayoutImgListDetail> layoutResponses = layoutImageList.stream().map(LayoutImgListDetail::toDto).toList();
 
         return RouteVersionFilteringKeyResponse.toDTO(climbingGym, sectorDetailResponses,
-            difficultyMappingDetailResponses, maxFloor, routeVersion);
+            difficultyMappingDetailResponses, layoutResponses, maxFloor, routeVersion);
     }
 
     public PageResponseDto<List<RouteDetailResponse>> getRouteVersionFilteringRouteList(Long gymId,
@@ -172,8 +210,7 @@ public class RouteVersionService {
         // sector Filter 적용
         if (getFilteredRouteVersionRequest.getSectorId() != null) {
             routeList = routeList.stream()
-                .filter(route -> route.getSector().getId()
-                    == getFilteredRouteVersionRequest.getSectorId())
+                .filter(route -> route.getSector().getId().equals(getFilteredRouteVersionRequest.getSectorId()))
                 .toList();
         }
 
@@ -188,7 +225,7 @@ public class RouteVersionService {
         List<RouteDetailResponse> routeDetailResponseList = routeList.stream()
             .sorted(Comparator.comparing(Route::getId).reversed())
             .skip(
-                getFilteredRouteVersionRequest.getPage() * getFilteredRouteVersionRequest.getSize())
+                (long) getFilteredRouteVersionRequest.getPage() * getFilteredRouteVersionRequest.getSize())
             .limit(getFilteredRouteVersionRequest.getSize())
             .map(RouteDetailResponse::toDTO)
             .toList();

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/RouteVersionService.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -57,6 +58,7 @@ public class RouteVersionService {
         return timePointList;
     }
 
+    @Transactional
     public void createRouteVersion(CreateRouteVersionRequest requestDto, User user) {
         // user가 매니저인지 확인
         Manager manager = managerRepository.findById(user.getId())

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -9,9 +9,11 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public class RouteVersionRequestDto {
+
     @Getter
     @NoArgsConstructor
     public static class ExistingRouteVersionData {
+
         private List<String> difficulty = new ArrayList<>();
         private List<Integer> layout = new ArrayList<>();
         private List<Long> sector = new ArrayList<>();
@@ -21,6 +23,7 @@ public class RouteVersionRequestDto {
     @Getter
     @AllArgsConstructor
     public static class NewDifficultyData {
+
         private String gymDifficultyName;
         private String climeetDifficultyName;
     }
@@ -28,6 +31,7 @@ public class RouteVersionRequestDto {
     @Getter
     @AllArgsConstructor
     public static class NewLayoutData {
+
         private int floor;
         private String imgUrl;
     }
@@ -35,6 +39,7 @@ public class RouteVersionRequestDto {
     @Getter
     @AllArgsConstructor
     public static class NewSectorData {
+
         private String name;
         private int floor;
         private String imgUrl;
@@ -43,6 +48,7 @@ public class RouteVersionRequestDto {
     @Getter
     @AllArgsConstructor
     public static class NewRouteData {
+
         private String sectorName;
         private String gymDifficultyName;
         private String holdColor;
@@ -52,6 +58,7 @@ public class RouteVersionRequestDto {
     @Getter
     @NoArgsConstructor
     public static class NewRouteVersionData {
+
         private List<NewDifficultyData> difficulty = new ArrayList<>();
         private List<NewLayoutData> layout = new ArrayList<>();
         private List<NewSectorData> sector = new ArrayList<>();
@@ -61,9 +68,10 @@ public class RouteVersionRequestDto {
     @Getter
     @NoArgsConstructor
     public static class CreateRouteVersionRequest {
+
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         private LocalDate timePoint;
-        private ExistingRouteVersionData existingData = new ExistingRouteVersionData();;
+        private ExistingRouteVersionData existingData = new ExistingRouteVersionData();
         private NewRouteVersionData newData = new NewRouteVersionData();
     }
 

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -1,22 +1,70 @@
 package com.climeet.climeet_backend.domain.routeversion.dto;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 public class RouteVersionRequestDto {
+    @Getter
+    @NoArgsConstructor
+    public static class ExistingRouteVersionData {
+        private List<String> difficulty = new ArrayList<>();
+        private List<Integer> layout = new ArrayList<>();
+        private List<Long> sector = new ArrayList<>();
+        private List<Long> route = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class NewDifficultyData {
+        private String gymDifficultyName;
+        private String climeetDifficultyName;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class NewLayoutData {
+        private int floor;
+        private String imgUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class NewSectorData {
+        private String name;
+        private int floor;
+        private String imgUrl;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class NewRouteData {
+        private String sectorName;
+        private String gymDifficultyName;
+        private String holdColor;
+        private String imgUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class NewRouteVersionData {
+        private List<NewDifficultyData> difficulty = new ArrayList<>();
+        private List<NewLayoutData> layout = new ArrayList<>();
+        private List<NewSectorData> sector = new ArrayList<>();
+        private List<NewRouteData> route = new ArrayList<>();
+    }
 
     @Getter
     @NoArgsConstructor
     public static class CreateRouteVersionRequest {
-
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         private LocalDate timePoint;
-        private List<Long> routeIdList;
-        private List<Long> sectorIdList;
-        private Long layoutImageId;
+        private ExistingRouteVersionData existingData = new ExistingRouteVersionData();;
+        private NewRouteVersionData newData = new NewRouteVersionData();
     }
 
     @Getter

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -1,6 +1,8 @@
 package com.climeet.climeet_backend.domain.routeversion.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImage;
+import com.climeet.climeet_backend.domain.climbinggymlayoutimage.dto.ClimbingGymLayoutImageResponseDto.LayoutImgListDetail;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.RouteVersion;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
@@ -9,33 +11,31 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class RouteVersionResponseDto {
 
+
+
     @Builder
     @Getter
-    @NoArgsConstructor
     @AllArgsConstructor
     public static class RouteVersionFilteringKeyResponse {
 
         private Long gymId;
         private LocalDate timePoint;
-        private Long layoutImageUrlId;
-        private String layoutImageUrl;
+        private List<LayoutImgListDetail> layoutList;
         private List<SectorDetailResponse> sectorList;
         private List<DifficultyMappingDetailResponse> difficultyList;
         private int maxFloor;
 
         public static RouteVersionFilteringKeyResponse toDTO(ClimbingGym climbingGym,
             List<SectorDetailResponse> sectorList,
-            List<DifficultyMappingDetailResponse> difficultyList, int maxFloor,
+            List<DifficultyMappingDetailResponse> difficultyList, List<LayoutImgListDetail> layoutImageList, int maxFloor,
             RouteVersion routeVersion) {
             return RouteVersionFilteringKeyResponse.builder()
                 .gymId(climbingGym.getId())
                 .timePoint(routeVersion.getTimePoint())
-                .layoutImageUrlId(routeVersion.getClimbingGymLayoutImage().getId())
-                .layoutImageUrl(routeVersion.getClimbingGymLayoutImage().getImgUrl())
+                .layoutList(layoutImageList)
                 .sectorList(sectorList)
                 .difficultyList(difficultyList)
                 .maxFloor(maxFloor)

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionResponseDto.java
@@ -4,6 +4,7 @@ import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.climbinggymlayoutimage.ClimbingGymLayoutImage;
 import com.climeet.climeet_backend.domain.climbinggymlayoutimage.dto.ClimbingGymLayoutImageResponseDto.LayoutImgListDetail;
 import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingResponseDto.DifficultyMappingDetailResponse;
+import com.climeet.climeet_backend.domain.route.dto.RouteResponseDto.RouteDetailResponse;
 import com.climeet.climeet_backend.domain.routeversion.RouteVersion;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
 import java.time.LocalDate;
@@ -13,7 +14,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 public class RouteVersionResponseDto {
-
 
 
     @Builder
@@ -30,7 +30,8 @@ public class RouteVersionResponseDto {
 
         public static RouteVersionFilteringKeyResponse toDTO(ClimbingGym climbingGym,
             List<SectorDetailResponse> sectorList,
-            List<DifficultyMappingDetailResponse> difficultyList, List<LayoutImgListDetail> layoutImageList, int maxFloor,
+            List<DifficultyMappingDetailResponse> difficultyList,
+            List<LayoutImgListDetail> layoutImageList, int maxFloor,
             RouteVersion routeVersion) {
             return RouteVersionFilteringKeyResponse.builder()
                 .gymId(climbingGym.getId())
@@ -39,6 +40,37 @@ public class RouteVersionResponseDto {
                 .sectorList(sectorList)
                 .difficultyList(difficultyList)
                 .maxFloor(maxFloor)
+                .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class RouteVersionAllDataResponse {
+
+        private Long gymId;
+        private LocalDate timePoint;
+        private int maxFloor;
+        private List<DifficultyMappingDetailResponse> difficultyList;
+        private List<LayoutImgListDetail> layoutList;
+        private List<SectorDetailResponse> sectorList;
+        private List<RouteDetailResponse> routeList;
+
+        public static RouteVersionAllDataResponse toDTO(ClimbingGym climbingGym,
+            int maxFloor, RouteVersion routeVersion,
+            List<DifficultyMappingDetailResponse> difficultyList,
+            List<LayoutImgListDetail> layoutImageList,
+            List<SectorDetailResponse> sectorList,
+            List<RouteDetailResponse> routeList) {
+            return RouteVersionAllDataResponse.builder()
+                .gymId(climbingGym.getId())
+                .timePoint(routeVersion.getTimePoint())
+                .maxFloor(maxFloor)
+                .difficultyList(difficultyList)
+                .layoutList(layoutImageList)
+                .sectorList(sectorList)
+                .routeList(routeList)
                 .build();
         }
     }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -38,13 +38,12 @@ public class Sector extends BaseTimeEntity {
 
     private int floor = 1;
 
-    public static Sector toEntity(CreateSectorRequest requestDto, ClimbingGym climbingGym,
-        String sectorImageUrl) {
+    public static Sector toEntity(ClimbingGym climbingGym, String name, int floor,  String imgUrl) {
         return Sector.builder()
             .climbingGym(climbingGym)
-            .sectorName(requestDto.getName())
-            .floor(requestDto.getFloor())
-            .sectorImageUrl(sectorImageUrl)
+            .sectorName(name)
+            .floor(floor)
+            .sectorImageUrl(imgUrl)
             .build();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorController.java
@@ -1,8 +1,6 @@
 package com.climeet.climeet_backend.domain.sector;
 
-import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorSimpleResponse;
 import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.security.CurrentUser;
@@ -14,11 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "ClimbingSector", description = "클라이밍 섹터 API")
 @RequiredArgsConstructor
@@ -27,16 +22,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class SectorController {
 
     private final SectorService sectorService;
-
-    @Operation(summary = "클라이밍 섹터 생성 - 502 [무빗]")
-    @SwaggerApiError({ErrorStatus._EMPTY_MANAGER, ErrorStatus._DUPLICATE_SECTOR_NAME})
-    @PostMapping("/sector")
-    public ResponseEntity<SectorSimpleResponse> createSector(
-        @RequestPart(value = "image") MultipartFile sectorImage,
-        @RequestPart CreateSectorRequest createSectorRequest, @CurrentUser User user) {
-
-        return ResponseEntity.ok(sectorService.createSector(createSectorRequest, sectorImage, user));
-    }
 
     @Operation(summary = "특정 암장 전체 섹터 조회 - 501 [무빗]")
     @SwaggerApiError({ErrorStatus._EMPTY_SECTOR_LIST})

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorRepository.java
@@ -7,7 +7,5 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
 
     List<Sector> findSectorByClimbingGymId(Long gymId);
 
-    Sector findBySectorImageUrl(String sectorImageUrl);
-
     List<Sector> findByIdIn(List<Long> sectorIdList);
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/SectorService.java
@@ -1,52 +1,16 @@
 package com.climeet.climeet_backend.domain.sector;
 
-import com.climeet.climeet_backend.domain.manager.Manager;
-import com.climeet.climeet_backend.domain.manager.ManagerRepository;
-import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorDetailResponse;
-import com.climeet.climeet_backend.domain.sector.dto.SectorResponseDto.SectorSimpleResponse;
-import com.climeet.climeet_backend.domain.user.User;
 import com.climeet.climeet_backend.global.response.code.status.ErrorStatus;
 import com.climeet.climeet_backend.global.response.exception.GeneralException;
-import com.climeet.climeet_backend.global.s3.S3Service;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class SectorService {
-
     private final SectorRepository sectorRepository;
-    private final ManagerRepository managerRepository;
-    private final S3Service s3Service;
-
-    @Transactional
-    public SectorSimpleResponse createSector(CreateSectorRequest createSectorRequest,
-        MultipartFile sectorImage, User user) {
-
-        Manager manager = managerRepository.findById(user.getId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
-
-        // 섹터 이름 중복 체크 (같은 섹터에서 중복일 경우)
-        List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(
-            manager.getClimbingGym().getId());
-        for (Sector sector : sectorList) {
-            if (sector.getSectorName().equals(createSectorRequest.getName())) {
-                throw new GeneralException(ErrorStatus._DUPLICATE_SECTOR_NAME);
-            }
-        }
-
-        String sectorImageUrl = s3Service.uploadFile(sectorImage).getImgUrl();
-
-        Sector sector = sectorRepository.save(
-            Sector.toEntity(createSectorRequest, manager.getClimbingGym(), sectorImageUrl));
-
-        return SectorSimpleResponse.toDTO(sector);
-    }
 
     public List<SectorDetailResponse> getSectorList(Long gymId) {
         List<Sector> sectorList = sectorRepository.findSectorByClimbingGymId(gymId);
@@ -56,6 +20,6 @@ public class SectorService {
 
         return sectorList.stream()
             .map(SectorDetailResponse::toDTO)
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorResponseDto.java
@@ -19,12 +19,14 @@ public class SectorResponseDto {
         private Long sectorId;
         private String name;
         private int floor;
+        private String imgUrl;
 
         public static SectorDetailResponse toDTO(Sector sector) {
             return SectorDetailResponse.builder()
                 .sectorId(sector.getId())
                 .name(sector.getSectorName())
                 .floor(sector.getFloor())
+                .imgUrl(sector.getSectorImageUrl())
                 .build();
 
         }

--- a/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/climeet/climeet_backend/global/response/code/status/ErrorStatus.java
@@ -41,10 +41,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _MISMATCH_SECTOR_IDS(HttpStatus.CONFLICT, "ROUTE_VERSION_004", "등록된 섹터 데이터 중 불러오지 못한 값이 있습니다."),
     _DUPLICATE_ROUTE_VERSION(HttpStatus.CONFLICT, "ROUTE_VERSION_005", "해당일에 이미 등록된 버전이 있습니다."),
     _EMPTY_LAYOUT_IMAGE(HttpStatus.CONFLICT, "ROUTE_VERSION_006", "암장 도면 관련 데이터가 없습니다."),
+    _MISMATCH_SECTOR_DATA(HttpStatus.CONFLICT, "ROUTE_VERSION_007", "연관된 섹터 데이터가 올바르지 않습니다."),
 
     //난이도 매핑 관련
     _INVALID_DIFFICULTY(HttpStatus.CONFLICT, "DIFFICULTY_MAPPING_001", "해당하는 난이도가 없습니다."),
     _EMPTY_DIFFICULTY_LIST(HttpStatus.CONFLICT, "DIFFICULTY_MAPPING_002", "암장에 등록된 매핑이 없습니다."),
+    _MISMATCH_DIFFICULTY_DATA(HttpStatus.CONFLICT, "DIFFICULTY_MAPPING_003", "연관된 암장 난이도 정보가 올바르지 않습니다."),
 
     //벽면 관련
     _EMPTY_SECTOR(HttpStatus.CONFLICT, "SECTOR_001", "존재하지 않는 벽면입니다."),


### PR DESCRIPTION
## 요약
- 어... 상당히 많은 부분이 바뀌었습니다.
1. 루트 버전 추가 기능 API가 전체 수정되었습니다. 그냥 새로 만들었다고 봐도 무방합니다.
2. 루트 버전 추가 기능에 루트 추가, 섹터 추가, 난이도 추가, 도면 추가가 모두 들어갔습니다.
- 이는 프론트 측과 협의해서 나온 형태이며 request 형태는 상세 내용에 추가하겠습니다.
3. 루트, 섹터, 난이도 추가가 루트 버전 쪽으로 이동함에 따라 기존에 각각 존재하던 추가 API를 모두 없앴습니다.
4. 관리자가 루트 버전을 수정하기 위한 모든 데이터를 가져오는 API또한 구현하였고, 이 부분은 간단합니다.
5. 가능하면 PR을 2개로 나눠서 각 API로 구성하고 싶었지만, 서로 연관된 부분이 많아 이렇게 한번에 올리게 되었습니다.
6. 리뷰 잘 부탁합니다 ...^^

## 상세 내용
- 우선 프론트측과 협의된 루트 버전 추가를 위한 RequestDto의 json 형식은 다음과 같습니다.
``` json
{
  "timePoint": "2024-06-21",
  "existingData": {
    "difficulty": [ "하양", "빨강", "difficulty name(문자열)" ],
    "layout": [1, 2, "기존의 암장 도면을 사용할 floor(정수)"],
    "sector": [ 1, 2, 3, "sector id (정수)" ],
    "route": [ 1, 2, 3, "route id (정수)" ]
  },
  "newData": {
    "difficulty": [
      {
        "gymDifficultyName": "암장난이도이름",
        "climeetDifficultyName": "클밋기준이름"
      }
    ],
    "layout": [
      {
        "floor": 1,
        "imgUrl": "1층 암장 이미지 주소"
      },
    ],
    "sector": [
      {
        "name": "섹터이름",
        "floor": 0,
        "imgUrl": "섹터 이미지 url"
      }
    ],
    "route": [
      {
        "sectorName": "섹터이름",
        "gymDifficultyName": "암장난이도이름",
        "holdColor": "홀드이름",
        "imgUrl": "루트 이미지 url"
      }
    ]
  }
}
```
1. 위의 json 형식과 같이 특정 timePoint의 routeVersion을 추가하는데, 기존에 암장에서 사용하는 데이터와 새롭게 추가된 데이터의 영역이 existingData 부분과 newData 부분으로 나뉘게 되었습니다.
- 이는 데이터의 중복 추가를 막기 위함이며, 한 암장에서 여러 루트버전이 존재할 때 섹터와 난이도 데이터를 서로 연관하기 수월하게 하기 위함입니다.
2. existingData에서는 기존에 존재하며, 새롭게 생성할 routeVersion에서 그대로 사용할 데이터들이 담겨있습니다. 따라서 모든 데이터를 저장하는게 아닌, 식별할 수 있는 값들만 List로 받아오도록 구성하였습니다.
3. newData에서는 routeVersion이 새로 생성되면서 같이 생성되어야할 데이터들이 담겨있습니다. 이 부분에서는 데이터를 생성하기 위한 각각의 모든 데이터를 받게 되며, routeVersion을 생성하기 전 전체를 생성하게 됩니다.

### RouteVersionService - createRouteVersion
- 가장 큰 변화를 불러온 RouteVersionService 부분입니다. 이 부분에서 createRouteVersion 함수가 새로 만들어지면서 모든 대 격변이 발생하게 되었습니다.

1. 우선 시작할 때 Transactional 어노테이션을 사용하여 전체가 save되거나 아니면 rollback되도록 구성하였습니다.
- 중간에 에러가 발생하게 되었을 때 루트 버전이 생성되지 않기 때문에, 새롭게 추가된 루트, 섹터 난이도 데이터는 쓰레기값이 되기 때문입니다.
``` java
    @transactional
    public void createRouteVersion(CreateRouteVersionRequest requestDto, User user) {
```

2. api를 호출한 유저가 관리자인지 확인하고, 맞다면 관리하는 암장에 루트 버전을 추가하게 됩니다.
``` java
        // user가 매니저인지 확인
        Manager manager = managerRepository.findById(user.getId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
```

3. 암장 난이도를 구하는 부분입니다. 암장의 난이도는 클밋 난이도에 하나씩 매칭되어 생성될 수 있도록 구성하여, 새롭게 바뀐 난이도가 있다면 기존 난이도의 암장 색에 해당하는 DifficultyMapping 객체의 클밋 난이도를 업데이트하는 방식으로 적용하였습니다.
``` java
        // 암장 난이도 추가 변경
        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
            manager.getClimbingGym());
        List<Long> filteredDifficultyMappingIdList = new ArrayList<>(difficultyMappingList.stream()
            .filter(difficulty -> requestDto.getExistingData().getDifficulty()
                .contains(difficulty.getGymDifficultyName()))
            .map(DifficultyMapping::getId)
            .toList());
        List<Long> newDifficultyImageIdList = requestDto.getNewData().getDifficulty().stream()
            .map(difficultyDto -> {
                DifficultyMapping targetDifficulty = difficultyMappingList.stream()
                    .filter(difficulty -> difficulty.getGymDifficultyName()
                        .equals(difficultyDto.getGymDifficultyName()))
                    .findFirst()
                    .orElse(null);
                if (targetDifficulty != null) {
                    targetDifficulty.changeDifficultyMapping(ClimeetDifficulty.findByString(
                        difficultyDto.getClimeetDifficultyName()));
                } else {
                    targetDifficulty = DifficultyMapping.toEntity(
                        GymDifficulty.findByName(difficultyDto.getGymDifficultyName()),
                        ClimeetDifficulty.findByString(difficultyDto.getClimeetDifficultyName()),
                        manager.getClimbingGym());
                }
                return difficultyMappingRepository.save(targetDifficulty).getId();
            })
            .toList();
        filteredDifficultyMappingIdList.addAll(newDifficultyImageIdList);
```

4. 암장이 여러개의 층으로 구성되어있을 때 암장의 도면을 추가하는 부분입니다. 이 부분으로 암장의 전체 층이 몇개로 이루어져있는지를 판단하게 됩니다.
- 해당 부분도 암장 난이도와 마찬가지로 여러개의 버전에 도면이 바뀔 때마다 해당 이미지를 저장할 필요는 없다고 판단하여, 새롭게 생성하는 newData 부분에 기존에 있던 층의 데이터가 있다면 덮어쓰는 방식으로 구성하였습니다.
``` java
        // 암장 층별 이미지 추가
        List<ClimbingGymLayoutImage> layoutImageList = climbingGymLayoutImageRepository.findClimbingGymLayoutImageByClimbingGym(
            manager.getClimbingGym());
        List<Long> filteredLayoutImageIdList = new ArrayList<>(layoutImageList.stream()
            .filter(layout -> requestDto.getExistingData().getLayout().contains(layout.getFloor()))
            .map(ClimbingGymLayoutImage::getId)
            .toList());
        List<Long> newLayoutImageIdList = requestDto.getNewData().getLayout().stream()
            .map(layoutDto -> {
                ClimbingGymLayoutImage targetLayoutImage = layoutImageList.stream()
                    .filter(layout -> layout.getFloor() == layoutDto.getFloor())
                    .findFirst()
                    .orElse(null);
                if (targetLayoutImage != null) {
                    targetLayoutImage.changeImgUrl(layoutDto.getImgUrl());
                } else {
                    targetLayoutImage = ClimbingGymLayoutImage.toEntity(
                        manager.getClimbingGym(), layoutDto.getFloor(), layoutDto.getImgUrl());
                }
                return climbingGymLayoutImageRepository.save(targetLayoutImage).getId();
            })
            .toList();
        filteredLayoutImageIdList.addAll(newLayoutImageIdList);
```

5. 암장의 섹터를 추가하는 부분입니다.
- 기존 섹터와 새롭게 생성되는 섹터는 완전히 구분되기 때문에 newData에 있는 섹터들은 따로 기존 섹터와 비교하지 않고 바로 추가하게 됩니다. 
- 아직 처리하지 않은 부분중에 중복된 섹터 이름이 발생한 경우를 고려해봐야하는데, 이 부분은 우선 프론트에 배포 후 처리하도록 하겠습니다.
``` java
        // 기존 Sector 가져오기
        List<Sector> sectorList = new ArrayList<>(
            sectorRepository.findByIdIn(requestDto.getExistingData().getSector()));
        // 새 Sector 추가하기
        List<Sector> newSectorList = requestDto.getNewData().getSector().stream()
            .map(sectorDto -> {
                return sectorRepository.save(
                    Sector.toEntity(manager.getClimbingGym(), sectorDto.getName(),
                        sectorDto.getFloor(),
                        sectorDto.getImgUrl()));
            })
            .toList();
        // Sector 데이터 병합(Route 추가시에 사용)
        sectorList.addAll(newSectorList);
```

6. 암장의 루트를 생성하는 부분입니다. 마찬가지로 섹터와 동일하게 추가되는데, 섹터와 난이도를 매칭하는 부분만 추가되었습니다.
- 만일 매칭되지 않는 데이터가 입력되면 예외처리를 하게 됩니다.
``` java
        // 기존 Route 가져오기
        List<Route> routeList = new ArrayList<>(
            routeRepository.findByIdIn(requestDto.getExistingData().getRoute()));
        // 새 Route 추가하기
        List<Route> newRouteList = requestDto.getNewData().getRoute().stream()
            .map(routeDto -> {
                Sector targetSector = sectorList.stream()
                    .filter(sector -> sector.getSectorName().equals(routeDto.getSectorName()))
                    .findFirst()
                    .orElseThrow(() -> new GeneralException(ErrorStatus._MISMATCH_SECTOR_DATA));
                DifficultyMapping targetDifficulty = difficultyMappingList.stream()
                    .filter(difficultyMapping -> difficultyMapping.getGymDifficultyName()
                        .equals(routeDto.getGymDifficultyName()))
                    .findFirst()
                    .orElseThrow(() -> new GeneralException(ErrorStatus._MISMATCH_DIFFICULTY_DATA));
                return routeRepository.save(
                    Route.toEntity(targetSector, targetDifficulty, routeDto.getImgUrl(),
                        routeDto.getHoldColor()));
            })
            .toList();
        routeList.addAll(newRouteList);
```

7. 이제 생성된 데이터를 모두 routeVersion에 넣는 과정입니다. 
- 각 timePoint마다 하나의 루트 버전을 구성할 수 있기 때문에 만약 해당 일자에 루트 버전이 이미 존재한다면, 덮어쓰기 하는 방식으로 구현하였습니다.
``` java
        Map<String, List<Long>> climbData = new HashMap<>();
        climbData.put("route", routeList.stream().map(Route::getId).toList());
        climbData.put("sector", sectorList.stream().map(Sector::getId).toList());

        RouteVersion routeVersion = routeVersionRepository.findByClimbingGymAndTimePoint(
                manager.getClimbingGym(), requestDto.getTimePoint())
            .orElse(null);
        if (routeVersion != null) {
            routeVersion.changeRouteVersion(filteredDifficultyMappingIdList,
                filteredLayoutImageIdList, climbData);
        } else {
            routeVersion = RouteVersion.toEntity(manager.getClimbingGym(),
                requestDto.getTimePoint(), filteredDifficultyMappingIdList,
                filteredLayoutImageIdList, climbData);
        }
```

8. 변환된 루트 버전을 저장하면 해당 API는 마무리됩니다.
``` java
        routeVersionRepository.save(routeVersion);

    }
```

### RouteVersionService - getRouteVersionAllData
- 루트 버전을 수정할 때 사용하고 싶다는 프론트의 요청에 따라 구성하였습니다.

1. 마찬가지로 관리자가 맞는지 확인합니다. 
- 일반 유저가 해당 api를 접근할 수 있다면 워낙 많은 데이터를 불러오게 되는지라, 부하가 클 것 같아 일단 막아두는 것으로 구성하였습니다.
``` java
    public RouteVersionAllDataResponse getRouteVersionAllData(User user, LocalDate timePoint) {
        Manager manager = managerRepository.findById(user.getId())
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_MANAGER));
```

2. 루트 버전을 가져와서 각각에 해당하는 데이터를 모두 가져옵니다.
- 이 과정에서 DB 호출이 너무 많은것 같긴 합니다만, 추후에 리팩토링 여부를 판단하겠습니다.
``` java
        RouteVersion routeVersion = routeVersionRepository.findFirstByClimbingGymAndTimePointLessThanEqualOrderByTimePointDesc(
                manager.getClimbingGym(), timePoint)
            .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_VERSION));

        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByIdIn(
            routeVersion.getDifficultyMappingList());
        List<DifficultyMappingDetailResponse> difficultyListDto = difficultyMappingList.stream()
            .map(DifficultyMappingDetailResponse::toDTO).toList();

        List<ClimbingGymLayoutImage> layoutImageList = climbingGymLayoutImageRepository.findByIdIn(
            routeVersion.getLayoutList());
        List<LayoutImgListDetail> layoutImgListDto = layoutImageList.stream()
            .map(LayoutImgListDetail::toDto).toList();

        List<Sector> sectorList = sectorRepository.findByIdIn(
            routeVersion.getClimbData().get("sector"));
        List<SectorDetailResponse> sectorListDto = sectorList.stream()
            .map(SectorDetailResponse::toDTO).toList();

        List<Route> routeList = routeRepository.findByIdIn(
            routeVersion.getClimbData().get("route"));
        List<RouteDetailResponse> routeListDto = routeList.stream().map(RouteDetailResponse::toDTO)
            .toList();

        int maxFloor = layoutImageList.stream()
            .mapToInt(ClimbingGymLayoutImage::getFloor).max().orElse(0);
```

3. 반환을 하게 됩니다.
``` java
        return RouteVersionAllDataResponse.toDTO(manager.getClimbingGym(), maxFloor, routeVersion,
            difficultyListDto, layoutImgListDto, sectorListDto, routeListDto);
    }
```
- 반환하는 데이터의 기본 형식입니다.
- 실제로는 좀 더 많은 속성들이 함께 반환되지만, 일단 이정도만 보셔도 충분할 것 같습니다.
``` json
{
  "timePoint": "2024-06-21",
  "difficulty": [
    {
      "gymDifficultyName": "암장난이도이름",
      "climeetDifficultyName": "클밋기준이름"
    }
  ],
  "layout": [
    {
      "floor": 1,
      "imgUrl": "1층 암장 이미지 주소"
    }
  ],
  "sector": [
    {
      "name": "섹터이름",
      "floor": 0,
      "imgUrl": "섹터 이미지 url"
    }
  ],
  "route": [
    {
      "sectorName": "섹터이름",
      "gymDifficultyName": "암장난이도이름",
      "holdColor": "홀드이름",
      "imgUrl": "루트 이미지 url"
    }
  ]
}
```

- 나머지는 기존 코드의 삭제가 대부분이며, 핵심적인 부분은 아닌 것 같아 이정도만 설명하도록 하겠습니다.
- 추가적인 질문이 있다면 성실하게 답변하겠습니다~

## 테스트 확인 내용
- 루트 버전 추가입니다. 호출했을 때 루트 버전이 추가되었다는 응답 문구가 나오게 됩니다.
<img width="855" alt="SCR-20240625-irla" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/09ec0e9a-b050-4d72-9007-cfb8c2ebc089">
- body 데이터는 다음과 같습니다.
``` java
{
  "timePoint": "2024-06-21",
  "newData": {
    "difficulty": [
      {
        "gymDifficultyName": "하양",
        "climeetDifficultyName": "VB"
      },
      {
        "gymDifficultyName": "빨강",
        "climeetDifficultyName": "V2"
      },
      {
        "gymDifficultyName": "주황",
        "climeetDifficultyName": "V3"
      },
      {
        "gymDifficultyName": "노랑",
        "climeetDifficultyName": "V4"
      }
    ],
    "layout": [
      {
        "floor": 1,
        "imgUrl": "이것은1층레이아웃이미지인거야"
      },
      {
        "floor": 2,
        "imgUrl": "이것은2층레이아웃이미지인거야"
      },
      {
        "floor": 3,
        "imgUrl": "만약3층이추가되었다면?"
      }
    ],
    "sector": [
      {
        "name": "하",
        "floor": 1,
        "imgUrl": "섹터1번이미지"
      },
      {
        "name": "나",
        "floor": 2,
        "imgUrl": "섹터2번이미지"
      }
    ],
    "route": [
      {
        "sectorName": "하",
        "gymDifficultyName": "빨강",
        "holdColor": "빨강",
        "imgUrl": "루트1번"
      },
      {
        "sectorName": "나",
        "gymDifficultyName": "주황",
        "holdColor": "주황",
        "imgUrl": "루트2번"
      }
    ]
  }
}
```
- 아래처럼 데이터베이스가 추가되게 됩니다.
<img width="632" alt="SCR-20240625-iroe" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/5d4444ff-c96a-4715-97bf-6997e58c70f0">
<img width="705" alt="SCR-20240625-irrx" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/01e696ef-4383-4330-8427-cba3ede29a05">
<img width="714" alt="SCR-20240625-isal" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/b70e84fc-00fe-44a9-900a-1b58b02d07ed">
<img width="904" alt="SCR-20240625-isfa" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/20c62666-a2c3-40b2-a968-c7e233f3dca9">
<img width="789" alt="SCR-20240625-iskb" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/b26f57e9-4dc5-460d-a102-1ac782569c70">

- 루트 버전의 모든 데이터를 가져오는 API입니다. 응답은 다음처럼 정상 반환됩니다.
<img width="743" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/dc1532e1-8fe6-4c2c-b906-4cc1fa628a71">

## 질문 및 이외 사항
- 리뷰 감사합니다~