### PR TITLE
[SPR-207] feat: 암장 이름 변경 요청 API 구현

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -1,5 +1,6 @@
 package com.climeet.climeet_backend.domain.climbinggym;
 
+import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymRequestDto.ChangeClimbingGymNameRequest;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymRequestDto.UpdateClimbingGymPriceRequest;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymRequestDto.UpdateClimbingGymServiceRequest;
 import com.climeet.climeet_backend.domain.climbinggym.dto.ClimbingGymResponseDto.AcceptedClimbingGymSimpleResponse;
@@ -140,6 +141,15 @@ public class ClimbingGymController {
     public ResponseEntity<String> getFollowingUserAverageLevelInClimbingGym(
         @CurrentUser User user, @PathVariable Long gymId) {
         return ResponseEntity.ok(climbingGymService.getClimberAverageDifficulty(user, gymId));
+    }
+
+    @Operation(summary = "암장 이름 변경 요청 전송 - 1013 [무빗]", description = "이름 변경이 바로 이루어지지 않으며, 클밋 관리자 측에서 확인하는 과정을 거칩니다.")
+    @SwaggerApiError({})
+    @PatchMapping("/name")
+    public ResponseEntity<String> changeGymNameRequest(@CurrentUser User user, @RequestBody
+        ChangeClimbingGymNameRequest changeClimbingGymNameRequest){
+        climbingGymService.changeGymNameRequest(user, changeClimbingGymNameRequest);
+        return ResponseEntity.ok("이름 변경 신청이 완료되었습니다.");
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymRequestDto.java
@@ -3,6 +3,7 @@ package com.climeet.climeet_backend.domain.climbinggym.dto;
 import com.climeet.climeet_backend.domain.climbinggym.enums.ServiceBitmask;
 import java.util.List;
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,12 @@ public class ClimbingGymRequestDto {
     public static class UpdateClimbingGymPriceRequest {
 
         private Map<String, String> priceMapList;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ChangeClimbingGymNameRequest {
+        private String name;
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/retool/gymnamechangerequest/GymNameChangeRequest.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/retool/gymnamechangerequest/GymNameChangeRequest.java
@@ -1,0 +1,39 @@
+package com.climeet.climeet_backend.domain.retool.gymnamechangerequest;
+
+import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
+import com.climeet.climeet_backend.domain.manager.Manager;
+import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder
+public class GymNameChangeRequest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private ClimbingGym climbingGym;
+
+    private String afterGymName;
+
+    public static GymNameChangeRequest toEntity(ClimbingGym climbingGym, String afterGymName){
+        return GymNameChangeRequest.builder()
+            .climbingGym(climbingGym)
+            .afterGymName(afterGymName)
+            .build();
+    }
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/retool/gymnamechangerequest/GymNameChangeRequestRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/retool/gymnamechangerequest/GymNameChangeRequestRepository.java
@@ -1,0 +1,7 @@
+package com.climeet.climeet_backend.domain.retool.gymnamechangerequest;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GymNameChangeRequestRepository extends JpaRepository<GymNameChangeRequest, Long> {
+
+}


### PR DESCRIPTION
## 요약
- 암장 이름 변경을 요청하는 API를 구현했습니다.
- 해당 API를 구현하기 위해 새로운 테이블을 만들었습니다.
- 매우매우 단순한 구조입니다.
- ClimbingGymService에 이상한 부분들이 좀 바뀌었는데, 이는 코드 정렬 기능을 사용했더니 이렇게 되었습니다.
- 요청을 날리는 API만 만들었고, 승인하고 하는 과정은 추후에 구현하겠습니다. 프론트에 먼저 주고...

## 상세 내용

- 생략하겠습니당

## 테스트 확인 내용

- 데이터가 제대로 입력됨을 알 수 있습니다. 현재는 중복으로 요청을 보낼 수 있는데, 같은 암장이면 계속 덮어쓰기를 할지는 고민해봐야할 것 같습니다.
<img width="961" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/89d528b9-6087-4f90-9a71-ae4da2025832">


## 질문 및 이외 사항
- 감사합니다.
