### PR TITLE
[SPR-208] 쇼츠 댓글 개수 수정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/ShortsService.java
@@ -385,7 +385,7 @@ public class ShortsService {
             shorts.getClimbingGym(),
             findShorts(user, shorts.getId(), difficultyMapping),
             gymDifficultyName,
-            gymDifficultyColor, climeetDifficultyName, shorts.getUser() instanceof Manager);
+            gymDifficultyColor, shorts.getUser() instanceof Manager);
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shorts/dto/ShortsResponseDto.java
@@ -24,13 +24,12 @@ public class ShortsResponseDto {
         private String gymName;
         private String gymDifficultyName;
         private String gymDifficultyColor;
-        private String climeetDifficultyName;
         private Boolean isManager;
         private ShortsDetailInfo shortsDetailInfo;
 
         public static ShortsSimpleInfo toDTO(Long shortsId, String thumbnailImageUrl,
             ClimbingGym climbingGym, ShortsDetailInfo shortsDetailInfo, String gymDifficultyName,
-            String gymDifficultyColor, String gymClimeetDifficultyName, boolean isManager) {
+            String gymDifficultyColor, boolean isManager) {
             String gymName = null;
             if(climbingGym != null) gymName = climbingGym.getName();
 
@@ -39,7 +38,6 @@ public class ShortsResponseDto {
                 .gymName(gymName)
                 .gymDifficultyName(gymDifficultyName)
                 .gymDifficultyColor(gymDifficultyColor)
-                .climeetDifficultyName(gymClimeetDifficultyName)
                 .isManager(isManager).shortsDetailInfo(shortsDetailInfo)
                 .build();
         }

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentRepository.java
@@ -19,7 +19,7 @@ public interface ShortsCommentRepository extends JpaRepository<ShortsComment, Lo
     Optional<ShortsComment> findFirstChildCommentByIdAndNotParentOrderByCreatedAtAsc(
         @Param("parentId") Long parentId);
 
-    Optional<Slice<ShortsComment>> findChildCommentsByShortsIdAndParentCommentIdAndIsFirstChildFalseOrderByCreatedAtDesc(
+    Optional<Slice<ShortsComment>> findChildCommentsByShortsIdAndParentCommentIdAndIsFirstChildFalseOrderByCreatedAtAsc(
         Long shortsId, Long parentCommentId, Pageable pageable);
 
     Slice<ShortsComment> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);

--- a/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/shortscomment/ShortsCommentService.java
@@ -42,6 +42,8 @@ public class ShortsCommentService {
     private final FcmNotificationService fcmNotificationService;
     private static final int ADJUSTED_CHILD_COUNT = 1;
     private static final int NO_CHILD_COMMENTS = 0;
+    private static final int SINGLE_COMMENT = 1;
+
 
     @Transactional
     public ShortsCommentParentResponse createShortsComment(User user, Long shortsId,
@@ -113,7 +115,7 @@ public class ShortsCommentService {
             .map(comment -> {
                 //댓글이 1개일때 예외처리
                 int childCommentCount = comment.getChildCommentCount();
-                int adjustedChildCount = (childCommentCount == 1) ? childCommentCount : childCommentCount - ADJUSTED_CHILD_COUNT;
+                int adjustedChildCount = (childCommentCount == SINGLE_COMMENT) ? childCommentCount : childCommentCount - ADJUSTED_CHILD_COUNT;
                 return ShortsCommentParentResponse.toDTO(
                     comment.getUser(), comment,
                     likeStatusMap.getOrDefault(comment.getId(), CommentLikeStatus.NONE),


### PR DESCRIPTION
## 요약

- 숏츠 dto에서 클밋 기준 삭제
- 댓글 개수가 -1로 가던 에러 수정

## 상세 내용
<img width="430" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/117848386/8237ce53-4325-4517-b65c-0f356e0687c9">

- 두 가지 문제가 존재했었습니다,,,
    - 대댓글이 1개일 경우 답글 -1개 더보기로 나오는 문제
    - 더보기를 눌렀을 경우 이미 나온 대댓글이 한번 더 나오는 문제

이전에는 대댓글의 첫번째는 무조건 부모 댓글과 함께 나오기에 내려주는 대댓글 개수에서-1을 무조건 빼주었는데욥,,항상 테스트를 댓글 2개 이상씩 넣고 해서 대댓글이 1개일때를 생각하지 못했습니답
![image](https://github.com/TheClimeet/climeet-spring/assets/117848386/bf8e7151-08ed-43e8-aae2-2861142326aa)

그래서 1개일때 예외를 추가해줬습니다!

---

![Movavi Online GIF Converter](https://github.com/TheClimeet/climeet-spring/assets/117848386/a5679bcb-2c7c-4376-99cf-bd495eec32bd)

2번째 문제는 대댓글 더보기를 누르면 하나만 나와야하는데 이전에 나왔던 첫번째 대댓글이 다시 나오고 또 순서가 위로 나오는 문제가 있었습니다.

-> 중복으로 나오는 문제는 또 디비...!에서 isFirstChild가 false로 되어있어 2번 중복되어 나왔습니다 얼른 밀죠 ㅎ
-> 댓글은 인스타처럼 최신순이 위, 대댓글은 아래로 반대인데 몰랐습니다, 디비에서 가져오는 순서만 변경해서 수정했습니당~

## 질문 및 이외 사항

- 간단하기도하고 if문과 임시변수를 쓰는것보다 삼항연산자가 나아보여 조금 찾아봤습니다! 
[삼항연산자의 멋짐을 모르는 당신이 불쌍해](https://tpgns.github.io/2018/04/24/nested-ternaries-are-great/)

if문이 낫나 싶기도한데 의견주시면 다시 수정해서 커밋하겠습니다~^^
