### PR TITLE
[SPR-210] 암장 난이도 관련 데이터 수정, 루트버전 관련 리팩토링

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymService.java
@@ -206,7 +206,7 @@ public class ClimbingGymService {
             throw new GeneralException(ErrorStatus._EMPTY_AVERAGE_LEVEL_DATA);
         }
 
-        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
+        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymAndDifficultyIsNotNullOrderByDifficultyAsc(
             climbingGym);
         if (difficultyMappingList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);
@@ -329,7 +329,7 @@ public class ClimbingGymService {
 
         ClimbingGym climbingGym = climbingGymRepository.findById(gymId)
             .orElseThrow(() -> new GeneralException(ErrorStatus._EMPTY_CLIMBING_GYM));
-        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
+        List<DifficultyMapping> difficultyMappingList = difficultyMappingRepository.findByClimbingGymAndDifficultyIsNotNullOrderByDifficultyAsc(
             climbingGym);
         if (difficultyMappingList.isEmpty()) {
             throw new GeneralException(ErrorStatus._EMPTY_DIFFICULTY_LIST);

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -156,7 +156,7 @@ public class ClimbingGymResponseDto {
     public static class ClimbingGymAverageLevelDetailResponse {
 
         private Long gymId;
-        private int difficulty;
+        private Integer difficulty;
         private String gymDifficultyName;
         private String gymDifficultyColor;
         private double percentage;

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/dto/ClimbingGymLayoutImageRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymlayoutimage/dto/ClimbingGymLayoutImageRequestDto.java
@@ -1,0 +1,15 @@
+package com.climeet.climeet_backend.domain.climbinggymlayoutimage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ClimbingGymLayoutImageRequestDto {
+    @Getter
+    @AllArgsConstructor
+    public static class CreateLayoutImageRequest {
+
+        private int floor;
+        private String imgUrl;
+    }
+
+}

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecord.java
@@ -43,12 +43,12 @@ public class ClimbingRecord extends BaseTimeEntity {
     private int totalCompletedCount;
 
     //평균레벨
-    private int avgDifficulty;
+    private Integer avgDifficulty;
 
     //도전횟수가 아닌 시도한 루트의 개수
     private int attemptRouteCount = 0;
 
-    private int highDifficulty = 0;
+    private Integer highDifficulty;
 
     public static ClimbingRecord toEntity(User user, CreateClimbingRecord requestDto,
         ClimbingGym climbingGym) {

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/ClimbingRecordService.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -147,7 +146,7 @@ public class ClimbingRecordService {
 
         return climbingRecordList.stream()
             .map(record -> ClimbingRecordSimpleInfo.toDTO(record))
-            .collect(Collectors.toList());
+            .toList();
     }
 
 
@@ -321,7 +320,7 @@ public class ClimbingRecordService {
                 return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount);
             })
             .sorted(Comparator.comparing(GymDifficultyMappingInfo::getDifficulty))
-            .collect(Collectors.toList());
+            .toList();
 
         return ClimbingRecordStatisticsInfoByGym.toDTO(
             time,
@@ -366,7 +365,7 @@ public class ClimbingRecordService {
                 return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount);
             })
             .sorted(Comparator.comparing(GymDifficultyMappingInfo::getDifficulty))
-            .collect(Collectors.toList());
+            .toList();
 
         return ClimbingRecordStatisticsSimpleInfo.toDTO(difficultyList);
     }
@@ -388,7 +387,7 @@ public class ClimbingRecordService {
                 Long totalCount = (Long) userRankMap[RANKING_CONDITION];
                 return BestClearUserSimpleInfo.toDTO(user, rank[0]++, totalCount);
             })
-            .collect(Collectors.toList());
+            .toList();
 
         return ranking;
     }
@@ -410,7 +409,7 @@ public class ClimbingRecordService {
                     (Double) userRankMap[RANKING_CONDITION]);
                 return BestTimeUserSimpleInfo.toDTO(user, rank[0]++, totalTime);
             })
-            .collect(Collectors.toList());
+            .toList();
 
         return ranking;
     }
@@ -447,7 +446,7 @@ public class ClimbingRecordService {
                     highDifficultyCount, climeetDifficultyName, gymDifficultyName,
                     gymDifficultyColor);
             })
-            .collect(Collectors.toList());
+            .toList();
 
         return ranking;
     }
@@ -539,7 +538,7 @@ public class ClimbingRecordService {
             difficulties.put(level, count);
         });
 
-        List<GymDifficultyMappingInfo> difficultyList = difficultyMappingRepository.findByClimbingGymOrderByDifficultyAsc(
+        List<GymDifficultyMappingInfo> difficultyList = difficultyMappingRepository.findByClimbingGymAndDifficultyIsNotNullOrderByDifficultyAsc(
                 gym).stream()
             .map(difficultyMapping -> {
                 Long levelCount = difficulties.getOrDefault(difficultyMapping.getDifficulty(),
@@ -547,7 +546,7 @@ public class ClimbingRecordService {
                 return GymDifficultyMappingInfo.toDTO(difficultyMapping, levelCount);
             })
             .sorted(Comparator.comparing(GymDifficultyMappingInfo::getDifficulty))
-            .collect(Collectors.toList());
+            .toList();
 
         return ClimbingRecordUserAndGymStatisticsDetailInfo.toDTO(
             userId,
@@ -565,7 +564,7 @@ public class ClimbingRecordService {
 
         return climbingGymList.stream()
             .map(gym -> new VisitedClimbingGym((Long)gym[GYM_ID], (String)gym[GYM_NAME]))
-            .collect(Collectors.toList());
+            .toList();
     }
 
     public List<VisitedClimbingGym> getVisitedMonthGymList(Long userId, int year, int month){
@@ -584,6 +583,6 @@ public class ClimbingRecordService {
 
         return climbingGymList.stream()
             .map(gym -> new VisitedClimbingGym((Long)gym[GYM_ID], (String)gym[GYM_NAME]))
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbingrecord/dto/ClimbingRecordResponseDto.java
@@ -130,7 +130,7 @@ public class ClimbingRecordResponseDto {
         private String gymDifficultyName;
         private String gymDifficultyColor;
         private Long count;
-        private int difficulty;
+        private Integer difficulty;
         public static GymDifficultyMappingInfo toDTO(
             DifficultyMapping difficultyMapping,
             Long count

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMapping.java
@@ -36,8 +36,7 @@ public class DifficultyMapping extends BaseTimeEntity {
     @Column(length = 10)
     private String climeetDifficultyName;
 
-    @NotNull
-    private int difficulty;
+    private Integer difficulty;
 
     @NotNull
     @Column(length = 10)

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/DifficultyMappingRepository.java
@@ -14,4 +14,6 @@ public interface DifficultyMappingRepository extends JpaRepository<DifficultyMap
 
     List<DifficultyMapping> findByClimbingGymOrderByDifficultyAsc(ClimbingGym climbingGym);
 
+    List<DifficultyMapping> findByClimbingGymAndDifficultyIsNotNullOrderByDifficultyAsc(ClimbingGym climbingGym);
+
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingRequestDto.java
@@ -1,16 +1,18 @@
 package com.climeet.climeet_backend.domain.difficultymapping.dto;
 
 import java.util.Map;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class DifficultyMappingRequestDto {
 
     @Getter
-    @NoArgsConstructor
+    @AllArgsConstructor
     public static class CreateDifficultyMappingRequest {
 
-        private Map<String, String> gymClimeetDifficulty;
+        private String gymDifficultyName;
+        private String climeetDifficultyName;
     }
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/dto/DifficultyMappingResponseDto.java
@@ -16,7 +16,7 @@ public class DifficultyMappingResponseDto {
 
         private String climeetDifficultyName;
         private String gymDifficultyName;
-        private int difficulty;
+        private Integer difficulty;
         private String gymDifficultyColor;
 
         public static DifficultyMappingDetailResponse toDTO(

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
@@ -15,12 +15,12 @@ public enum ClimeetDifficulty {
     V7("V7", 7),
     V8("V8", 8),
     V9("V9+", 9),
-    C("C", 10);
+    C("C", null);
 
     private String stringValue;
-    private int intValue;
+    private Integer intValue;
 
-    ClimeetDifficulty(String stringValue, int intValue) {
+    ClimeetDifficulty(String stringValue, Integer intValue) {
         this.stringValue = stringValue;
         this.intValue = intValue;
     }
@@ -29,7 +29,7 @@ public enum ClimeetDifficulty {
         return stringValue;
     }
 
-    public int getIntValue() {
+    public Integer getIntValue() {
         return intValue;
     }
 
@@ -42,7 +42,7 @@ public enum ClimeetDifficulty {
         throw new GeneralException(ErrorStatus._INVALID_DIFFICULTY);
     }
 
-    public static ClimeetDifficulty findByInt(int climeetDifficulty){
+    public static ClimeetDifficulty findByInt(Integer climeetDifficulty){
         return Arrays.stream(ClimeetDifficulty.values())
             .filter(difficulty -> difficulty.getIntValue() == climeetDifficulty)
             .findFirst()

--- a/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/difficultymapping/enums/ClimeetDifficulty.java
@@ -6,15 +6,16 @@ import java.util.Arrays;
 
 public enum ClimeetDifficulty {
     VB("VB", 0),
-    V1("V1", 1),
-    V2("V2", 2),
-    V3("V3", 3),
-    V4("V4", 4),
-    V5("V5", 5),
-    V6("V6", 6),
-    V7("V7", 7),
-    V8("V8", 8),
-    V9("V9+", 9),
+    V0("V0", 1),
+    V1("V1", 2),
+    V2("V2", 3),
+    V3("V3", 4),
+    V4("V4", 5),
+    V5("V5", 6),
+    V6("V6", 7),
+    V7("V7", 8),
+    V8("V8", 9),
+    V9("V9+", 10),
     C("C", null);
 
     private String stringValue;

--- a/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/route/dto/RouteRequestDto.java
@@ -1,16 +1,18 @@
 package com.climeet.climeet_backend.domain.route.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class RouteRequestDto {
 
     @Getter
-    @NoArgsConstructor
+    @AllArgsConstructor
     public static class CreateRouteRequest {
 
-        private Long sectorId;
+        private String sectorName;
         private String gymDifficultyName;
         private String holdColor;
+        private String imgUrl;
     }
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecord.java
@@ -47,7 +47,7 @@ public class RouteRecord extends BaseTimeEntity {
 
     private Boolean isCompleted = false;
 
-    private int difficulty;
+    private Integer difficulty;
 
     public static RouteRecord toEntity(User user, CreateRouteRecord createRouteRecordReq,
         ClimbingRecord climbingRecord, Route route) {

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -74,13 +74,15 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
         "FROM RouteRecord rr " +
         "JOIN FollowRelationship fr ON rr.user = fr.follower " +
         "WHERE rr.isCompleted = true AND fr.following = :manager " +
+        "AND rr.route.difficultyMapping.difficulty IS NOT NULL " +
         "GROUP BY rr.user")
     List<Float> getFollowUserSumCountDifficultyInClimbingGym(@Param("manager") User manager);
 
     @Query("SELECT " +
         "   AVG(rr.difficulty) as averageDifficulty " +
         "FROM RouteRecord rr " +
-        "WHERE rr.user = :user ")
+        "WHERE rr.user = :user " +
+        "AND rr.difficulty IS NOT NULL")
     Optional<Float> findAverageDifficultyByUser(@Param("user") User user);
 
 }

--- a/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routerecord/RouteRecordRepository.java
@@ -43,6 +43,7 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
         "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.user = :user AND rr.isCompleted = true " +
+        "AND rr.difficulty IS NOT NULL " +
         "GROUP BY rr.difficulty" )
     List<Object[]> findAllRouteRecordDifficultyAndUser(
         @Param("user") User user
@@ -52,6 +53,7 @@ public interface RouteRecordRepository extends JpaRepository<RouteRecord, Long> 
         "   rr.difficulty as difficulty, COUNT(*) as count " +
         "FROM RouteRecord rr " +
         "WHERE rr.user = :user AND rr.isCompleted = true AND rr.gym = :gym " +
+        "AND rr.difficulty IS NOT NULL " +
         "GROUP BY rr.difficulty" )
     List<Object[]> findAllRouteRecordDifficultyAndUserAndGym(
         @Param("user") User user,

--- a/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/routeversion/dto/RouteVersionRequestDto.java
@@ -1,9 +1,12 @@
 package com.climeet.climeet_backend.domain.routeversion.dto;
 
+import com.climeet.climeet_backend.domain.climbinggymlayoutimage.dto.ClimbingGymLayoutImageRequestDto.CreateLayoutImageRequest;
+import com.climeet.climeet_backend.domain.difficultymapping.dto.DifficultyMappingRequestDto.CreateDifficultyMappingRequest;
+import com.climeet.climeet_backend.domain.route.dto.RouteRequestDto.CreateRouteRequest;
+import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -21,48 +24,13 @@ public class RouteVersionRequestDto {
     }
 
     @Getter
-    @AllArgsConstructor
-    public static class NewDifficultyData {
-
-        private String gymDifficultyName;
-        private String climeetDifficultyName;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class NewLayoutData {
-
-        private int floor;
-        private String imgUrl;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class NewSectorData {
-
-        private String name;
-        private int floor;
-        private String imgUrl;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public static class NewRouteData {
-
-        private String sectorName;
-        private String gymDifficultyName;
-        private String holdColor;
-        private String imgUrl;
-    }
-
-    @Getter
     @NoArgsConstructor
     public static class NewRouteVersionData {
 
-        private List<NewDifficultyData> difficulty = new ArrayList<>();
-        private List<NewLayoutData> layout = new ArrayList<>();
-        private List<NewSectorData> sector = new ArrayList<>();
-        private List<NewRouteData> route = new ArrayList<>();
+        private List<CreateDifficultyMappingRequest> difficulty = new ArrayList<>();
+        private List<CreateLayoutImageRequest> layout = new ArrayList<>();
+        private List<CreateSectorRequest> sector = new ArrayList<>();
+        private List<CreateRouteRequest> route = new ArrayList<>();
     }
 
     @Getter

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/Sector.java
@@ -1,7 +1,6 @@
 package com.climeet.climeet_backend.domain.sector;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import com.climeet.climeet_backend.domain.sector.dto.SectorRequestDto.CreateSectorRequest;
 import com.climeet.climeet_backend.global.utils.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/sector/dto/SectorRequestDto.java
@@ -1,16 +1,16 @@
 package com.climeet.climeet_backend.domain.sector.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class SectorRequestDto {
 
     @Getter
-    @NoArgsConstructor
+    @AllArgsConstructor
     public static class CreateSectorRequest {
         private String name;
-        private int floor = 1;
-
-
+        private int floor;
+        private String imgUrl;
     }
 }


### PR DESCRIPTION
## 요약
1. 암장 난이도에서 C 난이도의 difficulty를 null로 바꾸었습니다.
2. (1)에 따라 null이 difficulty에 들어갈 수 있게되어 difficulty 자료형을 int에서 Integer로 바꿔주었습니다.
3. 기획 상에서 V0가 추가되었는데, 반영되어있지 않아 새롭게 추가했습니다.
4. RouteVersion의 RequestDto가 여러 도메인에서 데이터를 가져오지만 한 RequestDto에 모두 들어가있어서 각자의 도메인에 맞게 이동시키고, 변경했습니다.
5. (4)에 따라 여러 RequestDto가 변경되었습니다.
6. (1)에 따라서 문제가 발생할 수 있는 API를 체크하고 해결했습니다.

## 상세 내용

- 암장 난이도에서 C 난이도와 V0난이도가 변경되었습니다. 이에 따른 enum은 다음과 같습니다.
``` java
    VB("VB", 0),
    V0("V0", 1),
    V1("V1", 2),
    V2("V2", 3),
    V3("V3", 4),
    V4("V4", 5),
    V5("V5", 6),
    V6("V6", 7),
    V7("V7", 8),
    V8("V8", 9),
    V9("V9+", 10),
    C("C", null);
```
- C에 null값이 들어감에 따라서 difficulty가 int에서 Integer로 바뀌었습니다.

- RouteVersion의 RequestDto가 여러 도메인에서 데이터를 가져오지만 한 RequestDto에 모두 들어가있어서 각자의 도메인에 맞게 이동시키고, 변경했습니다. 따라서 여러 RequestDto가 변경되었습니다.
``` java
        private List<CreateDifficultyMappingRequest> difficulty = new ArrayList<>();
        // NewDifficultyData에서 바뀌었으며 RouteVersion에서 DifficultyMapping 도메인으로 이동
        private List<CreateLayoutImageRequest> layout = new ArrayList<>();
        // NewLayoutData에서 바뀌었으며 ClimbingGymLayoutImage 도메인으로 이동
        private List<CreateSectorRequest> sector = new ArrayList<>();
        // NewSectorData에서 바뀌었으며 Sector 도메인으로 이동
        private List<CreateRouteRequest> route = new ArrayList<>();
        // NewRouteData에서 바뀌었으며 Route 도메인으로 이동
```

- diffuculty 데이터가 null이 들어감에 따라서 문제가 발생할 수 있는 API를 체크하고 해결했습니다.

- 추가로 ` collect(Collection.toList()) ` 부분을 toList() 변경했습니다. (보이는 부분만...^^)

> 큰 구조가 바뀌는 부분은 없어서 코드의 이해는 쉬울 것이라 생각합니다!!

## 테스트 확인 내용
<img width="856" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/3e54b294-674f-4350-8ae0-2c5cbf390d00">
<img width="856" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/e13a9192-5add-4a6c-b4a3-e9f13a355b2e">
<img width="856" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/7514cb8a-4fc7-4bc1-a032-c36e515eb53e">
<img width="856" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/217e5eb7-9b43-48cd-9962-20f7fdf0c65f">
<img width="856" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/5df86ffd-580a-4dd0-9667-e0f77efbde35">

다음과 같이 통계 부분의 5개 api를 확인하였고, 이 중 초반 3개의 API에서 null로 인해서 difficulty 데이터를 가져오지 못하는 문제가 발생함을 발견했습니다. 따라서 repository에서 가져올 때 not null인 데이터들만 가져오도록 변경하여 해결하였습니다.

## 질문 및 이외 사항

@tjdgns8439 
- ClimbingRecord파일의 toEntity에서
<img width="671" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/7027e7dd-e9d8-4abd-92a2-aaec41e30c57">
시도 횟수나 최고난이도 부분에 항상 0이 들어가도록 설정되어있는데, 이 부분은 따로 건들지는 않았지만 0이 아닌 다른 값이 들어가야하는게 아닌가 하는 생각이 들어서 확인 부탁드립니다 ㅎㅎ
그리고 여기 최고 난이도 부분은 운동을 기록할 때 Competition 난이도만 진행하였을 경우 null이 발생할 수도 있겠다는 생각이 들긴 했는데, 나중에 QA할 때 어플에서 직접 확인해보는게 좋을 것 같습니다!! 백로그에 적어둘게요!
