### PR TITLE
[SPR-216] feat: 암장 프로필, 배경 기본 이미지 설정

### DIFF
--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/ClimbingGymController.java
@@ -87,7 +87,7 @@ public class ClimbingGymController {
     public ResponseEntity<List<ClimbingGymAverageLevelDetailResponse>> getFollowingUserAverageLevelInClimbingGym(
         @PathVariable Long gymId, @CurrentUser User user) {
         return ResponseEntity.ok(
-            climbingGymService.getFollowingUserAverageLevelInClimbingGym(gymId, user));
+            climbingGymService.getFollowingUserAverageLevelInClimbingGym(gymId));
     }
 
     @Operation(summary = "암장 배경사진 변경 (1개만 등록 가능) - 1006 [무빗]")

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggym/dto/ClimbingGymResponseDto.java
@@ -2,7 +2,6 @@ package com.climeet.climeet_backend.domain.climbinggym.dto;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
 import com.climeet.climeet_backend.domain.difficultymapping.DifficultyMapping;
-import com.climeet.climeet_backend.domain.manager.Manager;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -79,11 +78,12 @@ public class ClimbingGymResponseDto {
         private Boolean isFollower;
         private Boolean hasManager;
 
-        public static ClimbingGymDetailResponse toDTO(ClimbingGym climbingGym,  Long followerCount, Long followingCount,
+        public static ClimbingGymDetailResponse toDTO(ClimbingGym climbingGym, Long followerCount,
+            Long followingCount, String gymProfileImageUrl,
             String gymBackGroundImageUrl, Boolean isFollower, Boolean hasManager) {
             return ClimbingGymDetailResponse.builder()
                 .gymId(climbingGym.getId())
-                .gymProfileImageUrl(climbingGym.getProfileImageUrl())
+                .gymProfileImageUrl(gymProfileImageUrl)
                 .gymBackGroundImageUrl(gymBackGroundImageUrl)
                 .gymName(climbingGym.getName())
                 .followerCount(followerCount)

--- a/src/main/java/com/climeet/climeet_backend/domain/climbinggymimage/ClimbingGymBackgroundImageRepository.java
+++ b/src/main/java/com/climeet/climeet_backend/domain/climbinggymimage/ClimbingGymBackgroundImageRepository.java
@@ -1,12 +1,16 @@
 package com.climeet.climeet_backend.domain.climbinggymimage;
 
 import com.climeet.climeet_backend.domain.climbinggym.ClimbingGym;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClimbingGymBackgroundImageRepository extends JpaRepository<ClimbingGymBackgroundImage, Long>{
     Optional<ClimbingGymBackgroundImage> findByClimbingGym(ClimbingGym climbingGym);
+
+    @Query("SELECT c.imgUrl FROM ClimbingGymBackgroundImage c WHERE c.climbingGym = :climbingGym")
+    Optional<String> findImgUrlByClimbingGym(@Param("climbingGym") ClimbingGym climbingGym);
 }


### PR DESCRIPTION
## 요약
- 암장 프로필, 배경 기본 이미지를 설정했습니다.

## 상세 내용

- 서브모듈에 prod S3 기본 url을 세팅해두었고 다음처럼 불러옵니다.
``` java
    @Value("${cloud.aws.s3.public-uri}")
    private String s3Uri;
    private static final String DEFAULT_PROFILE_ENDPOINT = "default/profile.jpg";
    private static final String DEFAULT_BACKGROUND_ENDPOINT = "default/background.jpg";
```

- 그리고 다음처럼 사용합니다.
``` java
        String profileImgUrl =
            (climbingGym.getProfileImageUrl() != null) ? climbingGym.getProfileImageUrl()
                : s3Uri + DEFAULT_PROFILE_ENDPOINT;

        String backgroundImgUrl = climbingGymBackgroundImageRepository.findImgUrlByClimbingGym(
                climbingGym)
            .orElse(s3Uri + DEFAULT_BACKGROUND_ENDPOINT);
```
값이 없으면 기본값을 넣도록 했습니다. 저도 한번 삼항연산자를 써봤습니다 ㅎㅎ

- Url 값으로 String이 들어오는게 더 간결하다 생각이 들어서, 이렇게 바꾸었습니당
``` java
    @Query("SELECT c.imgUrl FROM ClimbingGymBackgroundImage c WHERE c.climbingGym = :climbingGym")
    Optional<String> findImgUrlByClimbingGym(@Param("climbingGym") ClimbingGym climbingGym);
```

## 테스트 확인 내용
정상적으로 반환됩니다
<img width="246" alt="image" src="https://github.com/TheClimeet/climeet-spring/assets/62535229/0cc422d1-23b4-4015-abbd-3f3f339e3b9c">


## 질문 및 이외 사항
